### PR TITLE
fix "too many open files" when running tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -60,7 +60,6 @@ def ip_empty():
     c.HistoryAccessor.enabled = False
     ip_session = InteractiveShell(config=c)
 
-    # ip_session = InteractiveShell()
     ip_session.register_magics(SqlMagic)
     ip_session.register_magics(RenderMagic)
     ip_session.register_magics(SqlPlotMagic)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,9 +1,11 @@
+from traitlets.config import Config
 import os
 import urllib.request
 from pathlib import Path
 
 import pytest
 from IPython.core.interactiveshell import InteractiveShell
+
 
 from sql.magic import SqlMagic, RenderMagic
 from sql.magic_plot import SqlPlotMagic
@@ -50,7 +52,15 @@ def clean_conns():
 
 @pytest.fixture
 def ip_empty():
-    ip_session = InteractiveShell()
+    c = Config()
+    # By default, InteractiveShell will record command's history in a SQLite database
+    # which leads to "too many open files" error when running tests; this setting
+    # disables the history recording.
+    # https://ipython.readthedocs.io/en/stable/config/options/terminal.html#configtrait-HistoryAccessor.enabled
+    c.HistoryAccessor.enabled = False
+    ip_session = InteractiveShell(config=c)
+
+    # ip_session = InteractiveShell()
     ip_session.register_magics(SqlMagic)
     ip_session.register_magics(RenderMagic)
     ip_session.register_magics(SqlPlotMagic)
@@ -107,6 +117,7 @@ def tmp_empty(tmp_path):
     Create temporary path using pytest native fixture,
     them move it, yield, and restore the original path
     """
+
     old = os.getcwd()
     os.chdir(str(tmp_path))
     yield str(Path(tmp_path).resolve())


### PR DESCRIPTION
## Describe your changes

Fixed an issue that caused errors when running unit tests.

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--696.org.readthedocs.build/en/696/

<!-- readthedocs-preview jupysql end -->