### PR TITLE
clean up _get_curr_sqlglot_dialect

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -542,7 +542,6 @@ class Connection:
             "server_version_info": getattr(engine.dialect, "server_version_info", None),
         }
 
-    # TODO: we have self.dialect and we also have this, which is confusing, see #732
     def _get_curr_sqlglot_dialect(self):
         """Get the dialect name in sqlglot package scope
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -552,12 +552,12 @@ class Connection:
             Available dialect in sqlglot package, see more:
             https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/dialect.py
         """
-        connection_info = self._get_curr_sqlalchemy_connection_info()
-        if not connection_info:
+
+        if not self.dialect:
             return None
 
         return DIALECT_NAME_SQLALCHEMY_TO_SQLGLOT_MAPPING.get(
-            connection_info["dialect"], connection_info["dialect"]
+            self.dialect, self.dialect
         )
 
     def is_use_backtick_template(self):


### PR DESCRIPTION
## Describe your changes

Hi team! Hope you’re doing great. After diving into the use cases of the `_get_curr_sqlglot_dialect` method and `Connection.dialect `attribute I came to the conclusion that `_get_curr_sqlglot_dialect` implementation can be simplified. 

My reasoning is the following:
The method `_get_curr_sqlglot_dialect` calls `_get_curr_sqlalchemy_connection_info` method, which gets the dialect on its own from the engine attribute (through metadata and session attributes). This same engine is the one used in the class initializer to set the dialect attribute. As I browsed through the code, there are very few spots in the codebase where `_get_curr_sqlglot_dialect` method is used (opposed to accessing the dialect attribute). 

I concluded also that the method in question, `_get_curr_sqlglot_dialect` , cannot be deleted since callers of the function expect the mapping provided by `DIALECT_NAME_SQLALCHEMY_TO_SQLGLOT_MAPPING`.

Please let me know your thoughts, so we can align the solution in the same path. Feedback is very well appreciated! Thank you so much!


## Issue number

Closes #732

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)


<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--747.org.readthedocs.build/en/747/

<!-- readthedocs-preview jupysql end -->