### PR TITLE
SQLachemy error overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # CHANGELOG
 
 ## 0.7.5dev
-* [Feature] Using native DuckDB `.df()` method when using `autopandas` 
-
+* [Feature] Using native DuckDB `.df()` method when using `autopandas`
 * [Doc] documenting `%sqlcmd tables`/`%sqlcmd columns`
 * [Feature] Better error messages when function used in plotting API unsupported by DB driver (#159)
 * [Fix] Fix the default value of %config SqlMagic.displaylimit to 10 (#462)
+* [Feature] Detailed error messages when syntax error in SQL query, postgres connection password missing or inaccessible, invalid DuckDB connection string (#229)
+
 
 ## 0.7.4 (2023-04-28)
 No changes

--- a/doc/community/developer-guide.md
+++ b/doc/community/developer-guide.md
@@ -61,6 +61,16 @@ The internal implementation of `sql.exceptions` is a workaround due to some IPyt
 
 +++
 
+### Handling common errors
+
+Currently, these common errors are handled by providing more meaningful error messages:
+
+* Syntax error in SQL query - The SQL query is parsed using `sqlglot` and possible syntax issues or query suggestions are provided to the user. This raises a `UsageError` with the message.
+* Missing password when connecting to PostgreSQL - Displays guide on DB connections
+* Invalid connection strings when connecting to DuckDB.
+
++++
+
 ## Unit testing
 
 ### Running tests

--- a/src/sql/__init__.py
+++ b/src/sql/__init__.py
@@ -1,4 +1,6 @@
 from .magic import RenderMagic, SqlMagic, load_ipython_extension
+from .error_message import SYNTAX_ERROR
+from .connection import PLOOMBER_DOCS_LINK_STR
 
 __version__ = "0.7.5dev"
 
@@ -7,4 +9,6 @@ __all__ = [
     "RenderMagic",
     "SqlMagic",
     "load_ipython_extension",
+    "SYNTAX_ERROR",
+    "PLOOMBER_DOCS_LINK_STR",
 ]

--- a/src/sql/error_message.py
+++ b/src/sql/error_message.py
@@ -1,0 +1,53 @@
+import sqlglot
+import sqlparse
+
+SYNTAX_ERROR = "\nLooks like there is a syntax error in your query."
+ORIGINAL_ERROR = "\nOriginal error message from DB driver:\n"
+
+
+def detail(original_error, query=None):
+    original_error = str(original_error)
+    return_msg = SYNTAX_ERROR
+    if "syntax error" in original_error:
+        query_list = sqlparse.split(query)
+        for q in query_list:
+            try:
+                q = q.strip()
+                q = q[:-1] if q.endswith(";") else q
+                parse = sqlglot.transpile(q)
+                suggestions = ""
+                if q.upper() not in [suggestion.upper() for suggestion in parse]:
+                    suggestions += f"Did you mean : {parse}\n"
+                return_msg = (
+                    return_msg + "Possible reason: \n" + suggestions
+                    if suggestions
+                    else return_msg
+                )
+
+            except sqlglot.errors.ParseError as e:
+                err = e.errors
+                position = ""
+                for item in err:
+                    position += (
+                        f"Syntax Error in {q}: {item['description']} at "
+                        f"Line {item['line']}, Column {item['col']}\n"
+                    )
+                return_msg = (
+                    return_msg + "Possible reason: \n" + position
+                    if position
+                    else return_msg
+                )
+
+        return return_msg + "\n" + ORIGINAL_ERROR + original_error + "\n"
+
+    if "fe_sendauth: no password supplied" in original_error:
+        return (
+            "\nLooks like you have run into some issues. "
+            "Review our DB connection via URL strings guide: "
+            "https://jupysql.ploomber.io/en/latest/connecting.html ."
+            " Using Ubuntu? Check out this guide: "
+            "https://help.ubuntu.com/community/PostgreSQL#fe_sendauth:_"
+            "no_password_supplied\n" + ORIGINAL_ERROR + original_error + "\n"
+        )
+
+    return None

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -69,7 +69,7 @@ def ip(ip_empty):
             "CREATE TABLE test (n INT, name TEXT)",
             "INSERT INTO test VALUES (1, 'foo')",
             "INSERT INTO test VALUES (2, 'bar')",
-            'CREATE TABLE "table with spaces" (first INT, second TEXT)',
+            "CREATE TABLE [table with spaces] (first INT, second TEXT)",
             "CREATE TABLE author (first_name, last_name, year_of_death)",
             "INSERT INTO author VALUES ('William', 'Shakespeare', 1616)",
             "INSERT INTO author VALUES ('Bertold', 'Brecht', 1956)",

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -131,6 +131,15 @@ def ip_with_postgreSQL(ip_empty, setup_postgreSQL):
     ip_empty.run_cell("%sql -x " + alias)
 
 
+@pytest.fixture
+def postgreSQL_config_incorrect_pwd(ip_empty, setup_postgreSQL):
+    configKey = "postgreSQL"
+    alias = _testing.DatabaseConfigHelper.get_database_config(configKey)["alias"]
+    url = _testing.DatabaseConfigHelper.get_database_url(configKey)
+    url = url.replace(":ploomber_app_password", "")
+    return alias, url
+
+
 @pytest.fixture(scope="session")
 def setup_mySQL(test_table_name_dict, skip_on_live_mode):
     with _testing.mysql():

--- a/src/tests/integration/test_postgreSQL.py
+++ b/src/tests/integration/test_postgreSQL.py
@@ -17,3 +17,16 @@ def test_auto_commit_mode_on(ip_with_postgreSQL, capsys):
     assert out_after_creating.error_in_exec is None
     assert any(row[0] == "new_db" for row in out_all_dbs)
     assert "CREATE DATABASE cannot run inside a transaction block" not in out
+
+
+def test_postgres_error(ip_empty, postgreSQL_config_incorrect_pwd):
+    alias, url = postgreSQL_config_incorrect_pwd
+
+    # Select database engine
+    out = ip_empty.run_cell("%sql " + url + " --alias " + alias)
+    assert "Review our DB connection via URL strings guide" in str(out.error_in_exec)
+    assert "Original error message from DB driver" in str(out.error_in_exec)
+    assert (
+        "If you need help solving this issue, "
+        "send us a message: https://ploomber.io/community" in str(out.error_in_exec)
+    )

--- a/src/tests/test_syntax_errors.py
+++ b/src/tests/test_syntax_errors.py
@@ -1,0 +1,172 @@
+import pytest
+import sqlalchemy.exc
+
+from sqlalchemy.exc import OperationalError
+from IPython.core.error import UsageError
+
+from sql.error_message import SYNTAX_ERROR, ORIGINAL_ERROR
+from ploomber_core.exceptions import COMMUNITY
+
+
+COMMUNITY = COMMUNITY.strip()
+
+
+@pytest.fixture
+def query_no_suggestion():
+    return (
+        "sql",
+        "",
+        """
+        sqlite://
+        SELECT FROM author;
+        """,
+    )
+
+
+@pytest.fixture
+def query_incorrect_column_name():
+    return (
+        "sql",
+        "",
+        """
+        sqlite://
+        SELECT first_(name FROM author;
+        """,
+    )
+
+
+@pytest.fixture
+def query_suggestion():
+    return (
+        "sql",
+        "",
+        """
+        sqlite://
+        ALTER TABLE author RENAME new_author;
+        """,
+    )
+
+
+@pytest.fixture
+def query_multiple():
+    return (
+        "sql",
+        "",
+        """
+        sqlite://
+        INSERT INTO author VALUES ('Charles', 'Dickens', 1812);
+        ALTER TABLE author RENAME another_name;
+        """,
+    )
+
+
+def _common_strings_check(err):
+    assert SYNTAX_ERROR.strip() in str(err.value)
+    assert ORIGINAL_ERROR.strip() in str(err.value)
+    assert COMMUNITY in str(err.value)
+    assert isinstance(err.value, UsageError)
+
+
+def test_syntax_error_no_suggestion(ip, query_no_suggestion):
+    with pytest.raises(UsageError) as err:
+        ip.run_cell_magic(*query_no_suggestion)
+    _common_strings_check(err)
+
+
+message_no_suggestion_long = f"""\
+(sqlite3.OperationalError) near "FROM": syntax error
+{COMMUNITY}
+[SQL: SELECT FROM author;]
+"""  # noqa
+
+
+def test_syntax_error_no_suggestion_long(ip, capsys, query_no_suggestion):
+    ip.run_line_magic("config", "SqlMagic.short_errors = False")
+    with pytest.raises(OperationalError) as err:
+        ip.run_cell_magic(*query_no_suggestion)
+    out, _ = capsys.readouterr()
+    assert message_no_suggestion_long.strip() in str(err.value).strip()
+    assert SYNTAX_ERROR.strip() in out
+    assert isinstance(err.value, sqlalchemy.exc.OperationalError)
+
+
+def test_syntax_error_incorrect_column_name(ip, query_incorrect_column_name):
+    with pytest.raises(UsageError) as err:
+        ip.run_cell_magic(*query_incorrect_column_name)
+    assert (
+        "Syntax Error in SELECT first_(name FROM author: "
+        "Expecting ) at Line 1, Column 24" in str(err.value)
+    )
+    _common_strings_check(err)
+
+
+message_incorrect_column_name_long = f"""\
+(sqlite3.OperationalError) near "FROM": syntax error
+{COMMUNITY}
+[SQL: SELECT first_(name FROM author;]
+"""  # noqa
+
+
+def test_syntax_error_incorrect_column_name_long(
+    ip, capsys, query_incorrect_column_name
+):
+    ip.run_line_magic("config", "SqlMagic.short_errors = False")
+    with pytest.raises(OperationalError) as err:
+        ip.run_cell_magic(*query_incorrect_column_name)
+    out, _ = capsys.readouterr()
+    assert message_incorrect_column_name_long.strip() in str(err.value).strip()
+    assert SYNTAX_ERROR.strip() in out
+    assert isinstance(err.value, sqlalchemy.exc.OperationalError)
+
+
+def test_syntax_error_suggestion(ip, query_suggestion):
+    with pytest.raises(UsageError) as err:
+        ip.run_cell_magic(*query_suggestion)
+    assert "Did you mean : ['ALTER TABLE author RENAME TO new_author']" in str(
+        err.value
+    )
+    _common_strings_check(err)
+
+
+message_error_suggestion_long = f"""\
+(sqlite3.OperationalError) near ";": syntax error
+{COMMUNITY}
+[SQL: ALTER TABLE author RENAME new_author;]
+"""  # noqa
+
+
+def test_syntax_error_suggestion_long(ip, capsys, query_suggestion):
+    ip.run_line_magic("config", "SqlMagic.short_errors = False")
+    with pytest.raises(OperationalError) as err:
+        ip.run_cell_magic(*query_suggestion)
+    out, _ = capsys.readouterr()
+    assert message_error_suggestion_long.strip() in str(err.value).strip()
+    assert SYNTAX_ERROR.strip() in out
+    assert isinstance(err.value, sqlalchemy.exc.OperationalError)
+
+
+def test_syntax_error_multiple_statements(ip, query_multiple):
+    with pytest.raises(UsageError) as err:
+        ip.run_cell_magic(*query_multiple)
+    assert (
+        "Did you mean : ['ALTER TABLE author RENAME TO another_name']"
+        in str(err.value).strip()
+    )
+    _common_strings_check(err)
+
+
+message_multiple_statements_long = f"""\
+(sqlite3.OperationalError) near ";": syntax error
+{COMMUNITY}
+[SQL: ALTER TABLE author RENAME another_name;]
+"""  # noqa
+
+
+def test_syntax_error_multiple_statements_long(ip, capsys, query_multiple):
+    ip.run_line_magic("config", "SqlMagic.short_errors = False")
+    with pytest.raises(OperationalError) as err:
+        ip.run_cell_magic(*query_multiple)
+    out, _ = capsys.readouterr()
+    assert message_multiple_statements_long.strip() in str(err.value).strip()
+    assert SYNTAX_ERROR.strip() in out
+    assert isinstance(err.value, sqlalchemy.exc.OperationalError)


### PR DESCRIPTION
## Describe your changes

Overriding sqlalchemy error handling for the case:
1. Syntax errors in query (we are using sqlglot to parse the query and prompt possible errors/ suggestions).
2. Password not provided/ in-accessible for postgres connections
3. Incorrect URL connection string for DuckDB

## Issue number

Closes #229 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--400.org.readthedocs.build/en/400/

<!-- readthedocs-preview jupysql end -->