### PR TITLE
checking custom connections according to PEP 249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.7.6dev
-* [Fix] Custom Connection using sqlalchemy now needs to be PEP 249 Compilant 
+* [Fix] Fix error when checking if custom connection was PEP 249 Compliant 
 ## 0.7.5 (2023-05-24)
 
 * [Feature] Using native DuckDB `.df()` method when using `autopandas`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.7.6dev
-
+* [Fix] Custom Connection using sqlalchemy now needs to be PEP 249 Compilant 
 ## 0.7.5 (2023-05-24)
 
 * [Feature] Using native DuckDB `.df()` method when using `autopandas`

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -117,7 +117,7 @@ def is_pep249_compliant(conn):
     pep249_methods = [
         "close",
         "commit",
-        "rollback",
+        # "rollback",
         # "cursor",
         # PEP 249 doesn't require the connection object to have
         # a cursor method strictly

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -110,6 +110,29 @@ def rough_dict_get(dct, sought, default=None):
     return default
 
 
+def is_pep249_compliant(conn):
+    """
+    Checks if given connection object complies with PEP 249
+    """
+    pep249_methods = [
+        "close",
+        "commit",
+        "rollback",
+        # "cursor",
+        # PEP 249 doesn't require the connection object to have
+        # a cursor method strictly
+        # ref: https://peps.python.org/pep-0249/#id52
+    ]
+
+    for method_name in pep249_methods:
+        # Checking whether the connection object has the method
+        # and if it is callable
+        if not hasattr(conn, method_name) or not callable(getattr(conn, method_name)):
+            return False
+
+    return True
+
+
 class Connection:
     """Manages connections to databases
 
@@ -395,12 +418,9 @@ class Connection:
         else:
             # TODO: Better check when user passes a custom
             # connection
-            if (
-                isinstance(
-                    conn, (sqlalchemy.engine.base.Connection, Connection, str, bool)
-                )
-                or conn.__class__.__name__ == "DataFrame"
-            ):
+            if isinstance(
+                conn, (sqlalchemy.engine.base.Connection, Connection)
+            ) or not (is_pep249_compliant(conn)):
                 is_custom_connection_ = False
             else:
                 is_custom_connection_ = True

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -416,8 +416,6 @@ class Connection:
         if isinstance(conn, (CustomConnection, CustomSession)):
             is_custom_connection_ = True
         else:
-            # TODO: Better check when user passes a custom
-            # connection
             if isinstance(
                 conn, (sqlalchemy.engine.base.Connection, Connection)
             ) or not (is_pep249_compliant(conn)):

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -269,6 +269,12 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
     assert conn._get_curr_sqlalchemy_connection_info() is None
 
 
+class dummy_connection:
+    def __init__(self):
+        self.engine_name = "dummy_engine"
+    def close(self):
+        pass
+
 @pytest.mark.parametrize(
     "conn, expected",
     [
@@ -281,6 +287,7 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
             Connection(engine=sqlalchemy.create_engine("sqlite://")),
             False,
         ],
+        [dummy_connection(), False],
         ["not_a_valid_connection", False],
         [0, False],
     ],
@@ -288,6 +295,7 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
         "sqlite3_connection",
         "custom_connection",
         "normal_connection",
+        "dummy_connection",
         "str",
         "int",
     ],

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -270,21 +270,19 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
 
 
 @pytest.mark.parametrize(
-    "conn, expected, desc",
+    "conn, expected",
     [
-        [sqlite3.connect(""), True, None],
+        [sqlite3.connect(""), True],
         [
             CustomConnection(engine=sqlalchemy.create_engine("sqlite://")),
             True,
-            "custom_driver",
         ],
         [
             Connection(engine=sqlalchemy.create_engine("sqlite://")),
             False,
-            "sqlite://",
         ],
-        ["not_a_valid_connection", False, None],
-        [0, False, None],
+        ["not_a_valid_connection", False],
+        [0, False],
     ],
     ids=[
         "sqlite3_connection",
@@ -294,6 +292,6 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
         "int",
     ],
 )
-def test_custom_connection(conn, expected, desc):
+def test_custom_connection(conn, expected):
     is_custom = Connection.is_custom_connection(conn)
     assert is_custom == expected

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -8,7 +8,7 @@ from sql.connection import Connection, CustomConnection
 from IPython.core.error import UsageError
 import sqlglot
 import sqlalchemy
-import duckdb
+import sqlite3
 
 
 @pytest.fixture
@@ -272,36 +272,28 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
 @pytest.mark.parametrize(
     "conn, expected, desc",
     [
-        [duckdb.connect(database=":memory:"), True, None],
+        [sqlite3.connect(""), True, None],
         [
-            CustomConnection(engine=sqlalchemy.create_engine("duckdb://")),
+            CustomConnection(engine=sqlalchemy.create_engine("sqlite://")),
             True,
-            "duckdb://",
+            "custom_driver",
         ],
         [
-            Connection(engine=sqlalchemy.create_engine("duckdb://")),
+            Connection(engine=sqlalchemy.create_engine("sqlite://")),
             False,
-            "duckdb://",
+            "sqlite://",
         ],
         ["not_a_valid_connection", False, None],
         [0, False, None],
-        [None, False, None],
     ],
     ids=[
-        "duckdb_connection",
+        "sqlite3_connection",
         "custom_connection",
         "normal_connection",
         "str",
         "int",
-        "none_connection",
     ],
 )
 def test_custom_connection(conn, expected, desc):
     is_custom = Connection.is_custom_connection(conn)
     assert is_custom == expected
-
-    if is_custom:
-        if desc:
-            conn.close(desc)
-        else:
-            conn.close()

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -272,8 +272,10 @@ def test_no_current_connection_and_get_info(monkeypatch, mock_database):
 class dummy_connection:
     def __init__(self):
         self.engine_name = "dummy_engine"
+
     def close(self):
         pass
+
 
 @pytest.mark.parametrize(
     "conn, expected",


### PR DESCRIPTION
## Describe your changes
Added PEP 249 compliance to custom connection. 
Checking whether the connection object has `close`, `commit` and `rollback` methods
## Issue number

Closes #433 

## Checklist before requesting a review

- [X] Performed a self-review of my code
- [X] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [X] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [X] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--517.org.readthedocs.build/en/517/

<!-- readthedocs-preview jupysql end -->