### PR TITLE
Fix: Doc Typo in Connecting: PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.5.4dev
 
-* [Fix] Doc Typo `PosgreSQL` in Connecting
 * [Fix] Adds community link to `ValueError` and `TypeError`
 
 ## 0.5.3 (2023-01-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.4dev
 
+* [Fix] Doc Typo `PosgreSQL` in Connecting
 * [Fix] Adds community link to `ValueError` and `TypeError`
 
 ## 0.5.3 (2023-01-31)

--- a/doc/connecting.md
+++ b/doc/connecting.md
@@ -57,7 +57,7 @@ a flag with (-a|--connection_arguments)the connection string as a JSON string. S
 
 Check out our guide for connecting to a database:
 
-- [PosgreSQL](howto/postgres-connect)
+- [PostgreSQL](howto/postgres-connect)
 
 +++
 


### PR DESCRIPTION
Close https://github.com/ploomber/jupysql/issues/109

## Change

- Fix Typo `PosgreSQL` -> `PostgreSQL`

## Verification

Before:
<img width="494" alt="Screenshot 2023-02-02 at 11 32 52 AM" src="https://user-images.githubusercontent.com/123580782/216386983-e4c505ad-be9c-4a24-b455-20d242d671f2.png">

After:
<img width="537" alt="Screenshot 2023-02-02 at 11 39 42 AM" src="https://user-images.githubusercontent.com/123580782/216386997-b763d565-2bb7-463d-a18b-bf32354408cc.png">


<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--110.org.readthedocs.build/en/110/

<!-- readthedocs-preview jupysql end -->