### PR TITLE
Connection names

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -14,10 +14,10 @@ kernelspec:
 # API
 
 ``-l`` / ``--connections``
-    List all active connections
+    List all active connections ([example](#list-connections))
 
-``-x`` / ``--close <session-name>`` 
-    Close named connection 
+``-x`` / ``--close <session-name/alias>``
+    Close named connection ([example](#close-connection))
 
 ``-c`` / ``--creator <creator-function>``
     Specify creator function for new connection
@@ -26,37 +26,37 @@ kernelspec:
     Section of dsn_file to be used for generating a connection string
 
 ``-p`` / ``--persist``
-    Create a table name in the database from the named DataFrame
+    Create a table name in the database from the named DataFrame ([example](#create-table))
 
 ``--append``
-    Like ``--persist``, but appends to the table if it already exists 
+    Like ``--persist``, but appends to the table if it already exists ([example](#append-to-table))
 
 ``-a`` / ``--connection_arguments <"{connection arguments}">``
     Specify dictionary of connection arguments to pass to SQL driver
 
 ``-f`` / ``--file <path>``
-    Run SQL from file at this path
+    Run SQL from file at this path ([example](#run-query-from-file))
 
 ```{versionadded} 0.4.2
 ```
 
 ``-n`` / ``--no-index``
-    Do not persist data frame's index (used with `-p/--persist`)
+    Do not persist data frame's index (used with `-p/--persist`) ([example](#create-table-without-dataframe-index))
 
 ```{versionadded} 0.4.3
 ```
 
 ``-S`` / ``--save <name>``
-    Save this query for later use
+    Save this query for later use ([example](#compose-large-queries))
 
 ``-w`` / ``--with <name>``
-    Use a previously saved query (used after `-S/--save`)
+    Use a previously saved query (used after `-S/--save`) ([example](#compose-large-queries))
 
 ```{versionadded} 0.5.2
 ```
 
 ``-A`` / ``--alias <alias>``
-    Assign an alias when establishing a connection
+    Assign an alias when establishing a connection ([example](#connect-to-database))
 
 ```{code-cell} ipython3
 :tags: [remove-input]

--- a/doc/api.md
+++ b/doc/api.md
@@ -28,9 +28,6 @@ kernelspec:
 ``-p`` / ``--persist``
     Create a table name in the database from the named DataFrame
 
-``-n`` / ``--no-index``
-    Do not persist data frame's index
-
 ``--append``
     Like ``--persist``, but appends to the table if it already exists 
 
@@ -39,6 +36,24 @@ kernelspec:
 
 ``-f`` / ``--file <path>``
     Run SQL from file at this path
+
+```{versionadded} 0.4.2
+```
+
+``-n`` / ``--no-index``
+    Do not persist data frame's index (used with `-p/--persist`)
+
+```{versionadded} 0.4.3
+```
+
+``-S`` / ``--save <name>``
+    Save this query for later use
+
+``-w`` / ``--with <name>``
+    Use a previously saved query (used after `-S/--save`)
+
+```{versionadded} 0.5.2
+```
 
 ``-A`` / ``--alias <alias>``
     Assign an alias when establishing a connection
@@ -67,7 +82,7 @@ for f in files:
 %sql sqlite:///db_one.db
 ```
 
-Assign an alias to the connection:
+Assign an alias to the connection (**added 0.5.2**):
 
 ```{code-cell} ipython3
 %sql sqlite:///db_two.db --alias db-two
@@ -85,7 +100,7 @@ Assign an alias to the connection:
 %sql --close sqlite:///db_one.db
 ```
 
-Or pass an alias:
+Or pass an alias (**added in 0.5.2**):
 
 ```{code-cell} ipython3
 %sql --close db-two

--- a/doc/api.md
+++ b/doc/api.md
@@ -40,6 +40,9 @@ kernelspec:
 ``-f`` / ``--file <path>``
     Run SQL from file at this path
 
+``-A`` / ``--alias <alias>``
+    Assign an alias when establishing a connection
+
 ```{code-cell} ipython3
 :tags: [remove-input]
 
@@ -64,13 +67,13 @@ for f in files:
 %sql sqlite:///db_one.db
 ```
 
-## List connections
-
-Connect to another database to demonstrate `--list`'s usage:
+Assign an alias to the connection:
 
 ```{code-cell} ipython3
-%sql sqlite:///db_two.db
+%sql sqlite:///db_two.db --alias db-two
 ```
+
+## List connections
 
 ```{code-cell} ipython3
 %sql --list
@@ -82,7 +85,17 @@ Connect to another database to demonstrate `--list`'s usage:
 %sql --close sqlite:///db_one.db
 ```
 
+Or pass an alias:
+
+```{code-cell} ipython3
+%sql --close db-two
+```
+
 ## Create table
+
+```{code-cell} ipython3
+%sql sqlite://
+```
 
 ```{code-cell} ipython3
 import pandas as pd

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -6,7 +6,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.0
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -152,6 +152,10 @@ SELECT * FROM numbers
 
 ## Switch connections
 
+```{versionadded} 0.5.2
+`-A/--alias`
+```
+
 ```{code-cell} ipython3
 from sqlalchemy import create_engine
 import pandas as pd

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -149,3 +149,80 @@ _ = pd.DataFrame({"x": range(5)}).to_sql("numbers", engine)
 %%sql
 SELECT * FROM numbers
 ```
+
+## Switch connections
+
+```{code-cell} ipython3
+from sqlalchemy import create_engine
+import pandas as pd
+
+engine_one = create_engine("sqlite:///one.db")
+pd.DataFrame({"x": range(5)}).to_sql("one", engine_one)
+
+engine_two = create_engine("sqlite:///two.db")
+_ = pd.DataFrame({"x": range(5)}).to_sql("two", engine_two)
+```
+
+```{code-cell} ipython3
+%load_ext sql
+```
+
+Assign alias to both connections so we can switch them by it:
+
+```{code-cell} ipython3
+%sql sqlite:///one.db --alias one
+%sql sqlite:///two.db --alias two
+```
+
+```{code-cell} ipython3
+%sql
+```
+
+Pass the alias to use such connection:
+
+```{code-cell} ipython3
+%%sql one
+SELECT * FROM one
+```
+
+It becomes the current active connection:
+
+```{code-cell} ipython3
+%sql
+```
+
+Hence, we can skip it in upcoming queries:
+
+```{code-cell} ipython3
+%%sql
+SELECT * FROM one
+```
+
+Switch connection:
+
+```{code-cell} ipython3
+%%sql two
+SELECT * FROM two
+```
+
+```{code-cell} ipython3
+%sql
+```
+
+Close by passing the alias:
+
+```{code-cell} ipython3
+%sql --close one
+```
+
+```{code-cell} ipython3
+%sql
+```
+
+```{code-cell} ipython3
+%sql --close two
+```
+
+```{code-cell} ipython3
+%sql -l
+```

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # Quick Start
 
-JupySQL allows you to run SQL in Jupyter/IPython via a `%sql` and `%%sql` magics.
+JupySQL allows you to run SQL in Jupyter/IPython via a `%sql` and `%%sql` magics. It is a fork of `ipython-sql` with bug fixes and a lot of great new features!
 
 +++
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -50,34 +50,39 @@ class Connection:
             cls.connections.keys()
         )
 
-    def __init__(self, engine):
+    def __init__(self, engine, alias=None):
         self.dialect = engine.url.get_dialect()
         self.metadata = sqlalchemy.MetaData(bind=engine)
         self.name = self.assign_name(engine)
         self.session = engine.connect()
-        self.connections[repr(self.metadata.bind.url)] = self
+        self.connections[alias or repr(self.metadata.bind.url)] = self
         self.connect_args = None
         Connection.current = self
 
     @classmethod
-    def from_connect_str(cls, connect_str=None, connect_args=None, creator=None):
+    def from_connect_str(
+        cls, connect_str=None, connect_args=None, creator=None, alias=None
+    ):
         """Creates a new connection from a connection string"""
         connect_args = connect_args or {}
 
         try:
             if creator:
                 engine = sqlalchemy.create_engine(
-                    connect_str, connect_args=connect_args, creator=creator
+                    connect_str,
+                    connect_args=connect_args,
+                    creator=creator,
                 )
             else:
                 engine = sqlalchemy.create_engine(
-                    connect_str, connect_args=connect_args
+                    connect_str,
+                    connect_args=connect_args,
                 )
         except Exception:
             print(cls.tell_format())
             raise
 
-        connection = cls(engine)
+        connection = cls(engine, alias=alias)
         connection.connect_args = connect_args
 
         return connection

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -57,6 +57,7 @@ class Connection:
         self.session = engine.connect()
         self.connections[alias or repr(self.metadata.bind.url)] = self
         self.connect_args = None
+        self.alias = alias
         Connection.current = self
 
     @classmethod
@@ -88,7 +89,7 @@ class Connection:
         return connection
 
     @classmethod
-    def set(cls, descriptor, displaycon, connect_args=None, creator=None):
+    def set(cls, descriptor, displaycon, connect_args=None, creator=None, alias=None):
         """
         Sets the current database connection
         """
@@ -110,7 +111,10 @@ class Connection:
                 # when descriptor is a connection object
                 # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments # noqa
                 cls.current = existing or Connection.from_connect_str(
-                    descriptor, connect_args, creator
+                    connect_str=descriptor,
+                    connect_args=connect_args,
+                    creator=creator,
+                    alias=alias,
                 )
         else:
 
@@ -120,7 +124,10 @@ class Connection:
             else:
                 if os.getenv("DATABASE_URL"):
                     cls.current = Connection.from_connect_str(
-                        os.getenv("DATABASE_URL"), connect_args, creator
+                        connect_str=os.getenv("DATABASE_URL"),
+                        connect_args=connect_args,
+                        creator=creator,
+                        alias=alias,
                     )
                 else:
                     raise ConnectionError(
@@ -138,14 +145,18 @@ class Connection:
     def connection_list(cls):
         result = []
         for key in sorted(cls.connections):
-            engine_url = cls.connections[
-                key
-            ].metadata.bind.url  # type: sqlalchemy.engine.url.URL
-            if cls.connections[key] == cls.current:
-                template = " * {}"
+            conn = cls.connections[key]
+            engine_url = conn.metadata.bind.url  # type: sqlalchemy.engine.url.URL
+
+            prefix = "* " if conn == cls.current else "  "
+
+            if conn.alias:
+                repr_ = f"{prefix} ({conn.alias}) {engine_url!r}"
             else:
-                template = "   {}"
-            result.append(template.format(repr(engine_url)))
+                repr_ = f"{prefix} {engine_url!r}"
+
+            result.append(repr_)
+
         return "\n".join(result)
 
     @classmethod
@@ -161,7 +172,12 @@ class Connection:
                 "Could not close connection because it was not found amongst these: %s"
                 % str(cls.connections.keys())
             )
-        cls.connections.pop(str(conn.metadata.bind.url))
+
+        if descriptor in cls.connections:
+            cls.connections.pop(descriptor)
+        else:
+            cls.connections.pop(str(conn.metadata.bind.url))
+
         conn.session.close()
 
     def close(self):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -191,6 +191,12 @@ class SqlMagic(Magics, Configurable):
         action="store_true",
         help="Do not execute query (use it with --save)",
     )
+    @argument(
+        "-A",
+        "--alias",
+        type=str,
+        help="Assign an alias to the connection",
+    )
     def execute(self, line="", cell="", local_ns={}):
         """
         Runs SQL statement against a database, specified by
@@ -273,6 +279,7 @@ class SqlMagic(Magics, Configurable):
                 displaycon=self.displaycon,
                 connect_args=args.connection_arguments,
                 creator=args.creator,
+                alias=args.alias,
             )
         except Exception as e:
             print(e)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -266,6 +266,8 @@ class SqlMagic(Magics, Configurable):
             args.creator = user_ns[args.creator]
 
         try:
+            # this creates a new connection or use an existing one
+            # depending on the connect_arg value
             conn = sql.connection.Connection.set(
                 connect_arg,
                 displaycon=self.displaycon,

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -125,6 +125,7 @@ def test_args(ip, sql_magic):
     cmd = SQLCommand(sql_magic, ip.user_ns, line="--with author_one", cell="")
 
     assert cmd.args.__dict__ == {
+        "alias": None,
         "line": "",
         "connections": False,
         "close": None,

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1,15 +1,37 @@
 import sys
 from unittest.mock import Mock
 
+import pytest
 from sqlalchemy.engine import Engine
 
 from sql.connection import Connection
 
 
-def test_password_isnt_displayed(monkeypatch):
+@pytest.fixture
+def cleanup():
+    yield
+    Connection.connections = {}
+
+
+@pytest.fixture
+def mock_postgres(monkeypatch, cleanup):
     monkeypatch.setitem(sys.modules, "psycopg2", Mock())
     monkeypatch.setattr(Engine, "connect", Mock())
 
+
+def test_password_isnt_displayed(mock_postgres):
     Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
 
     assert "topsecret" not in Connection.connection_list()
+
+
+def test_connection_name(mock_postgres):
+    conn = Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
+
+    assert conn.name == "user@db"
+
+
+def test_alias(cleanup):
+    Connection.from_connect_str("sqlite://", alias="some-alias")
+
+    assert list(Connection.connections) == ["some-alias"]

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -391,6 +391,21 @@ def test_close_connection(ip, tmp_empty):
     assert "sqlite:///two.db" not in Connection.connections
 
 
+def test_close_connection_with_alias(ip, tmp_empty):
+    # open two connections
+    ip.run_cell("%sql sqlite:///one.db --alias one")
+    ip.run_cell("%sql sqlite:///two.db --alias two")
+
+    # close them
+    ip.run_cell("%sql -x one")
+    ip.run_cell("%sql --close two")
+
+    assert "sqlite:///one.db" not in Connection.connections
+    assert "sqlite:///two.db" not in Connection.connections
+    assert "one" not in Connection.connections
+    assert "two" not in Connection.connections
+
+
 def test_column_names_visible(ip, tmp_empty):
     res = ip.run_line_magic("sql", "SELECT * FROM empty_table")
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -187,6 +187,7 @@ def test_without_sql_persist():
 
 def complete_with_defaults(mapping):
     defaults = {
+        "alias": None,
         "line": ["some-argument"],
         "connections": False,
         "close": None,


### PR DESCRIPTION
Closes https://github.com/ploomber/jupysql/issues/37

This PR adds a new option to the magics to allow connections to have an alias:

```
%sql {connection-string} --alias my-db
```

This allows users to close the connection with the alias:

```
%sql my-db --close
```


It also adds a few improvements to the docs.