### PR TITLE
adds example

### DIFF
--- a/doc/howto.md
+++ b/doc/howto.md
@@ -63,3 +63,50 @@ FROM penguins.csv
 GROUP BY species
 ORDER BY count DESC
 ```
+
+## Register SQLite UDF
+
+To register a user-defined function (UDF) when using SQLite, you can use [SQLAlchemy's `@event.listens_for`](https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#user-defined-functions) and SQLite's [`create_function`](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.create_function):
+
+### Install JupySQL
+
+```{code-cell} ipython3
+%pip install jupysql --quiet
+```
+
+### Create engine and register function
+
+```{code-cell} ipython3
+from sqlalchemy import create_engine
+from sqlalchemy import event
+
+def mysum(x, y):
+    return x + y
+
+engine = create_engine("sqlite://")
+
+@event.listens_for(engine, "connect")
+def connect(conn, rec):
+    conn.create_function(name="MYSUM", narg=2, func=mysum)
+```
+
+### Create connection with existing engine
+
+```{versionadded} 0.5.1
+Pass existing engines to `%sql`
+```
+
+```{code-cell} ipython3
+%load_ext sql
+```
+
+```{code-cell} ipython3
+%sql engine
+```
+
+## Query
+
+```{code-cell} ipython3
+%%sql
+SELECT MYSUM(1, 2)
+```


### PR DESCRIPTION
closes #49

Registering SQLite UDFs is possible since version 0.5.1 when we added support for registering existing SQLAlchemy engines; this PR adds an example.