### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ with open("src/sql/__init__.py", "rb") as f:
 
 install_requires = [
     "prettytable",
-    "ipython<=8.12.0; python_version == '3.8'",
+    # IPython dropped support for Python 3.8
+    "ipython<=8.12.0; python_version <= '3.8'",
+    "ipython",
     "sqlalchemy",
     "sqlparse",
     "ipython-genutils>=0.1.0",


### PR DESCRIPTION
## Describe your changes

hey @idomic - I found an error in the setup.py. this will only install IPython in Python 3.8, other Python versions won't install IPython. the CI was passing because a previous step was installing IPython anyway. but I detected this because I encountered it in the ploomber-engine repo

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--471.org.readthedocs.build/en/471/

<!-- readthedocs-preview jupysql end -->