### PR TITLE
fixes --alias when passing an existing engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [Doc] Add QuestDB tutorial (#350)
 * [Fix] Fixes `%sqlcmd plot` when `--table` or `--column` have spaces (#409)
 * [Feature] Add sticky first column styling to sqlcmd profile command
+* [Fix] Fix `--alias` when passing an existing engine
 
 ## 0.7.1 (2023-04-19)
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -49,6 +49,7 @@ class SQLCommand:
             add_alias = True
         else:
             add_alias = False
+
         self.command_text = " ".join(line_for_command) + "\n" + cell
 
         if self.args.file:

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -270,7 +270,7 @@ class Connection:
             if isinstance(descriptor, Connection):
                 cls.current = descriptor
             elif isinstance(descriptor, Engine):
-                cls.current = Connection(descriptor)
+                cls.current = Connection(descriptor, alias=alias)
             elif is_custom_connection_:
                 cls.current = CustomConnection(descriptor, alias=alias)
             else:


### PR DESCRIPTION
## Describe your changes


Fixed a bug when using existing engine objects and passing `--alias`

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--446.org.readthedocs.build/en/446/

<!-- readthedocs-preview jupysql end -->