### PR TITLE
adding `%jupysql`/`%%jupysql` as alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.3dev
 * [Fix] Adds telemetry collect for `%sqlplot` invocation ([#89](https://github.com/ploomber/jupysql/pull/89))
 * [Fix] `setup.py` fix due to change in setuptools 67.0.0
+* [Feature] Adds `%jupysql`/`%%jupysql` as alias for `%sql`/`%%sql`
 
 ## 0.5.2 (2023-01-03)
 * Adds example for connecting to a SQLite database with spaces ([#35](https://github.com/ploomber/jupysql/issues/35))

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 ```{code-cell} ipython3
-:tags: [hide-cell]
+:tags: [remove-cell]
 
 # clean up all .db files (this cell will not be displayed in the docs)
 from pathlib import Path
@@ -246,7 +246,7 @@ Close by passing the alias:
 
 ## Connect to existing `engine`
 
-Pass the name of the enfgine:
+Pass the name of the engine:
 
 ```{code-cell} ipython3
 some_engine = create_engine("sqlite:///some.db")
@@ -258,7 +258,7 @@ some_engine = create_engine("sqlite:///some.db")
 
 +++ {"tags": []}
 
-## Use `%sql`/`%%sql` in databricks
+## Use `%sql`/`%%sql` in Databricks
 
 Databricks uses the same name (`%sql`/`%%sql`) for its SQL magics; however, JupySQL exposes a `%jupysql`/`%%jupysql` alias so you can use both:
 

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -11,6 +11,19 @@ kernelspec:
   name: python3
 ---
 
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+# clean up all .db files (this cell will not be displayed in the docs)
+from pathlib import Path
+from glob import glob
+
+for file in (Path(f) for f in glob("*.db")):
+    if file.exists():
+        print(f"Deleting: {file}")
+        file.unlink()
+```
+
 # How-To
 
 ## Query CSV files with SQL
@@ -229,4 +242,37 @@ Close by passing the alias:
 
 ```{code-cell} ipython3
 %sql -l
+```
+
+## Connect to existing `engine`
+
+Pass the name of the enfgine:
+
+```{code-cell} ipython3
+some_engine = create_engine("sqlite:///some.db")
+```
+
+```{code-cell} ipython3
+%sql some_engine
+```
+
++++ {"tags": []}
+
+## Use `%sql`/`%%sql` in databricks
+
+Databricks uses the same name (`%sql`/`%%sql`) for its SQL magics; however, JupySQL exposes a `%jupysql`/`%%jupysql` alias so you can use both:
+
+```{code-cell} ipython3
+%jupysql duckdb://
+```
+
+```{code-cell} ipython3
+%jupysql SELECT * FROM "penguins.csv" LIMIT 3
+```
+
+```{code-cell} ipython3
+%%jupysql
+SELECT *
+FROM "penguins.csv"
+LIMIT 3
 ```

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -125,6 +125,8 @@ class SqlMagic(Magics, Configurable):
     @needs_local_scope
     @line_magic("sql")
     @cell_magic("sql")
+    @line_magic("jupysql")
+    @cell_magic("jupysql")
     @magic_arguments()
     @argument("line", default="", nargs="*", type=str, help="sql")
     @argument(

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from sql.connection import Connection
+from sql.magic import SqlMagic
 from conftest import runsql
 
 
@@ -458,3 +459,10 @@ def test_autolimit(ip):
     ip.run_line_magic("config", "SqlMagic.autolimit = 1")
     result = runsql(ip, "SELECT * FROM test;")
     assert len(result) == 1
+
+
+def test_jupysql_alias():
+    assert SqlMagic.magics == {
+        "line": {"jupysql": "execute", "sql": "execute"},
+        "cell": {"jupysql": "execute", "sql": "execute"},
+    }


### PR DESCRIPTION
closes #102

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--112.org.readthedocs.build/en/112/

<!-- readthedocs-preview jupysql end -->