### PR TITLE
217 add sql cmd for test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.5dev
 
+* [Feature] Adds sql magic test to list of possible magics to test datasets
 * [Doc] User guide on querying Github API with DuckDB and JupySQL
 * [Fix] Addresses enable AUTOCOMMIT config issue in PostgreSQL (#90)
 

--- a/doc/user-guide/tables-columns.md
+++ b/doc/user-guide/tables-columns.md
@@ -103,3 +103,16 @@ Get the columns for the table in the newly created schema:
 ```{code-cell} ipython3
 %sqlcmd columns --table numbers --schema some_schema
 ```
+
+## Run Tests on Column
+
+Use `%sqlcmd test` to run tests on your dataset. 
+
+See if your column name has values greater than 150. 
+```{code-cell} ipython3
+%sqlcmd test --table coordinates --column name --greater 150
+```
+
+Four different comparator commands exist: `greater`, `greater-or-equal`, `less-than`, `less-than-or-equal`, and `no-nulls`. 
+
+Command will return True if tests pass, otherwise an error with sample breaking cases will be printed out.

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
     "ipython>=1.0",
     "sqlalchemy",
     "sqlparse",
+    "sqlglot",
     "ipython-genutils>=0.1.0",
     "jinja2",
     "ploomber-core>=0.2.4",

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -9,6 +9,7 @@ from IPython.core.magic import (
 )
 from IPython.core.magic_arguments import argument, magic_arguments
 from IPython.core.error import UsageError
+from sqlglot import select, condition
 
 
 try:
@@ -16,8 +17,9 @@ try:
 except ImportError:
     from IPython.config.configurable import Configurable
 
-
+import sql.connection
 from sql import inspect
+import sql.run
 
 
 class CmdParser(argparse.ArgumentParser):
@@ -65,8 +67,120 @@ class SqlCmdMagic(Magics, Configurable):
 
             args = parser.parse_args(others)
             return inspect.get_columns(name=args.table, schema=args.schema)
-        else:
-            raise UsageError(
-                f"%sqlcmd has no command: {cmd_name!r}. "
-                "Valid commands are: 'tables', 'columns'"
+        elif cmd_name == "test":
+            parser = CmdParser()
+
+            parser.add_argument(
+                "-t", "--table", type=str, help="Table name", required=True
             )
+            parser.add_argument(
+                "-c", "--column", type=str, help="Column name", required=False
+            )
+            parser.add_argument(
+                "-g",
+                "--greater",
+                type=str,
+                help="Greater than a certain number.",
+                required=False,
+            )
+            parser.add_argument(
+                "-goe",
+                "--greater-or-equal",
+                type=str,
+                help="Greater or equal than a certain number.",
+                required=False,
+            )
+            parser.add_argument(
+                "-l",
+                "--less-than",
+                type=str,
+                help="Less than a certain number.",
+                required=False,
+            )
+            parser.add_argument(
+                "-loe",
+                "--less-than-or-equal",
+                type=str,
+                help="Less than or equal to a certain number.",
+                required=False,
+            )
+            parser.add_argument(
+                "-nn",
+                "--no-nulls",
+                help="Returns rows in specified column that are not null.",
+                action="store_true",
+            )
+
+            args = parser.parse_args(others)
+            if args.greater and args.greater_or_equal:
+                return ValueError(
+                    "You cannot use both greater and greater "
+                    "than or equal to arguments at the same time."
+                )
+            elif args.less_than and args.less_than_or_equal:
+                return ValueError(
+                    "You cannot use both less and less than "
+                    "or equal to arguments at the same time."
+                )
+
+            conn = sql.connection.Connection.current.session
+            result_dict = run_each_individually(args, conn)
+
+            if len(result_dict.keys()):
+                print(
+                    "Test failed. Returned are samples of the failures from your data:"
+                )
+                return result_dict
+            else:
+                print("All requirements were met. Test was succesful.")
+                return True
+
+        raise UsageError(
+            f"%sqlcmd has no command: {cmd_name!r}. "
+            "Valid commands are: 'tables', 'columns'"
+        )
+
+
+def run_each_individually(args, conn):
+    base_query = select("*").from_(args.table)
+    storage = {}
+
+    if args.greater:
+        where = condition(args.column + ">" + args.greater)
+        current_query = base_query.where(where).sql()
+
+        res = conn.execute(current_query).fetchone()
+
+        if res is not None:
+            storage["greater"] = res
+    if args.greater_or_equal:
+        where = condition(args.column + ">=" + args.greater_or_equal)
+
+        current_query = base_query.where(where).sql()
+
+        res = conn.execute(current_query).fetchone()
+        if res is not None:
+            storage["greater_or_equal"] = res
+    if args.less_than_or_equal:
+        where = condition(args.column + "<=" + args.less_than_or_equal)
+        current_query = base_query.where(where).sql()
+
+        res = conn.execute(current_query).fetchone()
+        if res is not None:
+            storage["less_than_or_equal"] = res
+    if args.less_than:
+        where = condition(args.column + "<" + args.less_than)
+        current_query = base_query.where(where).sql()
+
+        res = conn.execute(current_query).fetchone()
+        if res is not None:
+            storage["less_than"] = res
+    if args.no_nulls:
+        where = condition("{} is NULL".format(args.column))
+        current_query = base_query.where(where).sql()
+
+        res = conn.execute(current_query).fetchone()
+        if res is not None:
+            storage["null"] = res
+
+    return storage

--- a/src/tests/integration/test_duckDB.py
+++ b/src/tests/integration/test_duckDB.py
@@ -13,7 +13,7 @@ def test_auto_commit_mode_on(ip_with_duckDB, caplog):
             "execution option\nPerhaps you can try running a manual "
             "COMMIT command\nMessage from the database driver\n\t"
             "Exception:  'duckdb.DuckDBPyConnection' object has no attribute"
-            " 'set_isolation_level'\n"
+            " 'set_isolation_level'\n",
         )
     ]
 

--- a/src/tests/integration/test_generic_db_opeations.py
+++ b/src/tests/integration/test_generic_db_opeations.py
@@ -144,3 +144,32 @@ def test_telemetry_execute_command_has_connection_info(
             },
         },
     )
+
+
+def test_sql_cmd_magic_uno(ip):
+    result = ip.run_cell(
+        "%sqlcmd test --table author --column year_of_death"
+        " --less-than 1700 --greater 1600"
+    ).result
+
+    assert len(result) == 2
+    assert "William" in str(result["less_than"])
+
+
+def test_sql_cmd_magic_dos(ip):
+    result = ip.run_cell(
+        "%sqlcmd test --table author --column year_of_death" " --less-than 1650"
+    ).result
+
+    assert len(result) == 1
+    assert "William" in str(result["less_than"])
+
+
+def test_sql_cmd_magic_tres(ip):
+    result = ip.run_cell(
+        "%sqlcmd test --table author --column year_of_death"
+        " --greater-or-equal 1600 --less-than-or-equal 1956"
+    ).result
+
+    assert len(result) == 2
+    assert ("greater_or_equal" and "less_than_or_equal") in result.keys()

--- a/src/tests/integration/test_generic_db_opeations.py
+++ b/src/tests/integration/test_generic_db_opeations.py
@@ -145,6 +145,7 @@ def test_telemetry_execute_command_has_connection_info(
         },
     )
 
+
 @pytest.mark.parametrize(
     "ip_with_dynamic_db",
     [

--- a/src/tests/integration/test_generic_db_opeations.py
+++ b/src/tests/integration/test_generic_db_opeations.py
@@ -145,9 +145,20 @@ def test_telemetry_execute_command_has_connection_info(
         },
     )
 
+@pytest.mark.parametrize(
+    "ip_with_dynamic_db",
+    [
+        ("ip_with_postgreSQL"),
+        ("ip_with_mySQL"),
+        ("ip_with_mariaDB"),
+        ("ip_with_SQLite"),
+        ("ip_with_duckDB"),
+    ],
+)
+def test_sql_cmd_magic_uno(ip_with_dynamic_db, request):
+    ip_with_dynamic_db = request.getfixturevalue(ip_with_dynamic_db)
 
-def test_sql_cmd_magic_uno(ip):
-    result = ip.run_cell(
+    result = ip_with_dynamic_db.run_cell(
         "%sqlcmd test --table author --column year_of_death"
         " --less-than 1700 --greater 1600"
     ).result


### PR DESCRIPTION
## Describe your changes

Implements logic for new test sql command. This command currently allows users to quickly return rows in a set of data that satisfy arguments passed to the magic.

## Issue ticket number and link
Closes #217 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--258.org.readthedocs.build/en/258/

<!-- readthedocs-preview jupysql end -->