### PR TITLE
adds conda install command to quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 0.7.0 (2023-04-05)
 
+JupySQL is now available via `conda install jupysql -c conda-forge`. Thanks, [@sterlinm](https://github.com/sterlinm)!
+
 * [API Change] Deprecates old SQL parametrization: `$var`, `:var`, and `{var}` in favor of `{{var}}`
 * [Feature] Adds `%sqlcmd profile` ([#66](https://github.com/ploomber/jupysql/issues/66))
 * [Feature] Adds `%sqlcmd test` to run tests on tables

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Run SQL in Jupyter/IPython via a `%sql` and `%%sql` magics.
 pip install jupysql
 ```
 
+or:
+
+```
+conda install jupysql -c conda-forge
+```
+
 ## Documentation
 
 [Click here to see the documentation.](https://jupysql.ploomber.io)

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -42,6 +42,12 @@ Or the following in a Jupyter notebook:
 %pip install jupysql duckdb-engine --quiet
 ```
 
+You might also install it from conda:
+
+```sh
+conda install jupysql -c conda-forge
+```
+
 ## Setup
 
 ```{tip}


### PR DESCRIPTION
hey @sterlinm. can I add your GitHub handle to our changelog and quickstart? we want to highlight your contribution

@idomic: @sterlinm is maintaining a [conda-forge](https://github.com/conda-forge/jupysql-feedstock/pull/1) recipe so jupysql can be installed via `conda install` 🎉

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--376.org.readthedocs.build/en/376/

<!-- readthedocs-preview jupysql end -->