### PR TITLE
Fix CI integration local issue

### DIFF
--- a/.github/workflows/ci-integration-db.yaml
+++ b/.github/workflows/ci-integration-db.yaml
@@ -36,7 +36,7 @@ jobs:
           pip install ".[integration]"
           pip install "sqlalchemy>=2"
       - name: Integration Test
-        run:
+        run: |
           # Run the integration test by pytest marker
           python -c "import sqlalchemy; print('Sqlalchemy version ', sqlalchemy.__version__)"
           pytest src/tests/integration --verbose

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -245,7 +245,6 @@ def test_telemetry_execute_command_has_connection_info(
                 reason="Something wrong with sqlplot histogram in snowflake"
             ),
         ),
-        ("ip_with_oracle"),
     ],
 )
 def test_sqlplot_histogram(ip_with_dynamic_db, cell, request, test_table_name_dict):

--- a/src/tests/integration/test_oracle.py
+++ b/src/tests/integration/test_oracle.py
@@ -74,3 +74,36 @@ def test_sqlplot_histogram(ip_with_oracle, cell, request, test_table_name_dict):
     out = ip_with_oracle.run_cell(cell)
 
     assert type(out.result).__name__ in {"Axes", "AxesSubplot"}
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        "%sqlplot boxplot --with plot_something_subset \
+        --table plot_something_subset --column x",
+        "%sqlplot box --with plot_something_subset \
+        --table plot_something_subset --column x",
+        "%sqlplot boxplot --with plot_something_subset \
+        --table plot_something_subset --column x --orient h",
+        "%sqlplot boxplot --with plot_something_subset \
+        --table plot_something_subset --column x",
+    ],
+    ids=[
+        "boxplot",
+        "box",
+        "boxplot-with-horizontal",
+        "boxplot-with",
+    ],
+)
+def test_sqlplot_boxplot(ip_with_oracle, cell, request, test_table_name_dict):
+    # clean current Axes
+    plt.cla()
+    ip_with_oracle.run_cell(
+        f"%sql --save plot_something_subset --no-execute\
+          SELECT * from {test_table_name_dict['plot_something']} \
+            FETCH FIRST 3 ROWS ONLY"
+    )
+
+    out = ip_with_oracle.run_cell(cell)
+
+    assert type(out.result).__name__ in {"Axes", "AxesSubplot"}

--- a/src/tests/integration/test_oracle.py
+++ b/src/tests/integration/test_oracle.py
@@ -76,6 +76,10 @@ def test_sqlplot_histogram(ip_with_oracle, cell, request, test_table_name_dict):
     assert type(out.result).__name__ in {"Axes", "AxesSubplot"}
 
 
+@pytest.mark.xfail(
+    reason="Known table parameter issue with oracledb, \
+                   addressing in #506"
+)
 @pytest.mark.parametrize(
     "cell",
     [


### PR DESCRIPTION
## Describe your changes

- Fix by adding the pipeline symbol | on the run attribute
Ref: https://stackoverflow.com/questions/56726429/how-to-run-multiple-commands-in-one-github-actions-docker
- Add `test_sqlplot_boxplot` in `src/tests/integration/test_oracle.py`, although it's known failing test case
 
Takes 7m+ to run the test:
<img width="1462" alt="Screenshot 2023-05-29 at 10 12 38 AM" src="https://github.com/ploomber/jupysql/assets/123580782/8c4778c4-79d9-4f92-aa38-404b5dd22f8c">


## Issue number

Closes #514

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--535.org.readthedocs.build/en/535/

<!-- readthedocs-preview jupysql end -->