### PR TITLE
[Doc] Typo on JupySQL

### DIFF
--- a/doc/integrations/questdb.ipynb
+++ b/doc/integrations/questdb.ipynb
@@ -170,7 +170,7 @@
    "source": [
     "## Query\n",
     "\n",
-    "Now, let's start JuppySQL, authenticate and start querying the data!"
+    "Now, let's start JupySQL, authenticate and start querying the data!"
    ]
   },
   {


### PR DESCRIPTION
JupySQL was incorrectly shown as JuppySQL with double 'p'. Fixed






<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--454.org.readthedocs.build/en/454/

<!-- readthedocs-preview jupysql end -->