### PR TITLE
Fix: detecting when a db driver is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.6dev
 
+* [Feature] Shows missing driver package suggestion message ([#124](https://github.com/ploomber/jupysql/issues/124))
+
 ## 0.5.5 (2023-02-08)
 
 * [Fix] Clearer error message on connection failure ([#120](https://github.com/ploomber/jupysql/issues/120))

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -12,13 +12,29 @@ PLOOMBER_SUPPORT_LINK_STR = (
     "\nDocumentation: https://jupysql.ploomber.io/en/latest/connecting.html"
 )
 
+# Check Full List: https://docs.sqlalchemy.org/en/20/dialects
 MISSING_PACKAGE_LIST_EXCEPT_MATCHERS = {
+    # SQLite
     "sqlite": "sqlite",
+    "pysqlcipher3": "pysqlcipher3",
+    # DuckDB
     "duckdb": "duckdb-engine",
-    # MySQL + MariaDB: https://docs.sqlalchemy.org/en/20/dialects/mysql.html#dialect-mysql
+    # MySQL + MariaDB
     "pymysql": "pymysql",
     "mysqldb": "mysqlclient",
     "mariadb": "mariadb",
+    "mysql": "mysql-connector-python",
+    "asyncmy": "asyncmy",
+    "aiomysql": "aiomysql",
+    "cymysql": "cymysql",
+    "pyodbc": "pyodbc",
+    # PostgreSQL
+    "psycopg2": "psycopg2",
+    "psycopg": "psycopg",
+    "pg8000": "pg8000",
+    "asyncpg": "asyncpg",
+    "psycopg2cffi": "psycopg2cffi",
+
 }
 
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -34,7 +34,12 @@ MISSING_PACKAGE_LIST_EXCEPT_MATCHERS = {
     "pg8000": "pg8000",
     "asyncpg": "asyncpg",
     "psycopg2cffi": "psycopg2cffi",
-
+    # Oracle
+    "cx_oracle": "cx_oracle",
+    "oracledb": "oracledb",
+    # MSSQL
+    "pyodbc": "pyodbc",
+    "pymssql": "pymssql"
 }
 
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -78,7 +78,7 @@ def get_missing_package_suggestion_str(e):
         module_name, MISSING_PACKAGE_LIST_EXCEPT_MATCHERS.keys()
     )
     if close_matches:
-        return suggestion_prefix + "perhaps you meant to use driver name: {}".format(
+        return "Perhaps you meant to use driver the dialect: \"{}\"".format(
             close_matches[0]
         )
     # Not found

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -5,6 +5,11 @@ import sqlalchemy
 from sqlalchemy.engine import Engine
 from IPython.core.error import UsageError
 
+PLOOMBER_SUPPORT_LINK_STR = (
+    "For technical support: https://ploomber.io/community"
+    "\nDocumentation: https://jupysql.ploomber.io/en/latest/connecting.html"
+)
+
 
 def rough_dict_get(dct, sought, default=None):
     """
@@ -15,7 +20,7 @@ def rough_dict_get(dct, sought, default=None):
     """
 
     sought = sought.split("@")
-    for (key, val) in dct.items():
+    for key, val in dct.items():
         if not any(s.lower() not in key.lower() for s in sought):
             return val
     return default
@@ -35,6 +40,16 @@ class Connection:
 
     # all connections
     connections = {}
+
+    @classmethod
+    def _suggest_fix_no_module_found(module_name):
+        DEFAULT_PREFIX = "\n\n"
+
+        prefix = DEFAULT_PREFIX
+        suffix = "To fix it:"
+        suggest_str = "Install X package and try again"
+        options = [f"{prefix}{suffix}", suggest_str]
+        return "\n\n".join(options)
 
     @classmethod
     def _suggest_fix(cls, env_var, connect_str=None):
@@ -82,10 +97,7 @@ class Connection:
         if len(options) >= 3:
             options.insert(-1, "OR")
 
-        options.append(
-            "For technical support: https://ploomber.io/community"
-            "\nDocumentation: https://jupysql.ploomber.io/en/latest/connecting.html"
-        )
+        options.append(PLOOMBER_SUPPORT_LINK_STR)
 
         return "\n\n".join(options)
 
@@ -100,6 +112,10 @@ class Connection:
             "An error happened while creating the connection: "
             f"{e}.{cls._suggest_fix(env_var=False, connect_str=connect_str)}"
         )
+
+    @classmethod
+    def _error_module_not_found(cls, e):
+        return ModuleNotFoundError("test")
 
     def __init__(self, engine, alias=None):
         self.dialect = engine.url.get_dialect()
@@ -130,6 +146,17 @@ class Connection:
                     connect_str,
                     connect_args=connect_args,
                 )
+        except ModuleNotFoundError as e:
+            raise UsageError(
+                "\n\n".join(
+                    [
+                        str(e),
+                        "To fix it, try to install the missing module",
+                        PLOOMBER_SUPPORT_LINK_STR,
+                    ]
+                )
+            )
+            # raise ModuleNotFoundError("To fix itt")
         except Exception as e:
             raise cls._error_invalid_connection_info(e, connect_str) from e
 
@@ -169,7 +196,6 @@ class Connection:
                 )
 
         else:
-
             if cls.connections:
                 if displaycon:
                     # display list of connections

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -62,7 +62,6 @@ Three types of suggestions will be shown when the missing module name is:
 
 def get_missing_package_suggestion_str(e):
     suggestion_prefix = "To fix it, "
-    print("e", e)
     module_name = None
     if isinstance(e, ModuleNotFoundError):
         module_name = extract_module_name_from_ModuleNotFoundError(e)
@@ -84,9 +83,8 @@ def get_missing_package_suggestion_str(e):
         )
     # Not found
     return (
-        suggestion_prefix
-        + "make sure you are using correct driver name:\n\
-            https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls"
+        suggestion_prefix + "make sure you are using correct driver name:\n"
+        "Ref: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls"
     )
 
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -2,7 +2,7 @@ import os
 from difflib import get_close_matches
 
 import sqlalchemy
-from sqlalchemy.engine import Engine, Dialect
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoSuchModuleError
 from IPython.core.error import UsageError
 

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -51,6 +51,7 @@ def test_missing_duckdb_dependencies(cleanup, monkeypatch):
 @pytest.mark.parametrize(
     "missing_pkg, except_missing_pkg_suggestion, connect_str",
     [
+        # MySQL + MariaDB
         ["pymysql", "pymysql", "mysql+pymysql://"],
         ["mysqlclient", "mysqlclient", "mysql+mysqldb://"],
         ["mariadb", "mariadb", "mariadb+mariadbconnector://"],
@@ -59,6 +60,18 @@ def test_missing_duckdb_dependencies(cleanup, monkeypatch):
         ["aiomysql", "aiomysql", "mysql+aiomysql://"],
         ["cymysql", "cymysql", "mysql+cymysql://"],
         ["pyodbc", "pyodbc", "mysql+pyodbc://"],
+        # PostgreSQL
+        ["psycopg2", "psycopg2", "postgresql+psycopg2://"],
+        ["psycopg", "psycopg", "postgresql+psycopg://"],
+        ["pg8000", "pg8000", "postgresql+pg8000://"],
+        ["asyncpg", "asyncpg", "postgresql+asyncpg://"],
+        ["psycopg2cffi", "psycopg2cffi", "postgresql+psycopg2cffi://"],
+        # Oracle
+        ["cx_oracle", "cx_oracle", "oracle+cx_oracle://"],
+        ["oracledb", "oracledb", "oracle+oracledb://"],
+        # MSSQL
+        ["pyodbc", "pyodbc", "mssql+pyodbc://"],
+        ["pymssql", "pymssql", "mssql+pymssql://"],
     ],
 )
 def test_missing_driver(

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -489,12 +489,10 @@ def test_error_on_invalid_connection_string(ip_empty, clean_conns):
 
 
 invalid_connection_string_format = """\
-An error happened while creating the connection: Can't load plugin: sqlalchemy.dialects:something.
+Can't load plugin: sqlalchemy.dialects:something
 
-To fix it:
-
-Pass a valid connection string:
-    Example: %sql postgresql://username:password@hostname/dbname
+To fix it, make sure you are using correct driver name:
+            https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
@@ -509,17 +507,10 @@ def test_error_on_invalid_connection_string_format(ip_empty, clean_conns):
 
 
 invalid_connection_string_existing_conns = """
-An error happened while creating the connection: Can't load plugin: sqlalchemy.dialects:something.
+Can't load plugin: sqlalchemy.dialects:something
 
-To fix it:
-
-Pass a valid connection string:
-    Example: %sql postgresql://username:password@hostname/dbname
-
-OR
-
-Pass a connection key (one of: 'sqlite://')
-    Example: %sql 'sqlite://'
+To fix it, make sure you are using correct driver name:
+            https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
@@ -535,19 +526,9 @@ def test_error_on_invalid_connection_string_with_existing_conns(ip_empty, clean_
 
 
 invalid_connection_string_with_possible_typo = """
-An error happened while creating the connection: Can't load plugin: sqlalchemy.dialects:sqlit.
+Can't load plugin: sqlalchemy.dialects:sqlit
 
-Perhaps you meant to use the existing connection: %sql 'sqlite://'?
-
-Otherwise, try the following:
-
-Pass a valid connection string:
-    Example: %sql postgresql://username:password@hostname/dbname
-
-OR
-
-Pass a connection key (one of: 'sqlite://')
-    Example: %sql 'sqlite://'
+To fix it, perhaps you meant to use driver name: sqlite
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -492,7 +492,7 @@ invalid_connection_string_format = """\
 Can't load plugin: sqlalchemy.dialects:something
 
 To fix it, make sure you are using correct driver name:
-            https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
+Ref: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
@@ -510,7 +510,7 @@ invalid_connection_string_existing_conns = """
 Can't load plugin: sqlalchemy.dialects:something
 
 To fix it, make sure you are using correct driver name:
-            https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
+Ref: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -528,7 +528,7 @@ def test_error_on_invalid_connection_string_with_existing_conns(ip_empty, clean_
 invalid_connection_string_with_possible_typo = """
 Can't load plugin: sqlalchemy.dialects:sqlit
 
-To fix it, perhaps you meant to use driver name: sqlite
+Perhaps you meant to use driver the dialect: "sqlite"
 
 For technical support: https://ploomber.io/community
 Documentation: https://jupysql.ploomber.io/en/latest/connecting.html


### PR DESCRIPTION
## Describe your changes

* Provide the suggestion message when the driver package is not found
  - Correct driver name, but not install in the user environment
  - Closely matching to correct driver name, but not quite correct
  - Neither the above cases and incorrect driver name

* Test cases to cover those 

### Case 1 - Missing driver

Correct driver name `pymysql`, no `pymysql` package installed

1. 
```
%sql mysql+pymysql://database_url
```

2.
```
UsageError: No module named 'pymysql'

To fix it, try to install package: pymysql

For technical support: https://ploomber.io/community
Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
```

### Case 2 - Closely correct but incorrect driver name `pymysqll`

1. 
```
%sql mysql+pymysqll://
```

2.
```
UsageError: Can't load plugin: sqlalchemy.dialects:mysql.pymysqll

To fix it, perhaps you meant to use driver name: pymysql

For technical support: https://ploomber.io/community
Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
```

### Case 3 - Neither close or correct driver name `something`

1. 
```
%sql mysql+something://
```

2.
```
UsageError: Can't load plugin: sqlalchemy.dialects:mysql.something

To fix it, make sure you are using correct driver name:
Ref: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls

For technical support: https://ploomber.io/community
Documentation: https://jupysql.ploomber.io/en/latest/connecting.html
```

## Issue ticket number and link
Closes #124

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--127.org.readthedocs.build/en/127/

<!-- readthedocs-preview jupysql end -->