### PR TITLE
Change default displaylimit value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.3dev
 * [Doc] Tutorial on querying excel files with pandas and jupysql ([#423](https://github.com/ploomber/jupysql/pull/423))
 * [Fix] Fix `--alias` when passing an existing engine
-* [Fix] Fix displaylimit default value to 60 (#462)
+* [Fix] Fix displaylimit default value to 10 (#462)
 
 ## 0.7.2 (2023-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.3dev
 * [Doc] Tutorial on querying excel files with pandas and jupysql ([#423](https://github.com/ploomber/jupysql/pull/423))
 * [Fix] Fix `--alias` when passing an existing engine
+* [Fix] Fix displaylimit default value to 60 (#462)
 
 ## 0.7.2 (2023-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.5dev
 
 * [Doc] documenting `%sqlcmd tables`/`%sqlcmd columns`
-* [Fix] Fix displaylimit default value to 10 (#462)
+* [Fix] Fix the default value of %config SqlMagic.displaylimit to 10 (#462)
 
 ## 0.7.4 (2023-04-28)
 No changes

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -1,13 +1,13 @@
 ---
 jupytext:
+  notebook_metadata_filter: myst
   cell_metadata_filter: -all
   formats: md:myst
-  notebook_metadata_filter: myst
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -51,7 +51,7 @@ INSERT INTO languages VALUES ('Java', 11.59, 0.40);
 INSERT INTO languages VALUES ('C++', 10.00, 1.98);
 ```
 
-## Optionsss
+## Options
 
 ```{code-cell} ipython3
 %config SqlMagic

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -51,7 +51,7 @@ INSERT INTO languages VALUES ('Java', 11.59, 0.40);
 INSERT INTO languages VALUES ('C++', 10.00, 1.98);
 ```
 
-## Optionss
+## Optionsss
 
 ```{code-cell} ipython3
 %config SqlMagic

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -111,7 +111,7 @@ Default: `10`
 
 Automatically limit the number of rows displayed (full result set is still stored).
 
-(To display all rows: set to `None`)
+(To display all rows: set to `0` or `None`)
 
 ```{code-cell} ipython3
 %config SqlMagic.displaylimit = None

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -105,9 +105,11 @@ Automatically limit the size of the returned result sets (e.g., add a `LIMIT` at
 
 ## `displaylimit`
 
-Default: `None` (no limit)
+Default: `60`
 
 Automatically limit the number of rows displayed (full result set is still stored).
+
+(To display all rows: set to `None`)
 
 ```{code-cell} ipython3
 %config SqlMagic.displaylimit = None

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -51,7 +51,7 @@ INSERT INTO languages VALUES ('Java', 11.59, 0.40);
 INSERT INTO languages VALUES ('C++', 10.00, 1.98);
 ```
 
-## Options
+## Optionss
 
 ```{code-cell} ipython3
 %config SqlMagic

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -1,17 +1,17 @@
 ---
 jupytext:
-  notebook_metadata_filter: myst
   cell_metadata_filter: -all
   formats: md:myst
+  notebook_metadata_filter: myst
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.14.5
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: jupysql
   language: python
-  name: python3
+  name: jupysql
 myst:
   html_meta:
     description lang=en: Configure the %sql/%%sql magics in Jupyter
@@ -189,7 +189,9 @@ for _ in range(100):
 
 %sql SELECT * FROM points
 ```
+
 To unset:
+
 ```{code-cell} ipython3
 %config SqlMagic.polars_dataframe_kwargs = {}
 ```

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -28,6 +28,8 @@ set (usually with a `LIMIT` clause in the SQL).  `displaylimit` is similar,
 but the entire result set is still pulled into memory (for later analysis);
 only the screen display is truncated.
 
+If you are concerned about query performance, please use the `autolimit` config.
+
 +++
 
 ## Setup
@@ -105,7 +107,7 @@ Automatically limit the size of the returned result sets (e.g., add a `LIMIT` at
 
 ## `displaylimit`
 
-Default: `60`
+Default: `10`
 
 Automatically limit the number of rows displayed (full result set is still stored).
 

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -9,9 +9,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.14.5
 kernelspec:
-  display_name: jupysql
+  display_name: Python 3 (ipykernel)
   language: python
-  name: jupysql
+  name: python3
 myst:
   html_meta:
     description lang=en: Configure the %sql/%%sql magics in Jupyter

--- a/doc/community/vs.md
+++ b/doc/community/vs.md
@@ -16,3 +16,4 @@ If you're migrating from `ipython-sql` to JupySQL, these are the differences (in
 - Using `%sqlcmd tables` and `%sqlcmd columns --table/-t` user can quickly explore tables in the database and the columns each table has. [Click here](../user-guide/tables-columns) to learn more.
 - [Polars Integration](../integrations/polars) to convert query results to `polars.DataFrame`. `%config SqlMagic.autopolars` can be used to automatically return Polars DataFrames instead of regular result sets.
 - Integration tests with PostgreSQL, MariaDB, MySQL, SQLite and DuckDB.
+- The configuration default value of SqlMagic.displaylimit is different, in JupySQL is `10`, whereas in ipython-sql is `None`

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -144,6 +144,11 @@ class SqlMagic(Magics, Configurable):
         # Add ourself to the list of module configurable via %config
         self.shell.configurables.append(self)
 
+    # To verify displaylimit is valid positive integer
+    # If:
+    #   None -> We treat it as 0 (no limit)
+    #   Positive Integer -> Pass
+    #   Negative Integer -> raise Error
     @validate("displaylimit")
     def _valid_displaylimit(self, proposal):
         if proposal["value"] is None:

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -94,7 +94,7 @@ class SqlMagic(Magics, Configurable):
         help="Don't display the full traceback on SQL Programming Error",
     )
     displaylimit = Int(
-        None,
+        "UNSET",
         config=True,
         allow_none=True,
         help=(

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import re
 
@@ -135,16 +134,18 @@ class SqlMagic(Magics, Configurable):
     )
     autocommit = Bool(True, config=True, help="Set autocommit mode")
 
-    @validate('displaylimit')
+    @validate("displaylimit")
     def _valid_displaylimit(self, proposal):
         try:
-            value = int(proposal['value'])
+            value = int(proposal["value"])
             if value <= 0:
-                raise TraitError("{}: displaylimit cannot be a negative integer".format(value))
+                raise TraitError(
+                    "{}: displaylimit cannot be a negative integer".format(value)
+                )
         except ValueError:
             raise TraitError("{}: displaylimit is not an integer".format(value))
         return value
-    
+
     @telemetry.log_call("init")
     def __init__(self, shell):
         self._store = store
@@ -154,7 +155,6 @@ class SqlMagic(Magics, Configurable):
 
         # Add ourself to the list of module configurable via %config
         self.shell.configurables.append(self)
-
 
     @observe("autopandas", "autopolars")
     def _mutex_autopandas_autopolars(self, change):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -94,7 +94,7 @@ class SqlMagic(Magics, Configurable):
         help="Don't display the full traceback on SQL Programming Error",
     )
     displaylimit = Int(
-        -1,
+        60,
         config=True,
         allow_none=True,
         help=(

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -134,18 +134,6 @@ class SqlMagic(Magics, Configurable):
     )
     autocommit = Bool(True, config=True, help="Set autocommit mode")
 
-    @validate("displaylimit")
-    def _valid_displaylimit(self, proposal):
-        try:
-            value = int(proposal["value"])
-            if value <= 0:
-                raise TraitError(
-                    "{}: displaylimit cannot be a negative integer".format(value)
-                )
-        except ValueError:
-            raise TraitError("{}: displaylimit is not an integer".format(value))
-        return value
-
     @telemetry.log_call("init")
     def __init__(self, shell):
         self._store = store
@@ -155,6 +143,20 @@ class SqlMagic(Magics, Configurable):
 
         # Add ourself to the list of module configurable via %config
         self.shell.configurables.append(self)
+
+    @validate("displaylimit")
+    def _valid_displaylimit(self, proposal):
+        value = int(proposal["value"])
+        if value is None:
+            return value
+        try:
+            if value <= 0:
+                raise TraitError(
+                    "{}: displaylimit cannot be a negative integer".format(value)
+                )
+        except ValueError:
+            raise TraitError("{}: displaylimit is not an integer".format(value))
+        return value
 
     @observe("autopandas", "autopolars")
     def _mutex_autopandas_autopolars(self, change):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -94,7 +94,7 @@ class SqlMagic(Magics, Configurable):
         help="Don't display the full traceback on SQL Programming Error",
     )
     displaylimit = Int(
-        10,
+        sql.run.DEFAULT_DISPLAYLIMIT_VALUE,
         config=True,
         allow_none=True,
         help=(
@@ -146,17 +146,18 @@ class SqlMagic(Magics, Configurable):
 
     @validate("displaylimit")
     def _valid_displaylimit(self, proposal):
-        value = int(proposal["value"])
-        if value is None:
-            return value
+        if proposal["value"] is None:
+            print("displaylimit: Value None will be treated as 0 (no limit)")
+            return 0
         try:
-            if value <= 0:
+            value = int(proposal["value"])
+            if value < 0:
                 raise TraitError(
                     "{}: displaylimit cannot be a negative integer".format(value)
                 )
+            return value
         except ValueError:
             raise TraitError("{}: displaylimit is not an integer".format(value))
-        return value
 
     @observe("autopandas", "autopolars")
     def _mutex_autopandas_autopolars(self, change):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -94,7 +94,7 @@ class SqlMagic(Magics, Configurable):
         help="Don't display the full traceback on SQL Programming Error",
     )
     displaylimit = Int(
-        "UNSET",
+        -1,
         config=True,
         allow_none=True,
         help=(

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -163,9 +163,8 @@ class ResultSet(ColumnGuesserMixin):
                     "<br>"
                     '<span style="font-style:italic;text-align:center;">'
                     "If you want to see more, please visit "
-                    '<a href="https://jupysql.ploomber.io/en/latest/api/'
-                    'configuration.html#displaylimit">displaylimit</a>'
-                    " configuration</span>"
+                    '<a href="https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit">displaylimit</a>'  # noqa: E501
+                    ' configuration</span>'
                 )
                 result = HTML % (result, len(self), self.pretty.row_count)
             return result

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -25,6 +25,7 @@ import logging
 import warnings
 from collections.abc import Iterable
 
+DEFAULT_DISPLAY_LIMIT = 60
 
 def unduplicate_field_names(field_names):
     """Append a number to duplicate field names to make them unique."""
@@ -512,20 +513,23 @@ def raw_run(conn, sql):
 class PrettyTable(prettytable.PrettyTable):
     def __init__(self, *args, **kwargs):
         self.row_count = 0
-        self.displaylimit = None
+        self.displaylimit = DEFAULT_DISPLAY_LIMIT
         return super(PrettyTable, self).__init__(*args, **kwargs)
 
     def add_rows(self, data):
         if self.row_count and (data.config.displaylimit == self.displaylimit):
             return  # correct number of rows already present
         self.clear_rows()
-        self.displaylimit = data.config.displaylimit
-        if self.displaylimit == 0:
-            self.displaylimit = None  # TODO: remove this to make 0 really 0
-        if self.displaylimit in (None, 0):
-            self.row_count = len(data)
-        else:
-            self.row_count = min(len(data), self.displaylimit)
+        print ("Pre config: ", data.config.displaylimit)
+        if data.config.displaylimit == "UNSET":
+            
+        elif data.config.displaylimit:
+            self.displaylimit = data.config.displaylimit
+        # elif data.config.displaylimit 
+        self.row_count = min(len(data), self.displaylimit)
+
+        print ("Final row_count:", self.row_count)
+        print ("Final displaylimit:", self.displaylimit)
         for row in data[: self.displaylimit]:
             formatted_row = []
             for cell in row:

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -428,7 +428,7 @@ def handle_postgres_special(conn, statement):
     """Execute a PostgreSQL special statement using PGSpecial module."""
     if not PGSpecial:
         raise exceptions.MissingPackageError("pgspecial not installed")
-    
+
     pgspecial = PGSpecial()
     _, cur, headers, _ = pgspecial.execute(conn.session.connection.cursor(), statement)[
         0

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -164,7 +164,7 @@ class ResultSet(ColumnGuesserMixin):
                     '<span style="font-style:italic;text-align:center;">'
                     "If you want to see more, please visit "
                     '<a href="https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit">displaylimit</a>'  # noqa: E501
-                    ' configuration</span>'
+                    " configuration</span>"
                 )
                 result = HTML % (result, len(self), self.pretty.row_count)
             return result

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -159,7 +159,12 @@ class ResultSet(ColumnGuesserMixin):
             if len(self) > self.pretty.row_count:
                 HTML = (
                     '%s\n<span style="font-style:italic;text-align:center;">'
-                    "%d rows, truncated to displaylimit of %d</span>"
+                    '%d rows, truncated to displaylimit of %d</span>'
+                    '<br>'
+                    '<span style="font-style:italic;text-align:center;">'
+                    'If you want to see more, please visit '
+                    '<a href="https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit">displaylimit</a>'
+                    ' configuration</span>'
                 )
                 result = HTML % (result, len(self), self.pretty.row_count)
             return result

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -428,6 +428,7 @@ def handle_postgres_special(conn, statement):
     """Execute a PostgreSQL special statement using PGSpecial module."""
     if not PGSpecial:
         raise exceptions.MissingPackageError("pgspecial not installed")
+    
     pgspecial = PGSpecial()
     _, cur, headers, _ = pgspecial.execute(conn.session.connection.cursor(), statement)[
         0
@@ -480,7 +481,6 @@ def run(conn, sql, config):
         first_word = sql.strip().split()[0].lower()
         manual_commit = False
         if first_word == "begin":
-            # raise ValueError("ipython_sql does not support transactions")
             raise exceptions.RuntimeError("JupySQL does not support transactions")
         if first_word.startswith("\\") and is_postgres_or_redshift(conn.dialect):
             result = handle_postgres_special(conn, statement)

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -512,7 +512,7 @@ def raw_run(conn, sql):
 class PrettyTable(prettytable.PrettyTable):
     def __init__(self, *args, **kwargs):
         self.row_count = 0
-        self.displaylimit = 60
+        self.displaylimit = 10
         return super(PrettyTable, self).__init__(*args, **kwargs)
 
     def add_rows(self, data):

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -24,6 +24,7 @@ import logging
 import warnings
 from collections.abc import Iterable
 
+
 def unduplicate_field_names(field_names):
     """Append a number to duplicate field names to make them unique."""
     res = []

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -11,11 +11,12 @@ import prettytable
 import sqlalchemy
 import sqlparse
 from sql.connection import Connection
+from sql import exceptions
 from .column_guesser import ColumnGuesserMixin
 
 try:
     from pgspecial.main import PGSpecial
-except ImportError:
+except ModuleNotFoundError:
     PGSpecial = None
 from sqlalchemy.orm import Session
 
@@ -426,7 +427,7 @@ def is_pytds(dialect):
 def handle_postgres_special(conn, statement):
     """Execute a PostgreSQL special statement using PGSpecial module."""
     if not PGSpecial:
-        raise ImportError("pgspecial not installed")
+        raise exceptions.MissingPackageError("pgspecial not installed")
     pgspecial = PGSpecial()
     _, cur, headers, _ = pgspecial.execute(conn.session.connection.cursor(), statement)[
         0
@@ -479,7 +480,8 @@ def run(conn, sql, config):
         first_word = sql.strip().split()[0].lower()
         manual_commit = False
         if first_word == "begin":
-            raise ValueError("ipython_sql does not support transactions")
+            # raise ValueError("ipython_sql does not support transactions")
+            raise exceptions.RuntimeError("JupySQL does not support transactions")
         if first_word.startswith("\\") and is_postgres_or_redshift(conn.dialect):
             result = handle_postgres_special(conn, statement)
         else:

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -517,7 +517,7 @@ class PrettyTable(prettytable.PrettyTable):
         if self.row_count and (data.config.displaylimit == self.displaylimit):
             return  # correct number of rows already present
         self.clear_rows()
-        if data.config.displaylimit == None:
+        if data.config.displaylimit is None:
             self.displaylimit = len(data)
             self.row_count = len(data)
         else:

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -151,12 +151,13 @@ class ResultSet(list, ColumnGuesserMixin):
             # to create clickable links
             result = html.unescape(result)
             result = _cell_with_spaces_pattern.sub(_nonbreaking_spaces, result)
-            if self.config.displaylimit and len(self) > self.config.displaylimit:
+            actual_display_limit = self.config.displaylimit if self.config.displaylimit != -1 else DEFAULT_DISPLAY_LIMIT
+            if actual_display_limit and len(self) > actual_display_limit:
                 HTML = (
                     '%s\n<span style="font-style:italic;text-align:center;">'
                     "%d rows, truncated to displaylimit of %d</span>"
                 )
-                result = HTML % (result, len(self), self.config.displaylimit)
+                result = HTML % (result, len(self), actual_display_limit)
             return result
         else:
             return None
@@ -520,16 +521,17 @@ class PrettyTable(prettytable.PrettyTable):
         if self.row_count and (data.config.displaylimit == self.displaylimit):
             return  # correct number of rows already present
         self.clear_rows()
-        print ("Pre config: ", data.config.displaylimit)
-        if data.config.displaylimit == "UNSET":
-            
-        elif data.config.displaylimit:
+        # print ("Pre config: ", data.config.displaylimit)
+        if data.config.displaylimit == -1:
+            self.displaylimit = DEFAULT_DISPLAY_LIMIT
+            self.row_count = min(len(data), self.displaylimit)
+        elif data.config.displaylimit == None:
+            self.displaylimit = len(data)
+            self.row_count = len(data)
+        else:
             self.displaylimit = data.config.displaylimit
-        # elif data.config.displaylimit 
-        self.row_count = min(len(data), self.displaylimit)
+            self.row_count = min(len(data), self.displaylimit)
 
-        print ("Final row_count:", self.row_count)
-        print ("Final displaylimit:", self.displaylimit)
         for row in data[: self.displaylimit]:
             formatted_row = []
             for cell in row:

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -150,12 +150,15 @@ class ResultSet(list, ColumnGuesserMixin):
             # to create clickable links
             result = html.unescape(result)
             result = _cell_with_spaces_pattern.sub(_nonbreaking_spaces, result)
-            if self.config.displaylimit and len(self) > self.config.displaylimit:
+            truncated_number = self.config.displaylimit
+            if truncated_number is None:
+                truncated_number = 10
+            if len(self) > truncated_number:
                 HTML = (
                     '%s\n<span style="font-style:italic;text-align:center;">'
                     "%d rows, truncated to displaylimit of %d</span>"
                 )
-                result = HTML % (result, len(self), self.config.displaylimit)
+                result = HTML % (result, len(self), truncated_number)
             return result
         else:
             return None
@@ -519,9 +522,11 @@ class PrettyTable(prettytable.PrettyTable):
         if self.row_count and (data.config.displaylimit == self.displaylimit):
             return  # correct number of rows already present
         self.clear_rows()
-        if data.config.displaylimit is None:
+        if data.config.displaylimit == 0:
             self.displaylimit = len(data)
             self.row_count = len(data)
+        elif data.config.displaylimit is None:
+            self.row_count = min(len(data), self.displaylimit)
         else:
             self.displaylimit = data.config.displaylimit
             self.row_count = min(len(data), self.displaylimit)

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -159,12 +159,13 @@ class ResultSet(ColumnGuesserMixin):
             if len(self) > self.pretty.row_count:
                 HTML = (
                     '%s\n<span style="font-style:italic;text-align:center;">'
-                    '%d rows, truncated to displaylimit of %d</span>'
-                    '<br>'
+                    "%d rows, truncated to displaylimit of %d</span>"
+                    "<br>"
                     '<span style="font-style:italic;text-align:center;">'
-                    'If you want to see more, please visit '
-                    '<a href="https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit">displaylimit</a>'
-                    ' configuration</span>'
+                    "If you want to see more, please visit "
+                    '<a href="https://jupysql.ploomber.io/en/latest/api/'
+                    'configuration.html#displaylimit">displaylimit</a>'
+                    " configuration</span>"
                 )
                 result = HTML % (result, len(self), self.pretty.row_count)
             return result

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -236,7 +236,8 @@ def test_displaylimit_unlimited(ip):
     ip.run_line_magic("config", "SqlMagic.displaylimit = None")
 
     out = ip.run_cell("%sql SELECT * FROM author;")
-    assert out.result == [('William', 'Shakespeare', 1616), ('Bertold', 'Brecht', 1956)]
+    assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
+
 
 def test_displaylimit_disabled(ip):
     ip.run_line_magic("config", "SqlMagic.autolimit = None")
@@ -256,11 +257,13 @@ def test_displaylimit(ip):
     assert "Brecht" in result._repr_html_()
     assert "Shakespeare" not in result._repr_html_()
 
+
 @pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6)])
 def test_displaylimit_enabled(ip, config_value, expected_length):
     ip.run_cell(f"%config SqlMagic.displaylimit = {expected_length}")
     out = runsql(ip, "SELECT * FROM number_table;")
     assert f"truncated to displaylimit of {expected_length}" in out._repr_html_()
+
 
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -232,8 +232,7 @@ def test_connection_args_double_quotes(ip):
 #     assert 'Shakespeare' in str(persisted)
 
 
-def test_displaylimit_unlimited(ip):
-    ip.run_line_magic("config", "SqlMagic.autolimit = None")
+def test_displaylimit_default(ip):
     ip.run_line_magic("config", "SqlMagic.displaylimit = None")
 
     out = ip.run_cell("%sql SELECT * FROM author;")
@@ -250,8 +249,12 @@ def test_displaylimit(ip):
     assert "Shakespeare" not in result._repr_html_()
 
 
-@pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6), (-1, -1)])
+@pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6), (None, 10)])
 def test_displaylimit_enabled_truncated_length(ip, config_value, expected_length):
+    # Insert extra data to make number_table bigger (over 10 to see truncated string)
+    ip.run_cell("%sql INSERT INTO number_table VALUES (4, 3)")
+    ip.run_cell("%sql INSERT INTO number_table VALUES (4, 3)")
+
     ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
     out = runsql(ip, "SELECT * FROM number_table;")
     assert f"truncated to displaylimit of {expected_length}" in out._repr_html_()

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -232,6 +232,24 @@ def test_connection_args_double_quotes(ip):
 #     assert 'Shakespeare' in str(persisted)
 
 
+def test_displaylimit_no_limit(ip):
+    ip.run_line_magic("config", "SqlMagic.displaylimit = 0")
+
+    out = ip.run_cell("%sql SELECT * FROM number_table;")
+    assert out.result == [
+        (4, -2),
+        (-5, 0),
+        (2, 4),
+        (0, 2),
+        (-5, -1),
+        (-2, -3),
+        (-2, -3),
+        (-4, 2),
+        (2, -5),
+        (4, 3),
+    ]
+
+
 def test_displaylimit_default(ip):
     ip.run_line_magic("config", "SqlMagic.displaylimit = None")
 

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -295,13 +295,24 @@ def test_displaylimit_enabled_no_limit(
 
 
 @pytest.mark.parametrize(
-    "config_value", [(-1), (-1.05), ("'some_string'"), ("tuple(123)")]
+    "config_value, expected_error_msg",
+    [
+        (-1, "displaylimit cannot be a negative integer"),
+        (-2, "displaylimit cannot be a negative integer"),
+        (-2.5, "The 'displaylimit' trait of a SqlMagic instance expected an int"),
+        (
+            "'some_string'",
+            "The 'displaylimit' trait of a SqlMagic instance expected an int",
+        ),
+    ],
 )
-def test_displaylimit_enabled_with_invalid_values(ip, config_value, caplog):
+def test_displaylimit_enabled_with_invalid_values(
+    ip, config_value, expected_error_msg, caplog
+):
     with caplog.at_level(logging.ERROR):
         ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
-    out = ip.run_cell("%sql SELECT * FROM author;")
-    assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
+
+    assert expected_error_msg in caplog.text
 
 
 def test_column_local_vars(ip):

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import platform
 from pathlib import Path
@@ -16,6 +17,7 @@ from sql.connection import Connection
 from sql.magic import SqlMagic
 from sql.run import ResultSet
 from sql import magic
+from traitlets import TraitError
 
 from conftest import runsql
 
@@ -239,14 +241,6 @@ def test_displaylimit_unlimited(ip):
     assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
 
 
-def test_displaylimit_disabled(ip):
-    ip.run_line_magic("config", "SqlMagic.autolimit = None")
-
-    result = runsql(ip, "SELECT * FROM author;")
-
-    assert "Brecht" in result._repr_html_()
-    assert "Shakespeare" in result._repr_html_()
-
 
 def test_displaylimit(ip):
     ip.run_line_magic("config", "SqlMagic.autolimit = None")
@@ -258,12 +252,19 @@ def test_displaylimit(ip):
     assert "Shakespeare" not in result._repr_html_()
 
 
-@pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6)])
-def test_displaylimit_enabled(ip, config_value, expected_length):
-    ip.run_cell(f"%config SqlMagic.displaylimit = {expected_length}")
+@pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6), (-1, -1)])
+def test_displaylimit_enabled_truncated_length(ip, config_value, expected_length):
+    ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
     out = runsql(ip, "SELECT * FROM number_table;")
     assert f"truncated to displaylimit of {expected_length}" in out._repr_html_()
 
+
+@pytest.mark.parametrize("config_value", [(-1), (-1.05), ("'some_string'"), ("tuple(123)")])
+def test_displaylimit_enabled_with_invalid_values(ip, config_value, caplog):
+    with caplog.at_level(logging.ERROR):
+        ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
+    out = ip.run_cell("%sql SELECT * FROM author;")
+    assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
 
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -251,6 +251,11 @@ def test_displaylimit(ip):
     assert "Brecht" in result._repr_html_()
     assert "Shakespeare" not in result._repr_html_()
 
+@pytest.mark.parametrize("config_value, expected_length", [(3, 3), (6, 6)])
+def test_displaylimit_enabled(ip, config_value, expected_length):
+    ip.run_cell(f"%config SqlMagic.displaylimit = {expected_length}")
+    out = runsql(ip, "SELECT * FROM number_table;")
+    assert f"truncated to displaylimit of {expected_length}" in out._repr_html_()
 
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -231,11 +231,16 @@ def test_connection_args_double_quotes(ip):
 #     assert 'Shakespeare' in str(persisted)
 
 
-@pytest.mark.parametrize("value", ["None", "0"])
-def test_displaylimit_disabled(ip, value):
+def test_displaylimit_unlimited(ip):
+    ip.run_line_magic("config", "SqlMagic.autolimit = None")
+    ip.run_line_magic("config", "SqlMagic.displaylimit = None")
+
+    out = ip.run_cell("%sql SELECT * FROM author;")
+    assert out.result == [('William', 'Shakespeare', 1616), ('Bertold', 'Brecht', 1956)]
+
+def test_displaylimit_disabled(ip):
     ip.run_line_magic("config", "SqlMagic.autolimit = None")
 
-    ip.run_line_magic("config", f"SqlMagic.displaylimit = {value}")
     result = runsql(ip, "SELECT * FROM author;")
 
     assert "Brecht" in result._repr_html_()

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -314,6 +314,23 @@ def test_displaylimit_enabled_with_invalid_values(
 
     assert expected_error_msg in caplog.text
 
+@pytest.mark.parametrize("query_clause, expected_truncated_length",
+                          [
+    ("SELECT * FROM number_table LIMIT 5", None),
+    ("SELECT * FROM number_table LIMIT 11", 11),
+    ("SELECT * FROM number_table", 12),
+                           ]
+                          )
+def test_displaylimit_with_limit_clause(ip, query_clause, expected_truncated_length):
+    # Insert extra data to make number_table bigger (over 10 to see truncated string)
+    ip.run_cell("%sql INSERT INTO number_table VALUES (4, 3)")
+    ip.run_cell("%sql INSERT INTO number_table VALUES (4, 3)")
+
+    out = runsql(ip, query_clause)
+    print ("out: ", out._repr_html_())
+    if expected_truncated_length:
+        assert f"{expected_truncated_length} rows, truncated to displaylimit of 10" in out._repr_html_()
+
 
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -17,7 +17,6 @@ from sql.connection import Connection
 from sql.magic import SqlMagic
 from sql.run import ResultSet
 from sql import magic
-from traitlets import TraitError
 
 from conftest import runsql
 
@@ -241,7 +240,6 @@ def test_displaylimit_unlimited(ip):
     assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
 
 
-
 def test_displaylimit(ip):
     ip.run_line_magic("config", "SqlMagic.autolimit = None")
 
@@ -259,12 +257,15 @@ def test_displaylimit_enabled_truncated_length(ip, config_value, expected_length
     assert f"truncated to displaylimit of {expected_length}" in out._repr_html_()
 
 
-@pytest.mark.parametrize("config_value", [(-1), (-1.05), ("'some_string'"), ("tuple(123)")])
+@pytest.mark.parametrize(
+    "config_value", [(-1), (-1.05), ("'some_string'"), ("tuple(123)")]
+)
 def test_displaylimit_enabled_with_invalid_values(ip, config_value, caplog):
     with caplog.at_level(logging.ERROR):
         ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
     out = ip.run_cell("%sql SELECT * FROM author;")
     assert out.result == [("William", "Shakespeare", 1616), ("Bertold", "Brecht", 1956)]
+
 
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")


### PR DESCRIPTION
## Describe your changes

- Change default display limit as -> `10`
- Add unlimited display limit support if user sets value as `0` or `None`

### Demo

Case 1: Unset -> Default display limit as  10 (Unset)

https://user-images.githubusercontent.com/123580782/235429111-4233f783-16f9-4cda-a8ec-9beb88ac274b.mov

Case 2: Set as 20

<img width="824" alt="Screenshot 2023-05-01 at 4 28 47 PM" src="https://user-images.githubusercontent.com/123580782/235429137-16c9b78b-3cc3-46ae-b5ca-64ee12520ca6.png">

Case 3: Set as None (no limit)

<img width="943" alt="Screenshot 2023-05-01 at 4 32 06 PM" src="https://user-images.githubusercontent.com/123580782/235429366-5852f0c9-61fc-4ea3-b709-c29d33027373.png">


[Doc preview](https://jupysql--462.org.readthedocs.build/en/462/api/configuration.html#displaylimit)

<img width="838" alt="Screenshot 2023-04-27 at 11 44 33 PM" src="https://user-images.githubusercontent.com/123580782/234915488-b34df3c0-06e9-4d59-9f67-263aa32ec1cf.png">



## Issue number

Closes https://github.com/ploomber/jupysql/issues/419

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--462.org.readthedocs.build/en/462/

<!-- readthedocs-preview jupysql end -->