### PR TITLE
CD for jupysql

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,3 +56,38 @@ jobs:
       - name: Check project
         run: |
           pkgmt check
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'master' && startsWith(github.event.head_commit.message, 'tag and release this version')
+    needs: [test, check]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'pkgmt[check]'
+          pip install wheel
+          pip install twine
+
+      - name: Configure git
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "github-actions"
+
+      - name: Bump up tag version 
+        run: |
+          pkgmt version --yes
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          TAG=$(git describe --abbrev=0)
+          echo yes | pkgmt release $TAG --production

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+description-file = README.md
+
 [flake8]
 exclude = build/, doc/_build/
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,11 @@ install_requires = [
     "jinja2",
     "ploomber-core>=0.2",
     'importlib-metadata;python_version<"3.8"',
+    "black",
 ]
 
 DEV = [
+    "flake8",
     "pytest",
     "pandas",
     "invoke",


### PR DESCRIPTION
## Changes
1. release job added to ci.yaml
2. flake8 and black added to the setup

### How it works

1. `release` job is triggered only on the `master` branch with the following commit message: `tag and release this version`
This means we can trigger the release in 2 ways:
    * Commit PR merge to master with `tag and release this version`
    * Add an empty commit on master

2. `release` job uses `pkgmt` and runs 4 steps: 
    * Installs all needed packages to deploy (pkgmt, wheel, and twine)
    * Sets git configuration (username : github-actions, email: github-actions@github.com)
    * Bumps up version with `pkgmt version`
    * Release to PyPI production with the new tag `pkgmt release $TAG --production`



### Closes: #23 
