### PR TITLE
pretty table styling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.9dev
 
-* [Fix] Fixed `ResultSet` class to display result table with proper style and added relevant example(#54)
+* [Fix] Fixed `ResultSet` class to display result table with proper style and added relevant example (#54)
 * [Fix] Fixed `Set` method in `Connection` class to recognize same descriptor with different aliases  (#532)
 * [Fix] Added bottom-padding to the buttons in table explorer. Now they are not hidden by the scrollbar (#540)
 * [Feature] Modified `histogram` command to support data with NULL values (#176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.9dev
 
-* [Fix] Fixed `ResultSet` class to display result table with proper style (#54)
+* [Fix] Fixed `ResultSet` class to display result table with proper style and added relevant example(#54)
 * [Fix] Fixed `Set` method in `Connection` class to recognize same descriptor with different aliases  (#532)
 * [Fix] Added bottom-padding to the buttons in table explorer. Now they are not hidden by the scrollbar (#540)
 * [Feature] Modified `histogram` command to support data with NULL values (#176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.9dev
 
+* [Fix] Fixed `ResultSet` class to display result table with proper style (#54)
 * [Fix] Fixed `Set` method in `Connection` class to recognize same descriptor with different aliases  (#532)
 * [Fix] Added bottom-padding to the buttons in table explorer. Now they are not hidden by the scrollbar (#540)
 * [Feature] Modified `histogram` command to support data with NULL values (#176)

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -223,3 +223,21 @@ CREATE TABLE more_points (x, y);
 INSERT INTO more_points VALUES (0, 0);
 INSERT INTO more_points VALUES (1, 1);
 ```
+
+## `style`
+
+DEFAULT: `DEFAULT`
+
+Set the table printing style to any of prettytable's defined styles
+
+```{code-cell} ipython3
+%config SqlMagic.style = "MSWORD_FRIENDLY"
+res = %sql SELECT * FROM languages LIMIT 2
+print(res)
+```
+
+```{code-cell} ipython3
+%config SqlMagic.style = "SINGLE_BORDER"
+res = %sql SELECT * FROM languages LIMIT 2
+print(res)
+```

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -93,7 +93,8 @@ class SqlMagic(Magics, Configurable):
         config=True,
         help=(
             "Set the table printing style to any of prettytable's "
-            "defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)"
+            "defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, "
+            "RANDOM, SINGLE_BORDER, DOUBLE_BORDER, MARKDOWN )"
         ),
     )
     short_errors = Bool(

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -113,7 +113,6 @@ class ResultSet(ColumnGuesserMixin):
         self.config = config
         self.keys = {}
         self._results = []
-
         # https://peps.python.org/pep-0249/#description
         is_dbapi_results = hasattr(sqlaproxy, "description")
 
@@ -143,10 +142,11 @@ class ResultSet(ColumnGuesserMixin):
 
                 _style = None
 
+                self.pretty = PrettyTable(self.field_names)
+
                 if isinstance(config.style, str):
                     _style = prettytable.__dict__[config.style.upper()]
-
-                self.pretty = PrettyTable(self.field_names, style=_style)
+                    self.pretty.set_style(_style)
 
     def _repr_html_(self):
         _cell_with_spaces_pattern = re.compile(r"(<td>)( {2,})")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -40,10 +40,19 @@ def test_print(ip):
     assert re.search(r"1\s+\|\s+foo", str(result))
 
 
-def test_plain_style(ip):
-    ip.run_line_magic("config", "SqlMagic.style = 'PLAIN_COLUMNS'")
+@pytest.mark.parametrize(
+    "style, expected",
+    [
+        ("'PLAIN_COLUMNS'", r"1\s+foo"),
+        ("'DEFAULT'", r" 1 \| foo  \|\n\|"),
+        ("'SINGLE_BORDER'", r"│\n├───┼──────┤\n│ 1 │ foo  │\n│"),
+        ("'MSWORD_FRIENDLY'", r"\n\| 1 \| foo  \|\n\|"),
+    ],
+)
+def test_styles(ip, style, expected):
+    ip.run_line_magic("config", f"SqlMagic.style = {style}")
     result = runsql(ip, "SELECT * FROM test;")
-    assert re.search(r"1\s+\|\s+foo", str(result))
+    assert re.search(expected, str(result))
 
 
 @pytest.mark.skip


### PR DESCRIPTION
## Describe your changes
Modified the ResultSet Class to handle the styling applied to the result table.  Implemented the`set_style` method of `PrettyTable` to apply styling. Now we can apply all the styles supported by `PrettyTable` 

eg:  DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM, SINGLE_BORDER, DOUBLE_BORDER, MARKDOWN
## Issue number

Closes #54 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)

![Screenshot 2023-06-15 at 12 07 07 PM](https://github.com/ploomber/jupysql/assets/69951190/e58ccf59-f741-47e7-bb26-5ee505b24d96)




<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--620.org.readthedocs.build/en/620/

<!-- readthedocs-preview jupysql end -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204812529638430