### PR TITLE
fix sqlalchemy2 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,11 +37,12 @@ jobs:
           # check package is importable
           python -c "import sql"
           pip install ".[dev]"
-
+          pip install sqlalchemy -U
 
       - name: Test with pytest
         run: |
           pytest --durations-min=5 --ignore=src/tests/integration
+          python -c 'import sqlalchemy; assert sqlalchemy.__version__.split(".")[0] == 2'
 
   test-sqlalchemy-v1:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.6.5dev
 
 * [Fix] Addresses enable AUTOCOMMIT config issue in PostgreSQL (#90)
-
+* [Fix] Fixes issue with sqlalchemy 2.0 when calling .execute
 ## 0.6.4 (2023-03-12)
 
 * [Fix] Adds support for SQL Alchemy 2.0

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 from sql.store import store
 import sql.connection
 from sql.telemetry import telemetry
-import sqlalchemy
+
 
 
 def _summary_stats(con, table, column, with_=None):
@@ -378,7 +378,7 @@ order by 1;
     if with_:
         query = str(store.render(query, with_=with_))
 
-    data = conn.execute(sqlalchemy.sql.text(query)).fetchall()
+    data = conn.execute(query).fetchall()
     bin_, height = zip(*data)
 
     if bin_[0] is None:

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -21,7 +21,6 @@ import sql.connection
 from sql.telemetry import telemetry
 
 
-
 def _summary_stats(con, table, column, with_=None):
     """Compute percentiles and mean for boxplot"""
     template = Template(

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 from sql.store import store
 import sql.connection
 from sql.telemetry import telemetry
-
+import sqlalchemy
 
 def _summary_stats(con, table, column, with_=None):
     """Compute percentiles and mean for boxplot"""
@@ -39,7 +39,7 @@ FROM "{{table}}"
     if with_:
         query = str(store.render(query, with_=with_))
 
-    values = con.execute(query).fetchone()
+    values = con.execute(sqlalchemy.sql.text(query)).fetchone()
     keys = ["q1", "med", "q3", "mean", "N"]
     return {k: float(v) for k, v in zip(keys, values)}
 
@@ -61,7 +61,7 @@ FROM (
     if with_:
         query = str(store.render(query, with_=with_))
 
-    values = con.execute(query).fetchone()
+    values = con.execute(sqlalchemy.sql.text(query)).fetchone()
     keys = ["N", "wiskhi_max"]
     return {k: float(v) for k, v in zip(keys, values)}
 
@@ -83,7 +83,7 @@ FROM (
     if with_:
         query = str(store.render(query, with_=with_))
 
-    values = con.execute(query).fetchone()
+    values = con.execute(sqlalchemy.sql.text(query)).fetchone()
     keys = ["N", "wisklo_min"]
     return {k: float(v) for k, v in zip(keys, values)}
 
@@ -101,7 +101,7 @@ FROM "{{table}}"
     if with_:
         query = str(store.render(query, with_=with_))
 
-    values = con.execute(query).fetchone()[0]
+    values = con.execute(sqlalchemy.sql.text(query)).fetchone()[0]
     return values
 
 
@@ -119,7 +119,7 @@ OR  "{{column}}" > {{whishi}}
     if with_:
         query = str(store.render(query, with_=with_))
 
-    results = [float(n[0]) for n in con.execute(query).fetchall()]
+    results = [float(n[0]) for n in con.execute(sqlalchemy.sql.text(query)).fetchall()]
     return results
 
 
@@ -281,7 +281,7 @@ FROM "{{table}}"
     if with_:
         query = str(store.render(query, with_=with_))
 
-    min_, max_ = con.execute(query).fetchone()
+    min_, max_ = con.execute(sqlalchemy.sql.text(query)).fetchone()
     return min_, max_
 
 
@@ -377,7 +377,7 @@ order by 1;
     if with_:
         query = str(store.render(query, with_=with_))
 
-    data = conn.execute(query).fetchall()
+    data = conn.execute(sqlalchemy.sql.text(query)).fetchall()
     bin_, height = zip(*data)
 
     if bin_[0] is None:

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -21,6 +21,7 @@ import sql.connection
 from sql.telemetry import telemetry
 import sqlalchemy
 
+
 def _summary_stats(con, table, column, with_=None):
     """Compute percentiles and mean for boxplot"""
     template = Template(

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 from sql.store import store
 import sql.connection
 from sql.telemetry import telemetry
-
+import sqlalchemy
 
 def _summary_stats(con, table, column, with_=None):
     """Compute percentiles and mean for boxplot"""
@@ -377,7 +377,7 @@ order by 1;
     if with_:
         query = str(store.render(query, with_=with_))
 
-    data = conn.execute(query).fetchall()
+    data = conn.execute(sqlalchemy.sql.text(query)).fetchall()
     bin_, height = zip(*data)
 
     if bin_[0] is None:

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -380,7 +380,7 @@ def _commit(conn, config, manual_commit):
 
     if _should_commit:
         try:
-            conn.session.execute(sqlalchemy.sql.text("commit"))
+            conn.session.execute("commit")
         except sqlalchemy.exc.OperationalError:
             print("The database does not support the COMMIT command")
 

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -380,7 +380,7 @@ def _commit(conn, config, manual_commit):
 
     if _should_commit:
         try:
-            conn.session.execute("commit")
+            conn.session.execute(sqlalchemy.sql.text("commit"))
         except sqlalchemy.exc.OperationalError:
             print("The database does not support the COMMIT command")
 

--- a/src/tests/integration/test_duckDB.py
+++ b/src/tests/integration/test_duckDB.py
@@ -17,4 +17,4 @@ def test_auto_commit_mode_off(ip_with_duckDB, capsys):
 
     # Check the tables is created
     out = ip_with_duckDB.run_cell("%sql SHOW TABLES;").result
-    assert any('weather' == table[0] for table in out)
+    assert any("weather" == table[0] for table in out)

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -6,6 +6,7 @@ from functools import partial
 from sql import inspect, connection
 import sqlalchemy
 
+
 @pytest.fixture
 def sample_db(tmp_empty):
     conn = connection.Connection.from_connect_str("sqlite://")

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -4,21 +4,21 @@ import pytest
 from functools import partial
 
 from sql import inspect, connection
-
+import sqlalchemy
 
 @pytest.fixture
 def sample_db(tmp_empty):
     conn = connection.Connection.from_connect_str("sqlite://")
 
-    conn.session.execute("CREATE TABLE one (x INT, y TEXT)")
-    conn.session.execute("CREATE TABLE another (i INT, j TEXT)")
+    conn.session.execute(sqlalchemy.sql.text("CREATE TABLE one (x INT, y TEXT)"))
+    conn.session.execute(sqlalchemy.sql.text("CREATE TABLE another (i INT, j TEXT)"))
 
     conn_mydb = sqlite3.connect("my.db")
     conn_mydb.execute("CREATE TABLE uno (x INT, y TEXT)")
     conn_mydb.execute("CREATE TABLE dos (i INT, j TEXT)")
     conn_mydb.close()
 
-    conn.session.execute("ATTACH DATABASE 'my.db' AS schema")
+    conn.session.execute(sqlalchemy.sql.text("ATTACH DATABASE 'my.db' AS schema"))
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -47,9 +47,9 @@ class DictOfFloats(Mapping):
 
 def test_boxplot_stats(chinook_db):
     con = duckdb.connect(database=":memory:")
-    con.execute(sqlalchemy.sql.text("INSTALL 'sqlite_scanner';"))
-    con.execute(sqlalchemy.sql.text("LOAD 'sqlite_scanner';"))
-    con.execute(sqlalchemy.sql.text(f"CALL sqlite_attach({chinook_db!r});"))
+    con.execute("INSTALL 'sqlite_scanner';")
+    con.execute("LOAD 'sqlite_scanner';")
+    con.execute(f"CALL sqlite_attach({chinook_db!r});")
 
     res = con.execute(sqlalchemy.sql.text("SELECT * FROM Invoice"))
     X = res.df().Total

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -7,7 +7,7 @@ from matplotlib import cbook
 from sql import plot
 from pathlib import Path
 import pytest
-
+import sqlalchemy
 
 class DictOfFloats(Mapping):
     def __init__(self, data) -> None:
@@ -46,11 +46,11 @@ class DictOfFloats(Mapping):
 
 def test_boxplot_stats(chinook_db):
     con = duckdb.connect(database=":memory:")
-    con.execute("INSTALL 'sqlite_scanner';")
-    con.execute("LOAD 'sqlite_scanner';")
-    con.execute(f"CALL sqlite_attach({chinook_db!r});")
+    con.execute(sqlalchemy.sql.text("INSTALL 'sqlite_scanner';"))
+    con.execute(sqlalchemy.sql.text("LOAD 'sqlite_scanner';"))
+    con.execute(sqlalchemy.sql.text(f"CALL sqlite_attach({chinook_db!r});"))
 
-    res = con.execute("SELECT * FROM Invoice")
+    res = con.execute(sqlalchemy.sql.text("SELECT * FROM Invoice"))
     X = res.df().Total
     expected = cbook.boxplot_stats(X)
 
@@ -61,11 +61,11 @@ def test_boxplot_stats(chinook_db):
 
 def test_boxplot_stats_exception(chinook_db):
     con = duckdb.connect(database=":memory:")
-    con.execute("INSTALL 'sqlite_scanner';")
-    con.execute("LOAD 'sqlite_scanner';")
-    con.execute(f"CALL sqlite_attach({chinook_db!r});")
+    con.execute(sqlalchemy.sql.text("INSTALL 'sqlite_scanner';"))
+    con.execute(sqlalchemy.sql.text("LOAD 'sqlite_scanner';"))
+    con.execute(sqlalchemy.sql.text(f"CALL sqlite_attach({chinook_db!r});"))
 
-    res = con.execute("SELECT * FROM Invoice")
+    res = con.execute(sqlalchemy.sql.text("SELECT * FROM Invoice"))
     X = res.df().Total
     cbook.boxplot_stats(X)
     with pytest.raises(

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import sqlalchemy
 
+
 class DictOfFloats(Mapping):
     def __init__(self, data) -> None:
         self._data = data


### PR DESCRIPTION
## Describe your changes

Fixes `sqlalchemy2` compatibility. Changes all places where `.execute` is called through sqlalchemy to new version.

## Issue ticket number and link
Closes #234 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview jupysql end -->