### PR TITLE
Syntactic sugar for outputting result variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.6dev
 
+* [Feature] Support for printing capture variables using `=<<` syntax (by [@jorisroovers](https://github.com/jorisroovers))
+
 ## 0.7.5 (2023-05-24)
 
 * [Feature] Using native DuckDB `.df()` method when using `autopandas`

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -144,6 +144,14 @@ can be used in multi-line ``%%sql``:
 FROM languages
 ```
 
+The `myvar= <<` syntax captures query results in a local variable as well as
+returning the results.
+
+```{code-cell} ipython3
+%%sql lang= << SELECT *
+FROM languages
+```
+
 +++
 
 ## Considerations

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -96,5 +96,10 @@ class SQLCommand:
         """Returns the result_var"""
         return self.parsed["result_var"]
 
+    @property
+    def return_result_var(self):
+        """Returns the return_result_var"""
+        return self.parsed["return_result_var"]
+
     def _var_expand(self, sql, user_ns, magic):
         return Template(sql).render(user_ns)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -423,6 +423,8 @@ class SqlMagic(Magics, Configurable):
             else:
                 if command.result_var:
                     self.shell.user_ns.update({command.result_var: result})
+                    if command.return_result_var:
+                        return result
                     return None
 
                 # Return results into the default ipython _ variable

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -38,7 +38,12 @@ def parse(cell, config):
     connection string and `<<` operator in.
     """
 
-    result = {"connection": "", "sql": "", "result_var": None}
+    result = {
+        "connection": "",
+        "sql": "",
+        "result_var": None,
+        "return_result_var": False,
+    }
 
     pieces = cell.split(None, 1)
     if not pieces:
@@ -51,7 +56,12 @@ def parse(cell, config):
 
     pieces = cell.split(None, 2)
     if len(pieces) > 1 and pieces[1] == "<<":
-        result["result_var"] = pieces[0]
+        if pieces[0].endswith("="):
+            result["result_var"] = pieces[0][:-1]
+            result["return_result_var"] = True
+        else:
+            result["result_var"] = pieces[0]
+
         if len(pieces) == 2:
             return result
         cell = pieces[2]

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -13,16 +13,38 @@ def sql_magic(ip):
 
 
 @pytest.mark.parametrize(
-    "line, cell, parsed_sql, parsed_connection, parsed_result_var",
+    "line, cell, parsed_sql, parsed_connection, parsed_result_var, parsed_return_result_var",
     [
-        ("something --no-execute", "", "something", "", None),
-        ("sqlite://", "", "", "sqlite://", None),
-        ("SELECT * FROM TABLE", "", "SELECT * FROM TABLE", "", None),
-        ("SELECT * FROM", "TABLE", "SELECT * FROM\nTABLE", "", None),
-        ("my_var << SELECT * FROM table", "", "SELECT * FROM table", "", "my_var"),
-        ("my_var << SELECT *", "FROM table", "SELECT *\nFROM table", "", "my_var"),
-        ("[db]", "", "", "sqlite://", None),
-        ("--persist df", "", "df", "", None),
+        ("something --no-execute", "", "something", "", None, False),
+        ("sqlite://", "", "", "sqlite://", None, False),
+        ("SELECT * FROM TABLE", "", "SELECT * FROM TABLE", "", None, False),
+        ("SELECT * FROM", "TABLE", "SELECT * FROM\nTABLE", "", None, False),
+        (
+            "my_var << SELECT * FROM table",
+            "",
+            "SELECT * FROM table",
+            "",
+            "my_var",
+            False,
+        ),
+        (
+            "my_var << SELECT *",
+            "FROM table",
+            "SELECT *\nFROM table",
+            "",
+            "my_var",
+            False,
+        ),
+        (
+            "my_var= << SELECT * FROM table",
+            "",
+            "SELECT * FROM table",
+            "",
+            "my_var",
+            True,
+        ),
+        ("[db]", "", "", "sqlite://", None, False),
+        ("--persist df", "", "df", "", None, False),
     ],
     ids=[
         "arg-with-option",
@@ -31,6 +53,7 @@ def sql_magic(ip):
         "sql-query-in-line-and-cell",
         "parsed-var-single-line",
         "parsed-var-multi-line",
+        "parsed-return-var-single-line",
         "config",
         "persist-dataframe",
     ],
@@ -43,6 +66,7 @@ def test_parsed(
     parsed_sql,
     parsed_connection,
     parsed_result_var,
+    parsed_return_result_var,
     tmp_empty,
 ):
     # needed for the last test case
@@ -58,6 +82,7 @@ drivername = sqlite
     assert cmd.parsed == {
         "connection": parsed_connection,
         "result_var": parsed_result_var,
+        "return_result_var": parsed_return_result_var,
         "sql": parsed_sql,
         "sql_original": parsed_sql,
     }
@@ -88,6 +113,7 @@ SELECT * FROM author_one"
     assert cmd.parsed == {
         "connection": "",
         "result_var": None,
+        "return_result_var": False,
         "sql": sql,
         "sql_original": sql_original,
     }
@@ -104,6 +130,7 @@ def test_parsed_sql_when_using_file(ip, sql_magic, tmp_empty):
     assert cmd.parsed == {
         "connection": "",
         "result_var": None,
+        "return_result_var": False,
         "sql": "SELECT * FROM author\n",
         "sql_original": "SELECT * FROM author\n",
     }
@@ -162,6 +189,7 @@ def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty, line):
     assert cmd.parsed == {
         "connection": engine,
         "result_var": None,
+        "return_result_var": False,
         "sql": sql_expected,
         "sql_original": sql_expected,
     }

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -13,7 +13,10 @@ def sql_magic(ip):
 
 
 @pytest.mark.parametrize(
-    "line, cell, parsed_sql, parsed_connection, parsed_result_var, parsed_return_result_var",
+    (
+        "line, cell, parsed_sql, parsed_connection, parsed_result_var,"
+        "parsed_return_result_var"
+    ),
     [
         ("something --no-execute", "", "something", "", None, False),
         ("sqlite://", "", "", "sqlite://", None, False),

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -111,6 +111,36 @@ def test_result_var_multiline_shovel(ip):
     assert "Shakespeare" in str(result) and "Brecht" in str(result)
 
 
+def test_return_result_var(ip, capsys):
+    # Assert that no result is returned when using regular result var syntax <<
+    result = ip.run_cell_magic(
+        "sql",
+        "",
+        """
+        sqlite://
+        x <<
+        SELECT last_name FROM author;
+        """,
+    )
+    var = ip.user_global_ns["x"]
+    assert "Shakespeare" in str(var) and "Brecht" in str(var)
+    assert result is None
+
+    # Assert that correct result is returned when using return result var syntax = <<
+    result = ip.run_cell_magic(
+        "sql",
+        "",
+        """
+        sqlite://
+        x= <<
+        SELECT last_name FROM author;
+        """,
+    )
+    var = ip.user_global_ns["x"]
+    assert "Shakespeare" in str(var) and "Brecht" in str(var)
+    assert result.dict() == {"last_name": ("Shakespeare", "Brecht")}
+
+
 def test_access_results_by_keys(ip):
     assert runsql(ip, "SELECT * FROM author;")["William"] == (
         "William",

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -25,6 +25,7 @@ def test_parse_no_sql():
         "connection": "will:longliveliz@localhost/shakes",
         "sql": "",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -36,6 +37,7 @@ def test_parse_with_sql():
         "connection": "postgresql://will:longliveliz@localhost/shakes",
         "sql": "SELECT * FROM work",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -44,6 +46,7 @@ def test_parse_sql_only():
         "connection": "",
         "sql": "SELECT * FROM work",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -52,6 +55,7 @@ def test_parse_postgresql_socket_connection():
         "connection": "postgresql:///shakes",
         "sql": "SELECT * FROM work",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -61,6 +65,7 @@ def test_expand_environment_variables_in_connection():
         "connection": "postgresql:///shakes",
         "sql": "SELECT * FROM work",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -69,6 +74,16 @@ def test_parse_shovel_operator():
         "connection": "",
         "sql": "SELECT * FROM work",
         "result_var": "dest",
+        "return_result_var": False,
+    }
+
+
+def test_parse_return_shovel_operator():
+    assert parse("dest= << SELECT * FROM work", empty_config) == {
+        "connection": "",
+        "sql": "SELECT * FROM work",
+        "result_var": "dest",
+        "return_result_var": True,
     }
 
 
@@ -77,6 +92,7 @@ def test_parse_connect_plus_shovel():
         "connection": "sqlite://",
         "sql": "SELECT * FROM work",
         "result_var": "dest",
+        "return_result_var": False,
     }
 
 
@@ -85,6 +101,7 @@ def test_parse_early_newlines():
         "connection": "",
         "sql": "--comment\nSELECT *\n--comment\nFROM work",
         "result_var": None,
+        "return_result_var": False,
     }
 
 
@@ -93,6 +110,7 @@ def test_parse_connect_shovel_over_newlines():
         "connection": "sqlite://",
         "sql": "SELECT *\nFROM work",
         "result_var": "dest",
+        "return_result_var": False,
     }
 
 


### PR DESCRIPTION
Easily capture and print result variables at the same time using new `= <<` syntax.

Closes #418 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--501.org.readthedocs.build/en/501/

<!-- readthedocs-preview jupysql end -->