### PR TITLE
snippets display improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [Feature] Support flexible spacing `myvar=<<` operator ([#525](https://github.com/ploomber/jupysql/issues/525))
 * [Feature] Added a line under `ResultSet` to distinguish it from data frame and error message when invalid operations are performed (#468)
 * [Feature] Moved `%sqlrender` feature to `%sqlcmd snippets` (#647)
+* [Feature] Added tables listing stored snippets when `%sqlcmd snippets` is called (#648)
 
 * [Doc] Modified integrations content to ensure they're all consistent (#523)
 * [Doc] Document --persist-replace in API section (#539)

--- a/src/sql/cmd/snippets.py
+++ b/src/sql/cmd/snippets.py
@@ -2,6 +2,7 @@ from sql import util
 from sql.exceptions import UsageError
 from sql.cmd.cmd_utils import CmdParser
 from sql.store import store
+from sql.display import Table, Message
 
 
 def _modify_display_msg(key, remaining_keys, dependent_keys=None):
@@ -63,8 +64,8 @@ def snippets(others):
         help="Force delete all stored snippets",
         required=False,
     )
+    all_snippets = util.get_all_keys()
     if len(others) == 1:
-        all_snippets = util.get_all_keys()
         if others[0] in all_snippets:
             return str(store[others[0]])
 
@@ -80,7 +81,11 @@ def snippets(others):
     args = parser.parse_args(others)
     SNIPPET_ARGS = [args.delete, args.delete_force, args.delete_force_all]
     if SNIPPET_ARGS.count(None) == len(SNIPPET_ARGS):
-        return ", ".join(util.get_all_keys())
+        if len(all_snippets) == 0:
+            return Message("No snippets stored")
+        else:
+            return Table(["Stored snippets"], [[snippet] for snippet in all_snippets])
+
     if args.delete:
         deps = util.get_key_dependents(args.delete)
         if deps:


### PR DESCRIPTION
## Describe your changes

Change `%sqlcmd snippets` output into displaying 1. snippet name 2. snippet query 3. snippet table. 

Still working on 1. figuring out how to retrieve `SqlMagic.displaylimit` 2. adding test functions 3. update documentation if needed, but I want to know whether it's on the right direction or not.

## Issue number

Closes #648 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--716.org.readthedocs.build/en/716/

<!-- readthedocs-preview jupysql end -->