### PR TITLE
Not compatible with SQLAlchemy 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("src/sql/__init__.py", "rb") as f:
 install_requires = [
     "prettytable<1",
     "ipython>=1.0",
-    "sqlalchemy>=0.6.7",
+    "sqlalchemy>=0.6.7,<2.0",
     "sqlparse",
     "six",
     "ipython-genutils>=0.1.0",


### PR DESCRIPTION
Fixed SQLAlchemy version.

SQLAlchemy 2 is still in beta and the following libraries are incompatible with it:
1. ipython-sql
2. duckdb_engine

Issue : #24 