### PR TITLE
Fixed Integration tests command getting stuck #644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [Doc] Document --persist-replace in API section (#539)
 * [Fix] Fixed CI issue by updating `invalid_connection_string_duckdb` in `test_magic.py` (#631)
 * [Fix] Refactored `ResultSet` to lazy loading (#470)
-* [Fix] Removed `WITH` when a snippet does not have a dependency (#657)
+* [Fix] Fixed Integration tests command getting stuck when database driver is not available. (#644)
 
 ## 0.7.9 (2023-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [Doc] Document --persist-replace in API section (#539)
 * [Fix] Fixed CI issue by updating `invalid_connection_string_duckdb` in `test_magic.py` (#631)
 * [Fix] Refactored `ResultSet` to lazy loading (#470)
+* [Fix] Removed `WITH` when a snippet does not have a dependency (#657)
 * [Fix] Fixed Integration tests command getting stuck when database driver is not available. (#644)
 
 ## 0.7.9 (2023-06-19)

--- a/doc/user-guide/py-scripts.md
+++ b/doc/user-guide/py-scripts.md
@@ -83,7 +83,7 @@ The percent format is also supported by `PyCharm Professional`:
 
 ![pycharm](../static/pycharm-interactive.png)
 
-[Click here](https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format) for more details on the percent format.
+[Click here](https://jupytext.readthedocs.io/en/latest/formats-scripts.html#the-percent-format) for more details on the percent format.
 
 ## Programmatic Execution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pytest.ini_options]
 addopts = "--pdbcls=IPython.terminal.debugger:Pdb"
+testpaths = ["src/tests/"]
 
 [tool.pkgmt]
 github = "ploomber/jupysql"

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -189,8 +189,7 @@ def database_ready(
             print(f"{database} is initialized successfully")
             return True
         except ModuleNotFoundError as e:
-            msg = "Please install " + e.name.lower() + " first!"
-            pytest.exit(msg)
+            raise BaseException("Please install {} first!".format(e.name))
         except Exception as e:
             print(type(e))
             errors.append(str(e))

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -7,7 +7,6 @@ from docker import errors
 from sqlalchemy.engine import URL
 import os
 import sqlalchemy
-import pytest
 
 TMP_DIR = "tmp"
 

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -7,6 +7,7 @@ from docker import errors
 from sqlalchemy.engine import URL
 import os
 import sqlalchemy
+import pytest
 
 TMP_DIR = "tmp"
 
@@ -187,6 +188,9 @@ def database_ready(
             eng.close()
             print(f"{database} is initialized successfully")
             return True
+        except ModuleNotFoundError as e:
+            msg = "Please install " + e.name.lower() + " first!"
+            pytest.exit(msg)
         except Exception as e:
             print(type(e))
             errors.append(str(e))


### PR DESCRIPTION
## Describe your changes
- Added testpaths to pyproject.toml for pytest to look for test in that directory only and reduce test collection time.
- Added pytest exit method to _testing.py for exiting the test script in case of unavailability of database connection library.

## Issue number

Closes #644 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--704.org.readthedocs.build/en/704/

<!-- readthedocs-preview jupysql end -->