### PR TITLE
Fix - Issue better detect the user uses sqlalchemy variable expansion

### DIFF
--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -92,8 +92,8 @@ class SQLCommand:
         sql = Template(sql).render(user_ns)
         parsed_sql = magic.shell.var_expand(sql, depth=2)
 
-        has_SQLAlchemy_var_expand = ":" in sql
-        # parsed_sql != sql: detect if using IPython fashion - {a} or $a
+        has_SQLAlchemy_var_expand = any((':' + ns_var_key in sql
+                                         for ns_var_key in user_ns.keys()))
         # has_SQLAlchemy_var_expand: detect if using Sqlalchemy fashion - :a
 
         msg = (

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 
 import pytest
 from sqlalchemy import create_engine
@@ -209,6 +210,17 @@ def test_variable_substitution_legacy_warning_message_colon(ip, sql_magic, capsy
             """,
         )
 
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ip.user_global_ns["limit_number"] = 1
+        ip.run_cell_magic(
+            "sql",
+            "",
+            """
+            SELECT * FROM author WHERE last_name = 'Something with : inside'
+            """,
+        )
+
 
 def test_variable_substitution_legacy_dollar_prefix_cell_magic(ip, sql_magic):
     ip.user_global_ns["username"] = "some-user"
@@ -246,7 +258,6 @@ def test_variable_substitution_double_curly_cell_magic(ip, sql_magic):
         cell="GRANT CONNECT ON DATABASE postgres TO {{username}};",
     )
 
-    print("cmd.parsed['sql']", cmd.parsed["sql"])
     assert cmd.parsed["sql"] == "\nGRANT CONNECT ON DATABASE postgres TO some-user;"
 
 
@@ -260,5 +271,4 @@ def test_variable_substitution_double_curly_line_magic(ip, sql_magic):
         cell="",
     )
 
-    # print ("cmd.parsed['sql']", cmd.parsed["sql"])
     assert cmd.parsed["sql"] == "SELECT first_name FROM author LIMIT 5;"


### PR DESCRIPTION
## Describe your changes

The root cause is originally we only rely on `has_SQLAlchemy_var_expand = ":" in sql` to see if the user might use sqlalchemy variable expansion

Fix by more delicate way - check the query statement it contains variable from `user_ns`

## Issue ticket number and link
Closes #214

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--215.org.readthedocs.build/en/215/

<!-- readthedocs-preview jupysql end -->