### PR TITLE
removing `with` when no dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [Doc] Document --persist-replace in API section (#539)
 * [Fix] Fixed CI issue by updating `invalid_connection_string_duckdb` in `test_magic.py` (#631)
 * [Fix] Refactored `ResultSet` to lazy loading (#470)
+* [Fix] Removed `WITH` when a snippet does not have a dependency (#657)
 
 ## 0.7.9 (2023-06-19)
 

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -130,6 +130,9 @@ class SQLQuery:
         template = (
             with_clause_template_backtick if is_use_backtick else with_clause_template
         )
+        # return query without 'with' when no dependency exists
+        if len(with_all) == 0:
+            return self._query.strip()
         return template.render(
             query=self._query,
             saved=self._store._data,

--- a/src/tests/test_magic_cte.py
+++ b/src/tests/test_magic_cte.py
@@ -170,7 +170,7 @@ def test_snippets_delete(ip, capsys):
     )
     result = ip.run_cell("%sqlrender final").result
     expected = (
-        "WITH\n\n        SELECT o.order_id, customers.name, "
+        "SELECT o.order_id, customers.name, "
         "o.order_value\n        "
         "FROM another_orders o\n        INNER JOIN customers "
         "ON o.customer_id=customers.customer_id"


### PR DESCRIPTION
## Describe your changes

Remove `WITH` when rendering a snippet when the snippet does not have a dependency

## Issue number

Closes #657 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--673.org.readthedocs.build/en/673/

<!-- readthedocs-preview jupysql end -->