### PR TITLE
allow to pass existing `sqlalchemy.engine.Engine`

### DIFF
--- a/doc/connecting.md
+++ b/doc/connecting.md
@@ -88,8 +88,8 @@ engine = create_engine("sqlite:///my.db")
 ```
 
 ```{code-cell} ipython3
-df = pd.DataFrame({"x": range(5)})
-df.to_sql("numbers", engine)
+# df = pd.DataFrame({"x": range(5)})
+# df.to_sql("numbers", engine)
 ```
 
 ```{code-cell} ipython3
@@ -101,6 +101,19 @@ df.to_sql("numbers", engine)
 ```
 
 ```{code-cell} ipython3
+%sql
+```
+
+```{code-cell} ipython3
 %%sql
 SELECT * FROM numbers
+```
+
+```{code-cell} ipython3
+%%sql engine
+SELECT * FROM numbers
+```
+
+```{code-cell} ipython3
+
 ```

--- a/doc/connecting.md
+++ b/doc/connecting.md
@@ -6,7 +6,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.0
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -74,6 +74,33 @@ then you can:
 %sql --section DB_CONFIG_1 
 ```
 
-```{code-cell} ipython3
++++
 
+## Using an existing `sqlalchemy.engine.Engine`
+
+```{code-cell} ipython3
+import pandas as pd
+from sqlalchemy.engine import create_engine
+```
+
+```{code-cell} ipython3
+engine = create_engine("sqlite:///my.db")
+```
+
+```{code-cell} ipython3
+df = pd.DataFrame({"x": range(5)})
+df.to_sql("numbers", engine)
+```
+
+```{code-cell} ipython3
+%load_ext sql
+```
+
+```{code-cell} ipython3
+%sql engine
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT * FROM numbers
 ```

--- a/doc/connecting.md
+++ b/doc/connecting.md
@@ -78,18 +78,20 @@ then you can:
 
 ## Using an existing `sqlalchemy.engine.Engine`
 
+Use an existing `Engine` by passing the variable name to `%sql`.
+
 ```{code-cell} ipython3
 import pandas as pd
 from sqlalchemy.engine import create_engine
 ```
 
 ```{code-cell} ipython3
-engine = create_engine("sqlite:///my.db")
+engine = create_engine("sqlite://")
 ```
 
 ```{code-cell} ipython3
-# df = pd.DataFrame({"x": range(5)})
-# df.to_sql("numbers", engine)
+df = pd.DataFrame({"x": range(5)})
+df.to_sql("numbers", engine)
 ```
 
 ```{code-cell} ipython3
@@ -97,23 +99,10 @@ engine = create_engine("sqlite:///my.db")
 ```
 
 ```{code-cell} ipython3
-%sql engine
-```
-
-```{code-cell} ipython3
-%sql
+%%sql engine
 ```
 
 ```{code-cell} ipython3
 %%sql
 SELECT * FROM numbers
-```
-
-```{code-cell} ipython3
-%%sql engine
-SELECT * FROM numbers
-```
-
-```{code-cell} ipython3
-
 ```

--- a/doc/connecting.md
+++ b/doc/connecting.md
@@ -99,7 +99,7 @@ df.to_sql("numbers", engine)
 ```
 
 ```{code-cell} ipython3
-%%sql engine
+%sql engine
 ```
 
 ```{code-cell} ipython3

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -4,7 +4,6 @@ from sql import parse
 from sql.store import store
 
 
-# NOTE: this will encapsulate the logic in magic.py
 class SQLCommand:
     """
     Encapsulates the parsing logic (arguments, SQL code, connection string, etc.)

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -1,0 +1,21 @@
+from sql import parse
+
+
+# NOTE: this will encapsulate the logic in magic.py
+class SQLCommand:
+    """
+    Encapsulates the parsing logic (arguments, SQL code, connection string, etc.)
+
+    """
+
+    def __init__(self, magic, line, cell) -> None:
+        self.args = parse.magic_args(magic.execute, line)
+
+        self.command_text = " ".join(self.args.line) + "\n" + cell
+
+        if self.args.file:
+            with open(self.args.file, "r") as infile:
+                self.command_text = infile.read() + "\n" + self.command_text
+
+        # TODO: test with something that requires the dsn_filename attribute
+        self.parsed = parse.parse(self.command_text, magic)

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -36,3 +36,22 @@ class SQLCommand:
         if self.args.with_:
             final = store.render(self.parsed["sql"], with_=self.args.with_)
             self.parsed["sql"] = str(final)
+
+    @property
+    def sql(self):
+        """
+        Returns the SQL query to execute, without any other options or arguments
+        """
+        return self.parsed["sql"]
+
+    @property
+    def sql_original(self):
+        """
+        Returns the raw SQL query. Might be different from `sql` if using --with
+        """
+        return self.parsed["sql_original"]
+
+    @property
+    def connection(self):
+        """Returns the connection string"""
+        return self.parsed["connection"]

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -55,3 +55,8 @@ class SQLCommand:
     def connection(self):
         """Returns the connection string"""
         return self.parsed["connection"]
+
+    @property
+    def result_var(self):
+        """Returns the result_var"""
+        return self.parsed["result_var"]

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -9,10 +9,22 @@ class SQLCommand:
 
     """
 
-    def __init__(self, magic, line, cell) -> None:
+    def __init__(self, magic, user_ns, line, cell) -> None:
         self.args = parse.magic_args(magic.execute, line)
 
-        self.command_text = " ".join(self.args.line) + "\n" + cell
+        # if line == "my_engine":
+        #     from IPython import embed
+
+        #     embed()
+
+        if len(self.args.line) == 1 and self.args.line[0] in user_ns:
+            line_for_command = []
+            add_conn = True
+        else:
+            line_for_command = self.args.line
+            add_conn = False
+
+        self.command_text = " ".join(line_for_command) + "\n" + cell
 
         if self.args.file:
             with open(self.args.file, "r") as infile:
@@ -22,6 +34,9 @@ class SQLCommand:
         self.parsed = parse.parse(self.command_text, magic)
 
         self.parsed["sql_original"] = self.parsed["sql"]
+
+        if add_conn:
+            self.parsed["connection"] = self.args.line[0]
 
         if self.args.with_:
             final = store.render(self.parsed["sql"], with_=self.args.with_)

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -1,3 +1,5 @@
+from sqlalchemy.engine import Engine
+
 from sql import parse
 from sql.store import store
 
@@ -12,7 +14,11 @@ class SQLCommand:
     def __init__(self, magic, user_ns, line, cell) -> None:
         self.args = parse.magic_args(magic.execute, line)
 
-        if len(self.args.line) == 1 and self.args.line[0] in user_ns:
+        if (
+            len(self.args.line) == 1
+            and self.args.line[0].strip() in user_ns
+            and isinstance(user_ns[self.args.line[0].strip()], Engine)
+        ):
             line_for_command = []
             add_conn = True
         else:
@@ -31,7 +37,7 @@ class SQLCommand:
         self.parsed["sql_original"] = self.parsed["sql"]
 
         if add_conn:
-            self.parsed["connection"] = self.args.line[0]
+            self.parsed["connection"] = user_ns[self.args.line[0].strip()]
 
         if self.args.with_:
             final = store.render(self.parsed["sql"], with_=self.args.with_)

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -12,11 +12,6 @@ class SQLCommand:
     def __init__(self, magic, user_ns, line, cell) -> None:
         self.args = parse.magic_args(magic.execute, line)
 
-        # if line == "my_engine":
-        #     from IPython import embed
-
-        #     embed()
-
         if len(self.args.line) == 1 and self.args.line[0] in user_ns:
             line_for_command = []
             add_conn = True

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -30,7 +30,6 @@ class SQLCommand:
             with open(self.args.file, "r") as infile:
                 self.command_text = infile.read() + "\n" + self.command_text
 
-        # TODO: test with something that requires the dsn_filename attribute
         self.parsed = parse.parse(self.command_text, magic)
 
         self.parsed["sql_original"] = self.parsed["sql"]

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -16,8 +16,8 @@ class SQLCommand:
 
         if (
             len(self.args.line) == 1
-            and self.args.line[0].strip() in user_ns
-            and isinstance(user_ns[self.args.line[0].strip()], Engine)
+            and self.args.line[0] in user_ns
+            and isinstance(user_ns[self.args.line[0]], Engine)
         ):
             line_for_command = []
             add_conn = True
@@ -37,7 +37,7 @@ class SQLCommand:
         self.parsed["sql_original"] = self.parsed["sql"]
 
         if add_conn:
-            self.parsed["connection"] = user_ns[self.args.line[0].strip()]
+            self.parsed["connection"] = user_ns[self.args.line[0]]
 
         if self.args.with_:
             final = store.render(self.parsed["sql"], with_=self.args.with_)

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -1,4 +1,5 @@
 from sql import parse
+from sql.store import store
 
 
 # NOTE: this will encapsulate the logic in magic.py
@@ -19,3 +20,9 @@ class SQLCommand:
 
         # TODO: test with something that requires the dsn_filename attribute
         self.parsed = parse.parse(self.command_text, magic)
+
+        self.parsed["sql_original"] = self.parsed["sql"]
+
+        if self.args.with_:
+            final = store.render(self.parsed["sql"], with_=self.args.with_)
+            self.parsed["sql"] = str(final)

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -1,6 +1,7 @@
 import os
 
 import sqlalchemy
+from sqlalchemy.engine import Engine
 
 
 class ConnectionError(Exception):
@@ -22,19 +23,47 @@ def rough_dict_get(dct, sought, default=None):
     return default
 
 
-class Connection(object):
+class Connection:
+    """Manages connections to databases
+
+    Parameters
+    ----------
+    engine: sqlalchemy.engine.Engine
+        The SQLAlchemy engine to use
+    """
+
+    # the active connection
     current = None
+
+    # all connections
     connections = {}
 
     @classmethod
     def tell_format(cls):
+        """
+        Returns an error message that we can display to the user
+        to tell them how to pass the connection string
+        """
         return """Connection info needed in SQLAlchemy format, example:
                postgresql://username:password@hostname/dbname
                or an existing connection: %s""" % str(
             cls.connections.keys()
         )
 
-    def __init__(self, connect_str=None, connect_args={}, creator=None):
+    def __init__(self, engine):
+        self.dialect = engine.url.get_dialect()
+        self.metadata = sqlalchemy.MetaData(bind=engine)
+        self.name = self.assign_name(engine)
+        self.session = engine.connect()
+        self.connections[repr(self.metadata.bind.url)] = self
+        self.connect_args = None
+        Connection.current = self
+
+    @classmethod
+    def from_connect_str(cls, connect_str=None, connect_args=None, creator=None):
+        """Creates a new connection from a connection string"""
+        connect_args = connect_args or {}
+
         try:
             if creator:
                 engine = sqlalchemy.create_engine(
@@ -45,27 +74,39 @@ class Connection(object):
                     connect_str, connect_args=connect_args
                 )
         except Exception:
-            print(self.tell_format())
+            print(cls.tell_format())
             raise
-        self.dialect = engine.url.get_dialect()
-        self.metadata = sqlalchemy.MetaData(bind=engine)
-        self.name = self.assign_name(engine)
-        self.session = engine.connect()
-        self.connections[repr(self.metadata.bind.url)] = self
-        self.connect_args = connect_args
-        Connection.current = self
+
+        connection = cls(engine)
+        connection.connect_args = connect_args
+
+        return connection
 
     @classmethod
-    def set(cls, descriptor, displaycon, connect_args={}, creator=None):
-        "Sets the current database connection"
+    def set(cls, descriptor, displaycon, connect_args=None, creator=None):
+        """
+        Sets the current database connection
+        """
+        connect_args = connect_args or connect_args
 
         if descriptor:
             if isinstance(descriptor, Connection):
                 cls.current = descriptor
+            elif isinstance(descriptor, Engine):
+                cls.current = Connection(descriptor)
             else:
                 existing = rough_dict_get(cls.connections, descriptor)
-            # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments # noqa
-            cls.current = existing or Connection(descriptor, connect_args, creator)
+
+                # NOTE: I added one indentation level, otherwise
+                # the "existing" variable would not exist if
+                # passing an engine object as descriptor.
+                # Since I never saw this breaking, my guess
+                # is that we're missing some unit tests
+                # when descriptor is a connection object
+                # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments # noqa
+                cls.current = existing or Connection.from_connect_str(
+                    descriptor, connect_args, creator
+                )
         else:
 
             if cls.connections:
@@ -73,7 +114,7 @@ class Connection(object):
                     print(cls.connection_list())
             else:
                 if os.getenv("DATABASE_URL"):
-                    cls.current = Connection(
+                    cls.current = Connection.from_connect_str(
                         os.getenv("DATABASE_URL"), connect_args, creator
                     )
                 else:

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -270,15 +270,9 @@ class SqlMagic(Magics, Configurable):
         if args.creator:
             args.creator = user_ns[args.creator]
 
-        # maybe there's a better variable to use than line
-        if line.strip() in user_ns and isinstance(user_ns[line.strip()], Engine):
-            existing_engine = user_ns[line]
-        else:
-            existing_engine = None
-
         try:
             conn = sql.connection.Connection.set(
-                existing_engine or connect_arg,
+                connect_arg,
                 displaycon=self.displaycon,
                 connect_args=args.connection_arguments,
                 creator=args.creator,

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -237,10 +237,8 @@ class SqlMagic(Magics, Configurable):
         # (for %sql this is done automatically)
         cell = self.shell.var_expand(cell)
 
-        # parse args
+        command = SQLCommand(self, user_ns, line, cell)
         # args.line: contains the line after the magic with all options removed
-
-        command = SQLCommand(self, line, cell)
         args = command.args
         parsed = command.parsed
         original = parsed["sql_original"]
@@ -278,13 +276,6 @@ class SqlMagic(Magics, Configurable):
             existing_engine = user_ns[line]
         else:
             existing_engine = None
-
-        # FIXME: tmp hack, otherwise when passing an engine name,
-        # this is set to the engine name. we need to modify
-        # the parse.parse logic so it doesn't put the engine_name
-        # here
-        if existing_engine:
-            parsed["sql"] = None
 
         try:
             conn = sql.connection.Connection.set(

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -15,7 +15,6 @@ from IPython.core.magic import (
 )
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from sqlalchemy.exc import OperationalError, ProgrammingError, DatabaseError
-from sqlalchemy.engine import Engine
 
 import sql.connection
 import sql.parse

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -4,6 +4,7 @@ from os.path import expandvars
 
 from six.moves import configparser as CP
 from sqlalchemy.engine.url import URL
+from IPython.core.magic_arguments import parse_argstring
 
 
 def connection_from_dsn_section(section, config):
@@ -90,3 +91,8 @@ def without_sql_comment(parser, line):
         shlex.split(line, posix=False),
     )
     return " ".join(result)
+
+
+def magic_args(magic_execute, line):
+    line = without_sql_comment(parser=magic_execute.parser, line=line)
+    return parse_argstring(magic_execute, line)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import urllib.request
 from pathlib import Path
 
@@ -58,3 +59,15 @@ def ip():
     yield ip_session
     runsql(ip_session, "DROP TABLE test")
     runsql(ip_session, "DROP TABLE author")
+
+
+@pytest.fixture
+def tmp_empty(tmp_path):
+    """
+    Create temporary path using pytest native fixture,
+    them move it, yield, and restore the original path
+    """
+    old = os.getcwd()
+    os.chdir(str(tmp_path))
+    yield str(Path(tmp_path).resolve())
+    os.chdir(old)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -45,6 +45,7 @@ def ip():
     ip_session.register_magics(SqlMagic)
     ip_session.register_magics(RenderMagic)
 
+    # runsql creates an inmemory sqlitedatabase
     runsql(
         ip_session,
         [

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sql.command import SQLCommand
 
 import pytest
@@ -27,25 +29,83 @@ def test_parsed(ip, line, cell, parsed_sql, parsed_connection):
         "connection": parsed_connection,
         "result_var": None,
         "sql": parsed_sql,
+        "sql_original": parsed_sql,
     }
 
 
-def test_args():
-    pass
-    # assert cmd.args.__dict__ == {
-    #     "line": ["something"],
-    #     "connections": False,
-    #     "close": None,
-    #     "creator": None,
-    #     "section": None,
-    #     "persist": False,
-    #     "no_index": False,
-    #     "append": False,
-    #     "connection_arguments": None,
-    #     "file": None,
-    #     "save": None,
-    #     "with_": None,
-    #     "no_execute": True,
-    # }
+def test_parsed_sql_when_using_with(ip):
+    ip.run_cell_magic(
+        "sql",
+        "--save author_one",
+        """
+        SELECT * FROM author LIMIT 1
+        """,
+    )
+
+    line = "--with author_one"
+    cell = "SELECT * FROM author_one"
+    sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
+
+    cmd = SQLCommand(sql_line, line, cell)
+
+    sql = (
+        "WITH author_one AS (\n    \n\n        "
+        "SELECT * FROM author LIMIT 1\n        \n)"
+        "\n\nSELECT * FROM author_one"
+    )
+
+    assert cmd.parsed == {
+        "connection": "",
+        "result_var": None,
+        "sql": sql,
+        "sql_original": "\nSELECT * FROM author_one",
+    }
+
+
+def test_parsed_sql_when_using_file(ip, tmp_empty):
+    Path("query.sql").write_text("SELECT * FROM author")
+
+    sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
+
+    cmd = SQLCommand(sql_line, "--file query.sql", "")
+
+    assert cmd.parsed == {
+        "connection": "",
+        "result_var": None,
+        "sql": "SELECT * FROM author\n\n",
+        "sql_original": "SELECT * FROM author\n\n",
+    }
+
+
+def test_args(ip):
+    ip.run_cell_magic(
+        "sql",
+        "--save author_one",
+        """
+        SELECT * FROM author LIMIT 1
+        """,
+    )
+
+    line = "--with author_one"
+    cell = ""
+    sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
+
+    cmd = SQLCommand(sql_line, line, cell)
+
+    assert cmd.args.__dict__ == {
+        "line": "",
+        "connections": False,
+        "close": None,
+        "creator": None,
+        "section": None,
+        "persist": False,
+        "no_index": False,
+        "append": False,
+        "connection_arguments": None,
+        "file": None,
+        "save": None,
+        "with_": ["author_one"],
+        "no_execute": False,
+    }
 
     # assert cmd.command_text == "something\n"

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -1,0 +1,51 @@
+from sql.command import SQLCommand
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "line, cell, parsed_sql, parsed_connection",
+    [
+        ("something --no-execute", "", "something\n", ""),
+        ("sqlite://", "", "", "sqlite://"),
+        ("SELECT * FROM TABLE", "", "SELECT * FROM TABLE\n", ""),
+        ("SELECT * FROM", "TABLE", "SELECT * FROM\nTABLE", ""),
+    ],
+    ids=[
+        "arg-with-option",
+        "connection-string",
+        "sql-query",
+        "sql-query-in-line-and-cell",  # NOTE: I'm unsure under which circumstances this happens # noqa
+    ],
+)
+def test_parsed(ip, line, cell, parsed_sql, parsed_connection):
+    sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
+
+    cmd = SQLCommand(sql_line, line, cell)
+
+    assert cmd.parsed == {
+        "connection": parsed_connection,
+        "result_var": None,
+        "sql": parsed_sql,
+    }
+
+
+def test_args():
+    pass
+    # assert cmd.args.__dict__ == {
+    #     "line": ["something"],
+    #     "connections": False,
+    #     "close": None,
+    #     "creator": None,
+    #     "section": None,
+    #     "persist": False,
+    #     "no_index": False,
+    #     "append": False,
+    #     "connection_arguments": None,
+    #     "file": None,
+    #     "save": None,
+    #     "with_": None,
+    #     "no_execute": True,
+    # }
+
+    # assert cmd.command_text == "something\n"

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -24,7 +24,7 @@ from sql.command import SQLCommand
 def test_parsed(ip, line, cell, parsed_sql, parsed_connection):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
 
-    cmd = SQLCommand(sql_line, line, cell)
+    cmd = SQLCommand(sql_line, ip.user_ns, line, cell)
 
     assert cmd.parsed == {
         "connection": parsed_connection,
@@ -47,7 +47,7 @@ def test_parsed_sql_when_using_with(ip):
     cell = "SELECT * FROM author_one"
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
 
-    cmd = SQLCommand(sql_line, line, cell)
+    cmd = SQLCommand(sql_line, ip.user_ns, line, cell)
 
     sql = (
         "WITH author_one AS (\n    \n\n        "
@@ -68,7 +68,7 @@ def test_parsed_sql_when_using_file(ip, tmp_empty):
 
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
 
-    cmd = SQLCommand(sql_line, "--file query.sql", "")
+    cmd = SQLCommand(sql_line, ip.user_ns, "--file query.sql", "")
 
     assert cmd.parsed == {
         "connection": "",
@@ -91,7 +91,7 @@ def test_args(ip):
     cell = ""
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
 
-    cmd = SQLCommand(sql_line, line, cell)
+    cmd = SQLCommand(sql_line, ip.user_ns, line, cell)
 
     assert cmd.args.__dict__ == {
         "line": "",

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -122,14 +122,19 @@ def test_args(ip, sql_magic):
     }
 
 
-def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty):
+@pytest.mark.parametrize(
+    "line",
+    [
+        "my_engine",
+        " my_engine",
+        "my_engine ",
+    ],
+)
+def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty, line):
     engine = create_engine("sqlite:///my.db")
     ip.user_global_ns["my_engine"] = engine
 
-    line = "my_engine"
-    cell = "SELECT * FROM author"
-
-    cmd = SQLCommand(sql_magic, ip.user_ns, line, cell)
+    cmd = SQLCommand(sql_magic, ip.user_ns, line, cell="SELECT * FROM author")
 
     sql_expected = "\nSELECT * FROM author"
 

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -19,6 +19,7 @@ def sql_magic(ip):
         ("SELECT * FROM TABLE", "", "SELECT * FROM TABLE\n", "", None),
         ("SELECT * FROM", "TABLE", "SELECT * FROM\nTABLE", "", None),
         ("my_var << SELECT *", "FROM table", "SELECT *\nFROM table", "", "my_var"),
+        ("[db]", "", "", "sqlite://", None),
     ],
     ids=[
         "arg-with-option",
@@ -26,11 +27,27 @@ def sql_magic(ip):
         "sql-query",
         "sql-query-in-line-and-cell",
         "parsed-var",
+        "config",
     ],
 )
 def test_parsed(
-    ip, sql_magic, line, cell, parsed_sql, parsed_connection, parsed_result_var
+    ip,
+    sql_magic,
+    line,
+    cell,
+    parsed_sql,
+    parsed_connection,
+    parsed_result_var,
+    tmp_empty,
 ):
+    # needed for the last test case
+    Path("odbc.ini").write_text(
+        """
+[db]
+drivername = sqlite
+"""
+    )
+
     cmd = SQLCommand(sql_magic, ip.user_ns, line, cell)
 
     assert cmd.parsed == {

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -36,6 +36,10 @@ def test_parsed(ip, sql_magic, line, cell, parsed_sql, parsed_connection):
         "sql_original": parsed_sql,
     }
 
+    assert cmd.connection == parsed_connection
+    assert cmd.sql == parsed_sql
+    assert cmd.sql_original == parsed_sql
+
 
 def test_parsed_sql_when_using_with(ip, sql_magic):
     ip.run_cell_magic(
@@ -56,12 +60,18 @@ def test_parsed_sql_when_using_with(ip, sql_magic):
         "\n\nSELECT * FROM author_one"
     )
 
+    sql_original = "\nSELECT * FROM author_one"
+
     assert cmd.parsed == {
         "connection": "",
         "result_var": None,
         "sql": sql,
-        "sql_original": "\nSELECT * FROM author_one",
+        "sql_original": sql_original,
     }
+
+    assert cmd.connection == ""
+    assert cmd.sql == sql
+    assert cmd.sql_original == sql_original
 
 
 def test_parsed_sql_when_using_file(ip, sql_magic, tmp_empty):
@@ -74,6 +84,10 @@ def test_parsed_sql_when_using_file(ip, sql_magic, tmp_empty):
         "sql": "SELECT * FROM author\n\n",
         "sql_original": "SELECT * FROM author\n\n",
     }
+
+    assert cmd.connection == ""
+    assert cmd.sql == "SELECT * FROM author\n\n"
+    assert cmd.sql_original == "SELECT * FROM author\n\n"
 
 
 def test_args(ip, sql_magic):
@@ -112,9 +126,16 @@ def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty):
 
     cmd = SQLCommand(sql_magic, ip.user_ns, line, cell)
 
+
+    sql_expected = "\nSELECT * FROM author"
+
     assert cmd.parsed == {
         "connection": "my_engine",
         "result_var": None,
-        "sql": "\nSELECT * FROM author",
-        "sql_original": "\nSELECT * FROM author",
+        "sql": sql_expected,
+        "sql_original": sql_expected,
     }
+
+    assert cmd.connection == "my_engine"
+    assert cmd.sql == sql_expected
+    assert cmd.sql_original == sql_expected

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -123,7 +123,8 @@ def test_args(ip, sql_magic):
 
 
 def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty):
-    ip.user_global_ns["my_engine"] = create_engine("sqlite:///my.db")
+    engine = create_engine("sqlite:///my.db")
+    ip.user_global_ns["my_engine"] = engine
 
     line = "my_engine"
     cell = "SELECT * FROM author"
@@ -133,12 +134,12 @@ def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty):
     sql_expected = "\nSELECT * FROM author"
 
     assert cmd.parsed == {
-        "connection": "my_engine",
+        "connection": engine,
         "result_var": None,
         "sql": sql_expected,
         "sql_original": sql_expected,
     }
 
-    assert cmd.connection == "my_engine"
+    assert cmd.connection is engine
     assert cmd.sql == sql_expected
     assert cmd.sql_original == sql_expected

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
-from sql.command import SQLCommand
-
 import pytest
+from sqlalchemy import create_engine
+
+from sql.command import SQLCommand
 
 
 @pytest.mark.parametrize(
@@ -109,3 +110,20 @@ def test_args(ip):
     }
 
     # assert cmd.command_text == "something\n"
+
+
+def test_parse_sql_when_passing_engine(ip, tmp_empty):
+    ip.user_global_ns["my_engine"] = create_engine("sqlite:///my.db")
+
+    line = "my_engine"
+    cell = "SELECT * FROM author"
+    sql_line = ip.magics_manager.lsmagic()["line"]["sql"].__self__
+
+    cmd = SQLCommand(sql_line, ip.user_ns, line, cell)
+
+    assert cmd.parsed == {
+        "connection": "my_engine",
+        "result_var": None,
+        "sql": "\nSELECT * FROM author",
+        "sql_original": "\nSELECT * FROM author",
+    }

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -4,6 +4,7 @@ import tempfile
 from textwrap import dedent
 
 import pytest
+from sqlalchemy import create_engine
 
 from conftest import runsql
 
@@ -373,6 +374,25 @@ def test_close_connection(ip):
     runsql(ip, f"%sql -x {connection_name}")
     connections_afterward = runsql(ip, "%sql -l")
     assert connection_name not in connections_afterward
+
+
+# TODO: try with spaces
+def test_pass_existing_engine(ip, tmp_empty):
+    ip.user_global_ns["my_engine"] = create_engine("sqlite:///my.db")
+    ip.run_line_magic("sql", "my_engine")
+
+    runsql(
+        ip,
+        [
+            "CREATE TABLE some_data (n INT, name TEXT)",
+            "INSERT INTO some_data VALUES (10, 'foo')",
+            "INSERT INTO some_data VALUES (20, 'bar')",
+        ],
+    )
+
+    result = ip.run_line_magic("sql", "SELECT * FROM some_data")
+
+    assert result == [(10, "foo"), (20, "bar")]
 
 
 # theres some weird shared state with this one, moving it to the end

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -376,10 +376,9 @@ def test_close_connection(ip):
     assert connection_name not in connections_afterward
 
 
-# TODO: try with spaces
 def test_pass_existing_engine(ip, tmp_empty):
     ip.user_global_ns["my_engine"] = create_engine("sqlite:///my.db")
-    ip.run_line_magic("sql", "my_engine")
+    ip.run_line_magic("sql", "  my_engine ")
 
     runsql(
         ip,


### PR DESCRIPTION
Closes #16

I also added more unit tests and created `SQLCommand` to encapsulate the input parsing logic (which allows us to test it more easily)