### PR TITLE
Solution for MSSQL integration tests getting stuck #645

### DIFF
--- a/doc/community/developer-guide.md
+++ b/doc/community/developer-guide.md
@@ -353,6 +353,14 @@ To run some of the tests:
 pytest src/tests/integration/test_generic_db_operations.py::test_profile_query
 ```
 
+```{important}
+There are tests which check compatibility of  Microsoft SQL Server. In order to run them you you will need to install the ODBC driver for SQL Server (https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16). 
+
+Instructions for Linux can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16
+Instructions for MAC can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16
+```
+
+
 ### Integration tests with cloud databases
 
 We run integration tests against cloud databases like Snowflake, which requires using pre-registered accounts to evaluate their behavior. To initiate these tests, please create a branch in our [ploomber/jupyter repository](https://github.com/ploomber/jupysql).

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -7,8 +7,37 @@ from docker import errors
 from sqlalchemy.engine import URL
 import os
 import sqlalchemy
+import pyodbc
 
 TMP_DIR = "tmp"
+
+
+
+def is_driver_installed(data_base_name):
+    """
+    In the event the database being used is MSSQL, tests if ODBC driver for SQL Server has been installed.
+    throws RunTimeError if suitable driver absent
+
+    Args:
+        data_base_name (string): describes type of database being used for the test
+
+    Returns:
+        bool : whether suitable drivers are in place for test to proceed
+    """
+    raise_error_flag = True
+    if data_base_name != "MSSQL":
+        raise_error_flag = False
+    else:
+        drivers =  pyodbc.drivers()
+        for driver in drivers:
+            if 'ODBC Driver' in driver:
+                raise_error_flag = False
+    if raise_error_flag:
+        raise RuntimeError(f''' The driver  ODBC driver for SQL Server is required for using  Microsoft SQL Server. It has not been installed.
+            Install it from https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16.
+            Instructions for Linux can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16
+            Instructions for MAC can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16 ''')
+
 
 
 class DatabaseConfigHelper:
@@ -178,6 +207,7 @@ def database_ready(
     :type timeout: float
     :type poll_freq: float
     """
+    is_driver_installed(database)
     errors = []
 
     t0 = time.time()

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -7,36 +7,10 @@ from docker import errors
 from sqlalchemy.engine import URL
 import os
 import sqlalchemy
-import pyodbc
 
 TMP_DIR = "tmp"
 
 
-
-def is_driver_installed(data_base_name):
-    """
-    In the event the database being used is MSSQL, tests if ODBC driver for SQL Server has been installed.
-    throws RunTimeError if suitable driver absent
-
-    Args:
-        data_base_name (string): describes type of database being used for the test
-
-    Returns:
-        bool : whether suitable drivers are in place for test to proceed
-    """
-    raise_error_flag = True
-    if data_base_name != "MSSQL":
-        raise_error_flag = False
-    else:
-        drivers =  pyodbc.drivers()
-        for driver in drivers:
-            if 'ODBC Driver' in driver:
-                raise_error_flag = False
-    if raise_error_flag:
-        raise RuntimeError(f''' The driver  ODBC driver for SQL Server is required for using  Microsoft SQL Server. It has not been installed.
-            Install it from https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16.
-            Instructions for Linux can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver16
-            Instructions for MAC can be found at https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16 ''')
 
 
 
@@ -207,7 +181,6 @@ def database_ready(
     :type timeout: float
     :type poll_freq: float
     """
-    is_driver_installed(database)
     errors = []
 
     t0 = time.time()
@@ -218,8 +191,11 @@ def database_ready(
             print(f"{database} is initialized successfully")
             return True
         except Exception as e:
-            print(type(e))
             errors.append(str(e))
+            if type(e) != sqlalchemy.exc.OperationalError:                
+                errors_ = "\n".join(errors)
+                print(f"ERRORS: {errors_}")
+                return True            
 
         time.sleep(poll_freq)
 


### PR DESCRIPTION
In the  database_ready method of ./src/sql/_testing.py, connection to the database is atttempted for 60 seconds, at an interval of every half a second.  When the driver is absent, this goes on for the entire 60 seconds.

 Reducing the number of attemtps is not suggested.  Even when driver is present  multiple attempts are often needed before sql.create_engine can connect to the database. 
 
 A function has been added to explicitly check if the driver is present, throws a runtime error, and displays appropriate message. Also suitable edits to the doumentation have been made. 
 
@edublancas
 @neelasha23
@yafimvo


<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--715.org.readthedocs.build/en/715/

<!-- readthedocs-preview jupysql end -->