### PR TITLE
Support for SqlMagic.autopolars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.7dev
 
+* [Feature] Adds `%%config SqlMagic.autopolars = True` ([#138](https://github.com/ploomber/jupysql/issues/138))
+
 ## 0.5.6 (2023-02-16)
 
 * [Feature] Shows missing driver package suggestion message ([#124](https://github.com/ploomber/jupysql/issues/124))

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -138,6 +138,24 @@ df = %sql SELECT * FROM languages
 type(df)
 ```
 
+## `autopolars`
+
+Default: `False`
+
+Return Polars DataFrames instead of regular result sets.
+
+```{code-cell} ipython3
+%config SqlMagic.autopolars = False
+res = %sql SELECT * FROM languages
+type(res)
+```
+
+```{code-cell} ipython3
+%config SqlMagic.autopolars = True
+df = %sql SELECT * FROM languages
+type(df)
+```
+
 ## `feedback`
 
 Default: `True`

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ DEV = [
     "flake8",
     "pytest",
     "pandas",
+    "polars",
     "invoke",
     "pkgmt",
     "twine",

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -19,12 +19,9 @@ from sql.command import SQLCommand
 from sql.magic_plot import SqlPlotMagic
 from sql.magic_cmd import SqlCmdMagic
 
-try:
-    from traitlets.config.configurable import Configurable
-    from traitlets import Bool, Int, Unicode, observe
-except ImportError:
-    from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Bool, Int, Unicode
+from traitlets.config.configurable import Configurable
+from traitlets import Bool, Int, Unicode, observe
+
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -98,6 +98,11 @@ class SqlMagic(Magics, Configurable):
         config=True,
         help="Return Pandas DataFrames instead of regular result sets",
     )
+    autopolars = Bool(
+        False,
+        config=True,
+        help="Return Polars DataFrames instead of regular result sets",
+    )
     column_local_vars = Bool(
         False, config=True, help="Return data into local variables from column names"
     )
@@ -308,7 +313,7 @@ class SqlMagic(Magics, Configurable):
                 # Instead of returning values, set variables directly in the
                 # users namespace. Variable names given by column names
 
-                if self.autopandas:
+                if self.autopandas or self.autopolars:
                     keys = result.keys()
                 else:
                     keys = result.keys

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -174,6 +174,14 @@ class ResultSet(list, ColumnGuesserMixin):
         frame = pd.DataFrame(self, columns=(self and self.keys) or [])
         return frame
 
+    @telemetry.log_call("polars-data-frame")
+    def PolarsDataFrame(self):
+        "Returns a Polars DataFrame instance built from the result set."
+        import polars as pl
+
+        frame = pl.DataFrame((tuple(row) for row in self), schema=self.keys)
+        return frame
+
     @telemetry.log_call("pie")
     def pie(self, key_word_sep=" ", title=None, **kwargs):
         """Generates a pylab pie chart from the result set.
@@ -397,6 +405,8 @@ def run(conn, sql, config, user_namespace):
         resultset = ResultSet(result, statement, config)
         if config.autopandas:
             return resultset.DataFrame()
+        elif config.autopolars:
+            return resultset.PolarsDataFrame()
         else:
             return resultset
         # returning only last result, intentionally

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -248,6 +248,15 @@ def test_autopandas(ip):
     assert dframe.ndim == 2
     assert dframe.name[0] == "foo"
 
+def test_autopolars(ip):
+    ip.run_line_magic("config", "SqlMagic.autopolars = True")
+    dframe = runsql(ip, "SELECT * FROM test;")
+
+    import polars as pl
+    assert type(dframe) == pl.DataFrame
+    assert not dframe.is_empty()
+    assert len(dframe.shape) == 2
+    assert dframe['name'][0] == "foo"
 
 def test_csv(ip):
     ip.run_line_magic("config", "SqlMagic.autopandas = False")  # uh-oh

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -11,6 +11,7 @@ from IPython.core.error import UsageError
 
 from sql.connection import Connection
 from sql.magic import SqlMagic
+from sql.run import ResultSet
 from conftest import runsql
 
 
@@ -248,6 +249,7 @@ def test_autopandas(ip):
     assert dframe.ndim == 2
     assert dframe.name[0] == "foo"
 
+
 def test_autopolars(ip):
     ip.run_line_magic("config", "SqlMagic.autopolars = True")
     dframe = runsql(ip, "SELECT * FROM test;")
@@ -257,6 +259,32 @@ def test_autopolars(ip):
     assert not dframe.is_empty()
     assert len(dframe.shape) == 2
     assert dframe['name'][0] == "foo"
+
+
+def test_mutex_autopolars_autopandas(ip):
+    dframe = runsql(ip, "SELECT * FROM test;")
+    assert type(dframe) == ResultSet
+
+    import polars as pl
+    ip.run_line_magic("config", "SqlMagic.autopolars = True")
+    dframe = runsql(ip, "SELECT * FROM test;")
+    assert type(dframe) == pl.DataFrame
+
+    import pandas as pd
+    ip.run_line_magic("config", "SqlMagic.autopandas = True")
+    dframe = runsql(ip, "SELECT * FROM test;")
+    assert type(dframe) == pd.DataFrame
+
+    # Test that re-enabling autopolars works
+    ip.run_line_magic("config", "SqlMagic.autopolars = True")
+    dframe = runsql(ip, "SELECT * FROM test;")
+    assert type(dframe) == pl.DataFrame
+
+    # Disabling autopolars at this point should result in the default behavior
+    ip.run_line_magic("config", "SqlMagic.autopolars = False")
+    dframe = runsql(ip, "SELECT * FROM test;")
+    assert type(dframe) == ResultSet
+
 
 def test_csv(ip):
     ip.run_line_magic("config", "SqlMagic.autopandas = False")  # uh-oh


### PR DESCRIPTION
Allows auto conversation of sql cells to polars Dataframes.

Closes #138



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--142.org.readthedocs.build/en/142/

<!-- readthedocs-preview jupysql end -->