### PR TITLE
Fix mssql.ipynb typo

### DIFF
--- a/doc/integrations/mssql.ipynb
+++ b/doc/integrations/mssql.ipynb
@@ -200,7 +200,7 @@
     "If you're on a Mac with Apple Silicon (e.g., M1 processor), you might encounter issues, if so, try thi:\n",
     "\n",
     "~~~sh\n",
-    "pip install pyodbc=4.0.34\n",
+    "pip install pyodbc==4.0.34\n",
     "~~~\n",
     "```\n",
     "\n",


### PR DESCRIPTION
`pip install pyodbc=4.0.34` isn't valid command

Should be `pip install pyodbc=4.0.34`

## Describe your changes

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#lintingformatting)
- [ ] Added [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] Added documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)

