### PR TITLE
Updating jupysql error messages - ValueError, TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.4dev
 
-* [Fix] Appends the community link to the exception message of ValueError and TypeError
+* [Fix] Shows the community link to the exception message of ValueError and TypeError
 
 ## 0.5.3 (2023-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.4dev
 
+* [Fix] Appends the community link to the exception message of ValueError and TypeError
+
 ## 0.5.3 (2023-01-31)
 
 * [Feature] Adds `%sqlcmd tables` ([#76](https://github.com/ploomber/jupysql/issues/76))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.4dev
 
-* [Fix] Shows the community link to the exception message of ValueError and TypeError
+* [Fix] Adds community link to `ValueError` and `TypeError`
 
 ## 0.5.3 (2023-01-31)
 

--- a/src/sql/inspect.py
+++ b/src/sql/inspect.py
@@ -1,6 +1,6 @@
 from sqlalchemy import inspect
 from prettytable import PrettyTable
-
+from ploomber_core import exceptions
 
 from sql.connection import Connection
 from sql.telemetry import telemetry
@@ -54,11 +54,11 @@ class Columns(DatabaseInspection):
 
         if not columns:
             if schema:
-                raise ValueError(
+                raise exceptions.PloomberValueError(
                     f"There is no table with name {name!r} in schema {schema!r}"
                 )
             else:
-                raise ValueError(
+                raise exceptions.PloomberValueError(
                     f"There is no table with name {name!r} in the default schema"
                 )
 

--- a/src/sql/inspect.py
+++ b/src/sql/inspect.py
@@ -1,6 +1,6 @@
 from sqlalchemy import inspect
 from prettytable import PrettyTable
-from ploomber_core import exceptions
+from ploomber_core.exceptions import modify_exceptions
 
 from sql.connection import Connection
 from sql.telemetry import telemetry
@@ -42,6 +42,7 @@ class Tables(DatabaseInspection):
         self._table_txt = self._table.get_string()
 
 
+@modify_exceptions
 class Columns(DatabaseInspection):
     """
     Represents the columns in a database table
@@ -54,11 +55,11 @@ class Columns(DatabaseInspection):
 
         if not columns:
             if schema:
-                raise exceptions.PloomberValueError(
+                raise ValueError(
                     f"There is no table with name {name!r} in schema {schema!r}"
                 )
             else:
-                raise exceptions.PloomberValueError(
+                raise ValueError(
                     f"There is no table with name {name!r} in the default schema"
                 )
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -1,6 +1,6 @@
 import json
 import re
-
+from ploomber_core.exceptions import modify_exceptions
 from IPython.core.magic import (
     Magics,
     cell_magic,
@@ -345,6 +345,7 @@ class SqlMagic(Magics, Configurable):
 
     legal_sql_identifier = re.compile(r"^[A-Za-z0-9#_$]+")
 
+    @modify_exceptions
     def _persist_dataframe(self, raw, conn, user_ns, append=False, index=True):
         """Implements PERSIST, which writes a DataFrame to the RDBMS"""
         if not DataFrame:

--- a/src/sql/magic_plot.py
+++ b/src/sql/magic_plot.py
@@ -4,7 +4,7 @@ from IPython.core.magic import (
     magics_class,
 )
 from IPython.core.magic_arguments import argument, magic_arguments
-from ploomber_core import exceptions
+from ploomber_core.exceptions import modify_exceptions
 
 try:
     from traitlets.config.configurable import Configurable
@@ -49,6 +49,7 @@ class SqlPlotMagic(Magics, Configurable):
         action="append",
         dest="with_",
     )
+    @modify_exceptions
     def execute(self, line="", cell="", local_ns=None):
         """
         Plot magic
@@ -62,7 +63,7 @@ class SqlPlotMagic(Magics, Configurable):
             column = cmd.args.column
 
         if not cmd.args.line:
-            raise exceptions.PloomberValueError(
+            raise ValueError(
                 "Missing the first argument, must be: 'histogram' or 'boxplot'"
             )
 
@@ -83,6 +84,6 @@ class SqlPlotMagic(Magics, Configurable):
                 conn=None,
             )
         else:
-            raise exceptions.PloomberValueError(
+            raise ValueError(
                 f"Unknown plot {cmd.args.line[0]!r}. Must be: 'histogram' or 'boxplot'"
             )

--- a/src/sql/magic_plot.py
+++ b/src/sql/magic_plot.py
@@ -4,7 +4,7 @@ from IPython.core.magic import (
     magics_class,
 )
 from IPython.core.magic_arguments import argument, magic_arguments
-
+from ploomber_core import exceptions
 
 try:
     from traitlets.config.configurable import Configurable
@@ -62,7 +62,7 @@ class SqlPlotMagic(Magics, Configurable):
             column = cmd.args.column
 
         if not cmd.args.line:
-            raise ValueError(
+            raise exceptions.PloomberValueError(
                 "Missing the first argument, must be: 'histogram' or 'boxplot'"
             )
 
@@ -83,6 +83,6 @@ class SqlPlotMagic(Magics, Configurable):
                 conn=None,
             )
         else:
-            raise ValueError(
+            raise exceptions.PloomberValueError(
                 f"Unknown plot {cmd.args.line[0]!r}. Must be: 'histogram' or 'boxplot'"
             )

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -2,7 +2,7 @@
 Plot using the SQL backend
 """
 from ploomber_core.dependencies import requires
-from ploomber_core import exceptions
+from ploomber_core.exceptions import modify_exceptions
 from jinja2 import Template
 
 try:
@@ -124,6 +124,7 @@ OR  "{{column}}" > {{whishi}}
 
 
 # https://github.com/matplotlib/matplotlib/blob/b5ac96a8980fdb9e59c9fb649e0714d776e26701/lib/matplotlib/cbook/__init__.py
+@modify_exceptions
 def _boxplot_stats(con, table, column, whis=1.5, autorange=False, with_=None):
     """Compute statistics required to create a boxplot"""
 
@@ -159,9 +160,7 @@ def _boxplot_stats(con, table, column, whis=1.5, autorange=False, with_=None):
         loval = q1 - whis * stats["iqr"]
         hival = q3 + whis * stats["iqr"]
     else:
-        raise exceptions.PloomberValueError(
-            "whis must be a float or list of percentiles"
-        )
+        raise ValueError("whis must be a float or list of percentiles")
 
     # get high extreme
     wiskhi_d = _whishi(con, table, column, hival, with_=with_)
@@ -350,6 +349,7 @@ def histogram(table, column, bins, with_=None, conn=None):
     return ax
 
 
+@modify_exceptions
 def _histogram(table, column, bins, with_=None, conn=None):
     """Compute bins and heights"""
     if not conn:
@@ -379,6 +379,6 @@ order by 1;
     bin_, height = zip(*data)
 
     if bin_[0] is None:
-        raise exceptions.PloomberValueError("Data contains NULLs")
+        raise ValueError("Data contains NULLs")
 
     return bin_, height

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -2,6 +2,7 @@
 Plot using the SQL backend
 """
 from ploomber_core.dependencies import requires
+from ploomber_core import exceptions
 from jinja2 import Template
 
 try:
@@ -376,6 +377,6 @@ order by 1;
     bin_, height = zip(*data)
 
     if bin_[0] is None:
-        raise ValueError("Data contains NULLs")
+        raise exceptions.PloomberValueError("Data contains NULLs")
 
     return bin_, height

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -159,7 +159,7 @@ def _boxplot_stats(con, table, column, whis=1.5, autorange=False, with_=None):
         loval = q1 - whis * stats["iqr"]
         hival = q3 + whis * stats["iqr"]
     else:
-        raise ValueError("whis must be a float or list of percentiles")
+        raise exceptions.PloomberValueError("whis must be a float or list of percentiles")
 
     # get high extreme
     wiskhi_d = _whishi(con, table, column, hival, with_=with_)

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -159,7 +159,9 @@ def _boxplot_stats(con, table, column, whis=1.5, autorange=False, with_=None):
         loval = q1 - whis * stats["iqr"]
         hival = q3 + whis * stats["iqr"]
     else:
-        raise exceptions.PloomberValueError("whis must be a float or list of percentiles")
+        raise exceptions.PloomberValueError(
+            "whis must be a float or list of percentiles"
+        )
 
     # get high extreme
     wiskhi_d = _whishi(con, table, column, hival, with_=with_)

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -1,6 +1,6 @@
 from typing import Iterator, Iterable
 from collections.abc import MutableMapping
-from ploomber_core import exceptions
+from ploomber_core.exceptions import modify_exceptions
 
 from jinja2 import Template
 
@@ -55,11 +55,10 @@ class SQLStore(MutableMapping):
         # TODO: if with is false, WITH should not appear
         return SQLQuery(self, query, with_)
 
+    @modify_exceptions
     def store(self, key, query, with_=None):
         if with_ and key in with_:
-            raise exceptions.PloomberValueError(
-                f"Script name ({key!r}) cannot appear in with_ argument"
-            )
+            raise ValueError(f"Script name ({key!r}) cannot appear in with_ argument")
 
         self._data[key] = SQLQuery(self, query, with_)
 

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -57,7 +57,9 @@ class SQLStore(MutableMapping):
 
     def store(self, key, query, with_=None):
         if with_ and key in with_:
-            raise exceptions.PloomberValueError(f"Script name ({key!r}) cannot appear in with_ argument")
+            raise exceptions.PloomberValueError(
+                f"Script name ({key!r}) cannot appear in with_ argument"
+            )
 
         self._data[key] = SQLQuery(self, query, with_)
 

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -1,5 +1,6 @@
 from typing import Iterator, Iterable
 from collections.abc import MutableMapping
+from ploomber_core import exceptions
 
 from jinja2 import Template
 
@@ -56,7 +57,7 @@ class SQLStore(MutableMapping):
 
     def store(self, key, query, with_=None):
         if with_ and key in with_:
-            raise ValueError(f"Script name ({key!r}) cannot appear in with_ argument")
+            raise exceptions.PloomberValueError(f"Script name ({key!r}) cannot appear in with_ argument")
 
         self._data[key] = SQLQuery(self, query, with_)
 

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -93,7 +93,7 @@ def test_get_column(sample_db, name, first, second, schema):
     ],
 )
 def test_nonexistent_table(name, schema, error):
-    with pytest.raises(excepts.PloomberValue) as excinfo:
+    with pytest.raises(exceptions.PloomberValueError) as excinfo:
         inspect.get_columns(name, schema)
 
     assert error.lower() in str(excinfo.value).lower()

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -2,7 +2,6 @@ from inspect import getsource
 import sqlite3
 import pytest
 from functools import partial
-from ploomber_core import exceptions
 
 from sql import inspect, connection
 
@@ -93,7 +92,7 @@ def test_get_column(sample_db, name, first, second, schema):
     ],
 )
 def test_nonexistent_table(name, schema, error):
-    with pytest.raises(exceptions.PloomberValueError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         inspect.get_columns(name, schema)
 
     assert error.lower() in str(excinfo.value).lower()

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -98,6 +98,7 @@ def test_nonexistent_table(name, schema, error):
 
     assert error.lower() in str(excinfo.value).lower()
 
+
 @pytest.mark.parametrize(
     "function",
     [

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -2,7 +2,7 @@ from inspect import getsource
 import sqlite3
 import pytest
 from functools import partial
-
+from ploomber_core import exceptions
 
 from sql import inspect, connection
 
@@ -93,7 +93,7 @@ def test_get_column(sample_db, name, first, second, schema):
     ],
 )
 def test_nonexistent_table(name, schema, error):
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(excepts.PloomberValue) as excinfo:
         inspect.get_columns(name, schema)
 
     assert error.lower() in str(excinfo.value).lower()

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -96,8 +96,7 @@ def test_nonexistent_table(name, schema, error):
     with pytest.raises(ValueError) as excinfo:
         inspect.get_columns(name, schema)
 
-    assert str(excinfo.value) == error
-
+    assert error.lower() in str(excinfo.value).lower()
 
 @pytest.mark.parametrize(
     "function",

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -104,6 +104,14 @@ def test_persist(ip):
     persisted = runsql(ip, "SELECT * FROM results_dframe")
     assert persisted == [(0, 1, "foo"), (1, 2, "bar")]
 
+def test_persist_with_exceptions(ip):
+    runsql(ip, "")
+    ip.run_cell("results = %sql SELECT * FROM test;")
+    out = ip.run_cell("results.RANDOM()")
+    print (out)
+    # ip.run_cell("%sql --persist sqlite:// results_dframe")
+    # persisted = runsql(ip, "SELECT * FROM results_dframe")
+    # assert persisted == [(0, 1, "foo"), (1, 2, "bar")]
 
 def test_persist_no_index(ip):
     runsql(ip, "")
@@ -135,8 +143,8 @@ def test_persist_non_frame_raises(ip):
     ip.run_cell("not_a_dataframe = 22")
     runsql(ip, "")
     result = ip.run_cell("%sql --persist sqlite:// not_a_dataframe")
-    assert result.error_in_exec
-
+    print (str(result.error_in_exec))
+    assert "is not a Pandas DataFrame or Series".lower() in str(result.error_in_exec).lower()
 
 def test_persist_bare(ip):
     result = ip.run_cell("%sql --persist sqlite://")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -104,14 +104,6 @@ def test_persist(ip):
     persisted = runsql(ip, "SELECT * FROM results_dframe")
     assert persisted == [(0, 1, "foo"), (1, 2, "bar")]
 
-def test_persist_with_exceptions(ip):
-    runsql(ip, "")
-    ip.run_cell("results = %sql SELECT * FROM test;")
-    out = ip.run_cell("results.RANDOM()")
-    print (out)
-    # ip.run_cell("%sql --persist sqlite:// results_dframe")
-    # persisted = runsql(ip, "SELECT * FROM results_dframe")
-    # assert persisted == [(0, 1, "foo"), (1, 2, "bar")]
 
 def test_persist_no_index(ip):
     runsql(ip, "")
@@ -143,8 +135,11 @@ def test_persist_non_frame_raises(ip):
     ip.run_cell("not_a_dataframe = 22")
     runsql(ip, "")
     result = ip.run_cell("%sql --persist sqlite:// not_a_dataframe")
-    print (str(result.error_in_exec))
-    assert "is not a Pandas DataFrame or Series".lower() in str(result.error_in_exec).lower()
+    assert (
+        "is not a Pandas DataFrame or Series".lower()
+        in str(result.error_in_exec).lower()
+    )
+
 
 def test_persist_bare(ip):
     result = ip.run_cell("%sql --persist sqlite://")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -135,6 +135,7 @@ def test_persist_non_frame_raises(ip):
     ip.run_cell("not_a_dataframe = 22")
     runsql(ip, "")
     result = ip.run_cell("%sql --persist sqlite:// not_a_dataframe")
+    assert isinstance(result.error_in_exec, TypeError)
     assert (
         "is not a Pandas DataFrame or Series".lower()
         in str(result.error_in_exec).lower()
@@ -307,7 +308,6 @@ def test_dicts(ip):
 
 
 def test_bracket_var_substitution(ip):
-
     ip.user_global_ns["col"] = "first_name"
     assert runsql(ip, "SELECT * FROM author" " WHERE {col} = 'William' ")[0] == (
         "William",
@@ -322,7 +322,6 @@ def test_bracket_var_substitution(ip):
 
 # the next two tests had the same name, so I added a _2 to the second one
 def test_multiline_bracket_var_substitution(ip):
-
     ip.user_global_ns["col"] = "first_name"
     assert runsql(ip, "SELECT * FROM author\n" " WHERE {col} = 'William' ")[0] == (
         "William",

--- a/src/tests/test_magic_plot.py
+++ b/src/tests/test_magic_plot.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from ploomber_core import exceptions
 import pytest
 from IPython.core.error import UsageError
 import matplotlib.pyplot as plt
@@ -10,12 +9,12 @@ import matplotlib.pyplot as plt
     [
         [
             "%sqlplot someplot -t a -c b",
-            exceptions.PloomberValueError,
+            ValueError,
             "Unknown plot 'someplot'. Must be: 'histogram' or 'boxplot'",
         ],
         [
             "%sqlplot -t a -c b",
-            exceptions.PloomberValueError,
+            ValueError,
             "Missing the first argument, must be: 'histogram' or 'boxplot'",
         ],
     ],

--- a/src/tests/test_magic_plot.py
+++ b/src/tests/test_magic_plot.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+from ploomber_core import exceptions
 import pytest
 from IPython.core.error import UsageError
 import matplotlib.pyplot as plt
@@ -10,12 +10,12 @@ import matplotlib.pyplot as plt
     [
         [
             "%sqlplot someplot -t a -c b",
-            ValueError,
+            exceptions.PloomberValueError,
             "Unknown plot 'someplot'. Must be: 'histogram' or 'boxplot'",
         ],
         [
             "%sqlplot -t a -c b",
-            ValueError,
+            exceptions.PloomberValueError,
             "Missing the first argument, must be: 'histogram' or 'boxplot'",
         ],
     ],
@@ -24,7 +24,7 @@ def test_validate_plot_name(tmp_empty, ip, cell, error_type, error_message):
     out = ip.run_cell(cell)
 
     assert isinstance(out.error_in_exec, error_type)
-    assert str(out.error_in_exec) == (error_message)
+    assert str(error_message).lower() in str(out.error_in_exec).lower()
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -59,6 +59,17 @@ def test_boxplot_stats(chinook_db):
 
     assert DictOfFloats(result) == DictOfFloats(expected[0])
 
+def test_boxplot_stats_exception(chinook_db):
+    con = duckdb.connect(database=":memory:")
+    con.execute("INSTALL 'sqlite_scanner';")
+    con.execute("LOAD 'sqlite_scanner';")
+    con.execute(f"CALL sqlite_attach({chinook_db!r});")
+
+    res = con.execute("SELECT * FROM Invoice")
+    X = res.df().Total
+    expected = cbook.boxplot_stats(X)
+    with pytest.raises(BaseException, match="whis must be a float or list of percentiles.*"):
+        result = plot._boxplot_stats(con, "Invoice", "Total", "Not a float or list of percentiles whis param")
 
 @pytest.mark.parametrize(
     "cell, error_type, error_message",

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -7,7 +7,6 @@ from matplotlib import cbook
 from sql import plot
 from pathlib import Path
 import pytest
-from ploomber_core import exceptions
 
 
 class DictOfFloats(Mapping):
@@ -82,7 +81,7 @@ def test_boxplot_stats_exception(chinook_db):
     [
         [
             "%sqlplot histogram --table data.csv --column age --table data.csv",
-            exceptions.PloomberValueError,
+            ValueError,
             "Data contains NULLs",
         ]
     ],

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -59,6 +59,7 @@ def test_boxplot_stats(chinook_db):
 
     assert DictOfFloats(result) == DictOfFloats(expected[0])
 
+
 def test_boxplot_stats_exception(chinook_db):
     con = duckdb.connect(database=":memory:")
     con.execute("INSTALL 'sqlite_scanner';")
@@ -67,9 +68,14 @@ def test_boxplot_stats_exception(chinook_db):
 
     res = con.execute("SELECT * FROM Invoice")
     X = res.df().Total
-    expected = cbook.boxplot_stats(X)
-    with pytest.raises(BaseException, match="whis must be a float or list of percentiles.*"):
-        result = plot._boxplot_stats(con, "Invoice", "Total", "Not a float or list of percentiles whis param")
+    cbook.boxplot_stats(X)
+    with pytest.raises(
+        BaseException, match="whis must be a float or list of percentiles.*"
+    ):
+        plot._boxplot_stats(
+            con, "Invoice", "Total", "Not a float or list of percentiles whis param"
+        )
+
 
 @pytest.mark.parametrize(
     "cell, error_type, error_message",
@@ -81,9 +87,9 @@ def test_boxplot_stats_exception(chinook_db):
         ]
     ],
 )
-# Test internal plot function e.g. 
+# Test internal plot function e.g.
 def test_internal_histogram_exception(tmp_empty, ip, cell, error_type, error_message):
-    Path("data.csv").write_text('name,age\nDan,33\nBob,19\nSheri,')
+    Path("data.csv").write_text("name,age\nDan,33\nBob,19\nSheri,")
     ip.run_cell("%sql duckdb://")
     ip.run_cell(
         """%%sql --save test_dataset --no-execute

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -11,7 +11,6 @@ def test_sqlstore_setitem():
 
 def test_key():
     store = SQLStore()
-    # store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
     with pytest.raises(ValueError):
         store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -1,7 +1,6 @@
 import pytest
 
 from sql.store import SQLStore
-from ploomber_core import exceptions
 
 
 def test_sqlstore_setitem():
@@ -14,7 +13,7 @@ def test_key():
     store = SQLStore()
     # store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
-    with pytest.raises(exceptions.PloomberValueError):
+    with pytest.raises(ValueError):
         store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
 

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sql.store import SQLStore
+from ploomber_core import exceptions
 
 
 def test_sqlstore_setitem():
@@ -11,8 +12,9 @@ def test_sqlstore_setitem():
 
 def test_key():
     store = SQLStore()
+    # store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.PloomberValueError):
         store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
 


### PR DESCRIPTION
Close https://github.com/ploomber/jupysql/issues/30

## Context

- Add @modify_exceptions decorator to function which might raise `ValueError`, `TypeError` exception, to show the community link
- Patch some test cases
 
## Changes
- Change all places `ValueError` -> `PloomberValueError`
- Change existing test cases to cover `PloomberValueError`
- Add new test cases to cover `PloomberValueError`
- Add CHANGELOG as
  * `[Fix] Shows the community link to the exception message of ValueError and TypeError` in 0.5.4dev


## Preview

Example for the `PloomberValueError` message

<img width="936" alt="Screenshot 2023-01-31 at 2 27 37 PM" src="https://user-images.githubusercontent.com/123580782/215863368-007bff72-3b85-4933-a9c2-5fd33134f20c.png">

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--106.org.readthedocs.build/en/106/

<!-- readthedocs-preview jupysql end -->