### PR TITLE
Ignore "binder.ploomber.io" on check-for-broken-links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ github = "ploomber/jupysql"
 
 [tool.pkgmt.check_links]
 extensions = ["md", "rst", "py", "ipynb"]
-ignore_substrings = ["d37ci6vzurychx.cloudfront.net", "https://bornsql.ca"]
+ignore_substrings = ["d37ci6vzurychx.cloudfront.net", "https://bornsql.ca", "binder.ploomber.io"]
 
 [tool.nbqa.addopts]
 flake8 = [


### PR DESCRIPTION
## Describe your changes
check-for-broken-links sometimes fails on "binder.ploomber.io".
"binder.ploomber.io" added to `ignore_substrings` in pyproject.toml

## Issue ticket number and link
No issue



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview jupysql end -->