### PR TITLE
Fix: SQL template rendered with Double Quote Issue

### DIFF
--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -65,7 +65,7 @@ class SQLStore(MutableMapping):
 
 _template = Template(
     """\
-WITH{% for name in with_ %} "{{name}}" AS (
+WITH{% for name in with_ %} {{name}} AS (
     {{saved[name]._query}}
 ){{ "," if not loop.last }}{% endfor %}
 {{query}}

--- a/src/tests/integration/test_generic_db_opeations.py
+++ b/src/tests/integration/test_generic_db_opeations.py
@@ -33,8 +33,18 @@ def mock_log_api(monkeypatch):
 )
 def test_query_count(ip_with_dynamic_db, excepted, request):
     ip_with_dynamic_db = request.getfixturevalue(ip_with_dynamic_db)
+    # Test normal query
     out = ip_with_dynamic_db.run_line_magic("sql", "SELECT * FROM taxi LIMIT 3")
     assert len(out) == excepted
+
+    # Test query with --with & --save param
+    ip_with_dynamic_db.run_cell(
+        "%sql --save taxi_subset --no-execute SELECT * FROM taxi LIMIT 5"
+    )
+    out = ip_with_dynamic_db.run_line_magic(
+        "sql", "--with taxi_subset SELECT * FROM taxi_subset"
+    )
+    assert len(out) == 5
 
 
 # Create


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
Closes #x

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--162.org.readthedocs.build/en/162/

<!-- readthedocs-preview jupysql end -->