### PR TITLE
Add: test - error when there is no active connection

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pandas
   - pip
   - pip:
-    - jupyter-book
+    - jupyter-book<0.14
     # duckdb example
     - duckdb
     - duckdb-engine

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -336,7 +336,7 @@ class Connection:
         self.__class__._close(self)
 
     @classmethod
-    def _get_curr_connection_info(self):
+    def _get_curr_connection_info(cls):
         """Returns the dialect, driver, and database server version info"""
         if not self.current:
             return None

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -78,7 +78,7 @@ def get_missing_package_suggestion_str(e):
         module_name, MISSING_PACKAGE_LIST_EXCEPT_MATCHERS.keys()
     )
     if close_matches:
-        return "Perhaps you meant to use driver the dialect: \"{}\"".format(
+        return 'Perhaps you meant to use driver the dialect: "{}"'.format(
             close_matches[0]
         )
     # Not found
@@ -337,6 +337,7 @@ class Connection:
     def close(self):
         self.__class__._close(self)
 
+    @classmethod
     def _get_curr_connection_info(self):
         """Returns the dialect, driver, and database server version info"""
         if not self.current:

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -78,9 +78,7 @@ def get_missing_package_suggestion_str(e):
         module_name, MISSING_PACKAGE_LIST_EXCEPT_MATCHERS.keys()
     )
     if close_matches:
-        return 'Perhaps you meant to use driver the dialect: "{}"'.format(
-            close_matches[0]
-        )
+        return f"Perhaps you meant to use driver the dialect: \"{close_matches[0]}\""
     # Not found
     return (
         suggestion_prefix + "make sure you are using correct driver name:\n"

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -338,10 +338,10 @@ class Connection:
     @classmethod
     def _get_curr_connection_info(cls):
         """Returns the dialect, driver, and database server version info"""
-        if not self.current:
+        if not cls.current:
             return None
 
-        engine = self.current.metadata.bind
+        engine = cls.current.metadata.bind
         return {
             "dialect": getattr(engine.dialect, "name", None),
             "driver": getattr(engine.dialect, "driver", None),

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -116,7 +116,6 @@ class SqlMagic(Magics, Configurable):
 
     @telemetry.log_call("init")
     def __init__(self, shell):
-
         self._store = store
 
         Configurable.__init__(self, config=shell.config)
@@ -296,7 +295,9 @@ class SqlMagic(Magics, Configurable):
             creator=args.creator,
             alias=args.alias,
         )
-        payload["connection_info"] = conn._get_curr_connection_info()
+        payload[
+            "connection_info"
+        ] = sql.connection.Connection._get_curr_connection_info()
         if args.persist:
             return self._persist_dataframe(
                 command.sql, conn, user_ns, append=False, index=not args.no_index
@@ -344,7 +345,6 @@ class SqlMagic(Magics, Configurable):
 
                 return None
             else:
-
                 if command.result_var:
                     self.shell.user_ns.update({command.result_var: result})
                     return None

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -244,10 +244,9 @@ def boxplot(payload, table, column, *, orient="v", with_=None, conn=None):
     if not conn:
         conn = sql.connection.Connection.current.session
 
-    if sql.connection.Connection.current:
-        payload[
+    payload[
             "connection_info"
-        ] = sql.connection.Connection.current._get_curr_connection_info()
+        ] = sql.connection.Connection._get_curr_connection_info()
 
     ax = plt.gca()
     vert = orient == "v"
@@ -329,10 +328,9 @@ def histogram(payload, table, column, bins, with_=None, conn=None):
     .. plot:: ../examples/plot_histogram_many.py
     """
     ax = plt.gca()
-    if sql.connection.Connection.current:
-        payload[
+    payload[
             "connection_info"
-        ] = sql.connection.Connection.current._get_curr_connection_info()
+        ] = sql.connection.Connection._get_curr_connection_info()
     if isinstance(column, str):
         bin_, height = _histogram(table, column, bins, with_=with_, conn=conn)
         ax.bar(bin_, height, align="center", width=bin_[-1] - bin_[-2])

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -174,7 +174,7 @@ class ResultSet(list, ColumnGuesserMixin):
         frame = pd.DataFrame(self, columns=(self and self.keys) or [])
         payload[
             "connection_info"
-        ] = sql.connection.Connection.current._get_curr_connection_info()
+        ] = sql.connection.Connection._get_curr_connection_info()
         return frame
 
     @telemetry.log_call("polars-data-frame")

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -42,8 +42,8 @@ def test_alias(cleanup):
 
 
 def test_get_curr_connection_info(mock_postgres):
-    conn = Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
-    assert conn._get_curr_connection_info() == {
+    Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
+    assert Connection._get_curr_connection_info() == {
         "dialect": "postgresql",
         "driver": "psycopg2",
         "server_version_info": None,
@@ -100,5 +100,4 @@ def test_missing_driver(
 
 
 def test_no_current_connection_and_get_info(mock_init_connection):
-    with pytest.raises(AttributeError):
-        Connection.current._get_curr_connection_info()
+    assert Connection._get_curr_connection_info() is None

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -23,7 +23,7 @@ def mock_init_connection(monkeypatch):
     monkeypatch.setattr(Connection, "current", None)
 
 
-def test_password_isnt_displayed(mock_postgres, cleanup):
+def test_password_isnt_displayed(mock_postgres):
     Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
 
     assert "topsecret" not in Connection.connection_list()
@@ -41,7 +41,7 @@ def test_alias(cleanup):
     assert list(Connection.connections) == ["some-alias"]
 
 
-def test_get_curr_connection_info(mock_postgres, cleanup):
+def test_get_curr_connection_info(mock_postgres):
     conn = Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
     assert conn._get_curr_connection_info() == {
         "dialect": "postgresql",
@@ -89,7 +89,7 @@ def test_missing_duckdb_dependencies(cleanup, monkeypatch):
     ],
 )
 def test_missing_driver(
-    missing_pkg, except_missing_pkg_suggestion, connect_str, monkeypatch, cleanup
+    missing_pkg, except_missing_pkg_suggestion, connect_str, monkeypatch
 ):
     with patch.dict(sys.modules):
         sys.modules[missing_pkg] = None

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -29,7 +29,7 @@ def test_password_isnt_displayed(mock_postgres):
     assert "topsecret" not in Connection.connection_list()
 
 
-def test_connection_name(mock_postgres, cleanup):
+def test_connection_name(mock_postgres):
     conn = Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
 
     assert conn.name == "user@db"

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -92,3 +92,8 @@ def test_missing_driver(
             Connection.from_connect_str(connect_str)
 
         assert "try to install package: " + missing_pkg in str(error.value)
+
+
+def test_no_current_connection_and_get_info(cleanup):
+    with pytest.raises(AttributeError):
+        Connection.current._get_curr_connection_info()

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -18,11 +18,6 @@ def mock_postgres(monkeypatch, cleanup):
     monkeypatch.setattr(Engine, "connect", Mock())
 
 
-@pytest.fixture
-def mock_init_connection(monkeypatch):
-    monkeypatch.setattr(Connection, "current", None)
-
-
 def test_password_isnt_displayed(mock_postgres):
     Connection.from_connect_str("postgresql://user:topsecret@somedomain.com/db")
 
@@ -99,5 +94,6 @@ def test_missing_driver(
         assert "try to install package: " + missing_pkg in str(error.value)
 
 
-def test_no_current_connection_and_get_info(mock_init_connection):
+def test_no_current_connection_and_get_info(monkeypatch):
+    monkeypatch.setattr(Connection, "current", None)
     assert Connection._get_curr_connection_info() is None


### PR DESCRIPTION
## Describe your changes

Add test case to cover 

```
AttributeError: 'NoneType' object has no attribute '_get_curr_connection_info'
```

## Issue ticket number and link

[Closes #156](https://github.com/ploomber/jupysql/issues/156)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--171.org.readthedocs.build/en/171/

<!-- readthedocs-preview jupysql end -->