### PR TITLE
Doc - Telemetry doc - Add more details on what's collected

### DIFF
--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -38,5 +38,6 @@ parts:
   - caption: Community
     chapters:
     - file: community/projects
-    - file: community/community
     - file: community/credits
+    - file: community/coc
+    - file: community/support

--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -37,7 +37,7 @@ parts:
 
   - caption: Community
     chapters:
-    - file: community/projects
-    - file: community/credits
     - file: community/coc
+    - file: community/projects
     - file: community/support
+    - file: community/credits

--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -38,6 +38,6 @@ parts:
   - caption: Community
     chapters:
     - file: community/coc
-    - file: community/projects
     - file: community/support
+    - file: community/projects
     - file: community/credits

--- a/doc/community/coc.md
+++ b/doc/community/coc.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
-Ploomber has been committed to build the product by making it easy for community users to facilitate the day-to-day work
+Ploomber has been committed to build the product by making it easy for community users to facilitate the day-to-day work.
 
 For more details, see [here](https://docs.ploomber.io/en/latest/community/coc.html)

--- a/doc/community/coc.md
+++ b/doc/community/coc.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+Ploomber has been committed to build the product by making it easy for community users to facilitate the day-to-day work
+
+For more details, see [here](https://docs.ploomber.io/en/latest/community/coc.html)

--- a/doc/community/community.md
+++ b/doc/community/community.md
@@ -1,9 +1,0 @@
-# Community
-
-## Code of Conduct
-
-[See here](https://docs.ploomber.io/en/latest/community/coc.html)
-
-## Telemetry
-
-[See here](https://docs.ploomber.io/en/latest/community/user-stats.html)

--- a/doc/community/support.md
+++ b/doc/community/support.md
@@ -4,4 +4,4 @@ For support, feature requests, and product updates: [join our community](https:/
 
 # Telemetry
 
-We collect (optional) anonymous statistics to understand and improve usage. For details, [see here](https://docs.ploomber.io/en/latest/community/user-stats.html).
+We collect (optional) anonymous statistics to understand and improve usage. For more details of what we collect and how to opt-out the telemetry collection, [see here](https://docs.ploomber.io/en/latest/community/user-stats.html).

--- a/doc/community/support.md
+++ b/doc/community/support.md
@@ -1,0 +1,7 @@
+# Support
+
+For support, feature requests, and product updates: [join our community](https://ploomber.io/community) or follow us on [Twitter](https://twitter.com/ploomber)/[LinkedIn](https://www.linkedin.com/company/ploomber/).
+
+# Telemetry
+
+We collect (optional) anonymous statistics to understand and improve usage. For details, [see here](https://docs.ploomber.io/en/latest/community/user-stats.html).


### PR DESCRIPTION
Context:
Respond to https://github.com/ploomber/jupysql/issues/72 
We need to add a doc to explain user about our telemetry part. Since we are using the shared telemetry module, we may refer to the detail section of [User Statistics](https://docs.ploomber.io/en/latest/community/user-stats.html)

However, something we can do:
1. Add the support page under community in jupysql doc, which contains the Support + Telemetry section
2. Polish original [User Statistics](https://docs.ploomber.io/en/latest/community/user-stats.html) doc in the ploomber project, I've raised [the PR](https://github.com/ploomber/jupysql/pull/101) for patching

Changes in this PR:
- Add support doc
- Add coc doc
- Remove community doc (replaced by new coc doc and new support doc)
- Reorder the _toc ordering (Page Navigation)


## Preview

Page Navigation
Before:
<img width="283" alt="Screenshot 2023-01-30 at 12 50 18 PM" src="https://user-images.githubusercontent.com/123580782/215555454-143323bb-cb80-450d-b794-a3dec5a945f9.png">

After (Remove `Community`, Add `Code of Conduct` & `Support`):
<img width="268" alt="Screenshot 2023-01-30 at 12 51 26 PM" src="https://user-images.githubusercontent.com/123580782/215555465-bf151160-87f9-4b31-8cad-c6718d548d81.png">

New Code of Conduct
<img width="1672" alt="Screenshot 2023-01-30 at 12 53 34 PM" src="https://user-images.githubusercontent.com/123580782/215555699-713be589-382a-4338-aad8-2e7d698c9b38.png">

New Support & Telemetry
<img width="1694" alt="Screenshot 2023-01-30 at 12 51 37 PM" src="https://user-images.githubusercontent.com/123580782/215555723-3434f039-c448-43f8-b0ca-a10ff61b57b5.png">

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--101.org.readthedocs.build/en/101/

<!-- readthedocs-preview jupysql end -->