### PR TITLE
adds g analytics id

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -29,6 +29,8 @@ html:
   use_repository_button: true
   extra_navbar: Join us on <a href="https://ploomber.io/community/">Slack!</a>
   announcement: To launch any tutorial in JupyterLab, click on the 🚀 button below!
+  google_analytics_id: G-JBZ8NNQSLN
+
 
 sphinx:
   config:


### PR DESCRIPTION
Adding google analytics

I created a new property on our analytics console and then a new web stream. Is this the right approach?

Also, when creating the web stream, the form asked me for the URL. Will this break once we switch the docs from the readthedocs.org domain to our domain? If so, we'll have to remember this.
