### PR TITLE
Move feat from %sqlrender to %sqlcmd snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.7.10dev
 * [Feature] Support flexible spacing `myvar=<<` operator ([#525](https://github.com/ploomber/jupysql/issues/525))
-
-* [Feature] Moved feature from `%sqlrender` to `%sqlcmd snippets` (#647)
+* [Feature] Moved `%sqlrender` feature to `%sqlcmd snippets` (#647)
 
 * [Doc] Modified integrations content to ensure they're all consistent (#523)
 * [Doc] Document --persist-replace in API section (#539)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.7.10dev
 * [Feature] Support flexible spacing `myvar=<<` operator ([#525](https://github.com/ploomber/jupysql/issues/525))
 
+* [Feature] Moved feature from `%sqlrender` to `%sqlcmd snippets` (#647)
+
 * [Doc] Modified integrations content to ensure they're all consistent (#523)
 * [Doc] Document --persist-replace in API section (#539)
 * [Fix] Fixed CI issue by updating `invalid_connection_string_duckdb` in `test_magic.py` (#631)

--- a/doc/api/magic-snippets.md
+++ b/doc/api/magic-snippets.md
@@ -5,15 +5,14 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.14.6
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
 myst:
   html_meta:
-    description lang=en: Documentation for  %sqlcmd snippets
-      from JupySQL
+    description lang=en: Documentation for  %sqlcmd snippets from JupySQL
     keywords: jupyter, sql, jupysql, snippets
     property=og:locale: en_US
 ---
@@ -73,6 +72,8 @@ Returns all the snippets saved in the environment
 
 Arguments:
 
+`{snippet_name}` Return a snippet.
+
 `-d`/`--delete` Delete a snippet.
 
 `-D`/`--delete-force` Force delete a snippet. This may be useful if there are other dependent snippets, and you still need to delete this snippet.
@@ -80,7 +81,13 @@ Arguments:
 `-A`/`--delete-force-all` Force delete a snippet and all dependent snippets.
 
 ```{code-cell} ipython3
+cte = %sqlcmd snippets gentoo
+print(cte)
+```
 
+This returns the stored snippet `gentoo`.
+
+```{code-cell} ipython3
 %sqlcmd snippets -d gentoo
 ```
 
@@ -94,7 +101,6 @@ To demonstrate `force-delete` let's create a snippet dependent on `chinstrap` sn
 %%sql --save chinstrap_sub
 SELECT * FROM chinstrap where island == 'Dream'
 ```
-+++
 
 Trying to delete the `chinstrap` snippet will display an error message:
 
@@ -107,7 +113,6 @@ Trying to delete the `chinstrap` snippet will display an error message:
 If you still wish to delete this snippet, you can run the below command:
 
 ```{code-cell} ipython3
-
 %sqlcmd snippets -D chinstrap
 ```
 
@@ -130,6 +135,5 @@ SELECT * FROM chinstrap where island == 'Dream'
 Now, force delete `chinstrap` and its dependent `chinstrap_sub`:
 
 ```{code-cell} ipython3
-
 %sqlcmd snippets -A chinstrap
 ```

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -72,6 +72,13 @@ class RenderMagic(Magics):
     @telemetry.log_call("sqlrender")
     def sqlrender(self, line):
         args = parse_argstring(self.sqlrender, line)
+        warnings.warn(
+            "'%sqlrender' will be deprecated soon, "
+            f"please use '%sqlcmd snippets {args.line[0]}' instead. "
+            "For documentation, follow this link : "
+            "https://jupysql.ploomber.io/en/latest/api/magic-snippets.html#id1",
+            FutureWarning,
+        )
         return str(store[args.line[0]])
 
 

--- a/src/sql/sqlcmd.py
+++ b/src/sql/sqlcmd.py
@@ -1,6 +1,7 @@
 from sql.magic_cmd import CmdParser
 from sql import util
 from sql.exceptions import UsageError
+from sql.store import store
 
 
 def _modify_display_msg(key, remaining_keys, dependent_keys=None):
@@ -58,6 +59,8 @@ def sqlcmd_snippets(others):
         help="Force delete all stored snippets",
         required=False,
     )
+    if len(others) == 1 and others[0] in util.get_all_keys():
+        return str(store[others[0]])
     args = parser.parse_args(others)
     SNIPPET_ARGS = [args.delete, args.delete_force, args.delete_force_all]
     if SNIPPET_ARGS.count(None) == len(SNIPPET_ARGS):

--- a/src/tests/test_magic_cte.py
+++ b/src/tests/test_magic_cte.py
@@ -25,9 +25,7 @@ SELECT * FROM positive_y;
 """
     )
 
-    cell_final_query = ip.run_cell(
-        "%sqlrender final --with positive_x --with positive_y"
-    )
+    cell_final_query = ip.run_cell("%sqlcmd snippets final")
 
     assert cell_execution.success
     assert cell_final_query.result == (
@@ -51,7 +49,7 @@ def test_infer_dependencies(ip, capsys):
         "SELECT last_name FROM author_sub;",
     )
     out, _ = capsys.readouterr()
-    result = ip.run_cell("%sqlrender final").result
+    result = ip.run_cell("%sqlcmd snippets final").result
     expected = (
         "WITH `author_sub` AS (\nSELECT last_name FROM author "
         "WHERE year_of_death > 1900)\nSELECT last_name FROM author_sub;"
@@ -168,7 +166,7 @@ def test_snippets_delete(ip, capsys):
         INNER JOIN customers ON o.customer_id=customers.customer_id;
         """,
     )
-    result = ip.run_cell("%sqlrender final").result
+    result = ip.run_cell("%sqlcmd snippets final").result
     expected = (
         "WITH\n\n        SELECT o.order_id, customers.name, "
         "o.order_value\n        "

--- a/src/tests/test_telemetry.py
+++ b/src/tests/test_telemetry.py
@@ -112,8 +112,10 @@ def test_data_frame_telemetry_execution(mock_log_api, ip, simple_file_path_iris)
     )
 
 
-def test_sqlrender_telemetry_execution(mock_log_api, ip, simple_file_path_iris):
-    # Simulate the sqlrender query
+def test_sqlcmd_snippets_query_telemetry_execution(
+    mock_log_api, ip, simple_file_path_iris
+):
+    # Simulate the sqlcmd snippets query
     ip.run_cell("%sql duckdb://")
     ip.run_cell(
         "%sql --save class_setosa --no-execute "
@@ -122,10 +124,10 @@ def test_sqlrender_telemetry_execution(mock_log_api, ip, simple_file_path_iris):
         + "')"
         + " WHERE class='Iris-setosa'"
     )
-    ip.run_cell("%sqlrender class_setosa")
+    ip.run_cell("%sqlcmd snippets class_setosa")
 
     mock_log_api.assert_called_with(
-        action="jupysql-sqlrender-success", total_runtime=ANY, metadata=ANY
+        action="jupysql-execute-success", total_runtime=ANY, metadata=ANY
     )
 
 


### PR DESCRIPTION
## Describe your changes

Moved `%sqlrender` feature to `%sqlcmd snippets`, added FutureWarning when user call `%sqlrender`, modified API Reference documentation, and modified test functions to test `%sqlcmd snippets {snippet_name}`

## Issue number

Closes #647 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--656.org.readthedocs.build/en/656/

<!-- readthedocs-preview jupysql end -->