### PR TITLE
Fixating Polars version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ DEV = [
     "flake8",
     "pytest",
     "pandas",
-    "polars",
+    "polars==0.17.2",  # 04/18/23 this breaks our CI
     "invoke",
     "pkgmt",
     "twine",


### PR DESCRIPTION
This PR is to make the version static so the CI isn't failing.

<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--412.org.readthedocs.build/en/412/

<!-- readthedocs-preview jupysql end -->