### PR TITLE
running flake8 in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,17 +13,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+
+      - name: Lint with flake8
+        shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
+          pip install flake8
+          flake8
+
+      - name: Install dependencies
+        run: |
+
           pip install .
           # check package is importable
           python -c "import sql"
           pip install ".[dev]"
+
+
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Lint with flake8
-        shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
           pip install flake8

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -51,7 +51,7 @@ class RenderMagic(Magics):
         action="append",
         dest="with_",
     )
-    @telemetry.log_call('sqlrender')
+    @telemetry.log_call("sqlrender")
     def sqlrender(self, line):
         args = parse_argstring(self.sqlrender, line)
         return str(store[args.line[0]])
@@ -62,7 +62,7 @@ class SqlMagic(Magics, Configurable):
     """Runs SQL statement on a database, specified by SQLAlchemy connect string.
 
     Provides the %%sql magic."""
-    
+
     displaycon = Bool(True, config=True, help="Show connection string after execution")
     autolimit = Int(
         0,
@@ -100,8 +100,7 @@ class SqlMagic(Magics, Configurable):
     column_local_vars = Bool(
         False, config=True, help="Return data into local variables from column names"
     )
-    feedback = Bool(True, config=True,
-                    help="Print number of rows affected by DML")
+    feedback = Bool(True, config=True, help="Print number of rows affected by DML")
     dsn_filename = Unicode(
         "odbc.ini",
         config=True,
@@ -112,7 +111,7 @@ class SqlMagic(Magics, Configurable):
     )
     autocommit = Bool(True, config=True, help="Set autocommit mode")
 
-    @telemetry.log_call('init')
+    @telemetry.log_call("init")
     def __init__(self, shell):
 
         self._store = store
@@ -189,7 +188,7 @@ class SqlMagic(Magics, Configurable):
         type=str,
         help="Assign an alias to the connection",
     )
-    @telemetry.log_call('execute')
+    @telemetry.log_call("execute")
     def execute(self, line="", cell="", local_ns={}):
         """
         Runs SQL statement against a database, specified by
@@ -319,8 +318,7 @@ class SqlMagic(Magics, Configurable):
 
                 if self.feedback:
                     print(
-                        "Returning data to local variables [{}]".format(
-                            ", ".join(keys))
+                        "Returning data to local variables [{}]".format(", ".join(keys))
                     )
 
                 self.shell.user_ns.update(result)
@@ -361,8 +359,7 @@ class SqlMagic(Magics, Configurable):
         except SyntaxError:
             raise SyntaxError("Syntax: %sql --persist <name_of_data_frame>")
         if not isinstance(frame, DataFrame) and not isinstance(frame, Series):
-            raise TypeError(
-                "%s is not a Pandas DataFrame or Series" % frame_name)
+            raise TypeError("%s is not a Pandas DataFrame or Series" % frame_name)
 
         # Make a suitable name for the resulting database table
         table_name = frame_name.lower()
@@ -370,8 +367,7 @@ class SqlMagic(Magics, Configurable):
 
         if_exists = "append" if append else "fail"
 
-        frame.to_sql(table_name, conn.session.engine,
-                     if_exists=if_exists, index=index)
+        frame.to_sql(table_name, conn.session.engine, if_exists=if_exists, index=index)
         return "Persisted %s" % table_name
 
 

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -166,7 +166,7 @@ class ResultSet(list, ColumnGuesserMixin):
         for row in self:
             yield dict(zip(self.keys, row))
 
-    @telemetry.log_call('data-frame')
+    @telemetry.log_call("data-frame")
     def DataFrame(self):
         "Returns a Pandas DataFrame instance built from the result set."
         import pandas as pd
@@ -174,7 +174,7 @@ class ResultSet(list, ColumnGuesserMixin):
         frame = pd.DataFrame(self, columns=(self and self.keys) or [])
         return frame
 
-    @telemetry.log_call('pie')
+    @telemetry.log_call("pie")
     def pie(self, key_word_sep=" ", title=None, **kwargs):
         """Generates a pylab pie chart from the result set.
 
@@ -205,7 +205,7 @@ class ResultSet(list, ColumnGuesserMixin):
         ax.set_title(title or self.ys[0].name)
         return ax
 
-    @telemetry.log_call('plot')
+    @telemetry.log_call("plot")
     def plot(self, title=None, **kwargs):
         """Generates a pylab plot from the result set.
 
@@ -244,7 +244,7 @@ class ResultSet(list, ColumnGuesserMixin):
 
         return ax
 
-    @telemetry.log_call('bar')
+    @telemetry.log_call("bar")
     def bar(self, key_word_sep=" ", title=None, **kwargs):
         """Generates a pylab bar plot from the result set.
 
@@ -279,7 +279,7 @@ class ResultSet(list, ColumnGuesserMixin):
         ax.set_ylabel(self.ys[0].name)
         return ax
 
-    @telemetry.log_call('generate-csv')
+    @telemetry.log_call("generate-csv")
     def csv(self, filename=None, **format_params):
         """Generate results in comma-separated form.  Write to ``filename`` if given.
         Any other parameters will be passed on to csv.writer."""
@@ -338,7 +338,7 @@ class FakeResultProxy(object):
         def fetchmany(size):
             pos = 0
             while pos < len(source_list):
-                yield source_list[pos: pos + size]
+                yield source_list[pos : pos + size]
                 pos += size
 
         self.fetchmany = fetchmany
@@ -379,8 +379,7 @@ def run(conn, sql, config, user_namespace):
             if first_word == "begin":
                 raise Exception("ipython_sql does not support transactions")
             if first_word.startswith("\\") and (
-                "postgres" in str(
-                    conn.dialect) or "redshift" in str(conn.dialect)
+                "postgres" in str(conn.dialect) or "redshift" in str(conn.dialect)
             ):
                 if not PGSpecial:
                     raise ImportError("pgspecial not installed")

--- a/src/sql/telemetry.py
+++ b/src/sql/telemetry.py
@@ -11,4 +11,3 @@ telemetry = Telemetry(
     package_name="jupysql",
     version=version("jupysql"),
 )
-


### PR DESCRIPTION
we were missing running flake8 in the CI, I also ran `black` so flake8 passes

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--94.org.readthedocs.build/en/94/

<!-- readthedocs-preview jupysql end -->