### PR TITLE
`ip.run_cell` now raises exceptions immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Fix] Modified histogram query to ensure histogram binning is done correctly (#751)
 * [Fix] Fix bug that caused the `COMMIT` not to work when the SQLAlchemy driver did not support `set_isolation_level`
 * [Fix] Fixed vertical color breaks in histograms (#702)
+* [Fix] Fix error that caused some connections not to be closed when calling `--close/-x`
 
 ## 0.8.0 (2023-07-18)
 

--- a/doc/community/developer-guide.md
+++ b/doc/community/developer-guide.md
@@ -161,8 +161,9 @@ This guide will show you the basics of writing unit tests for JupySQL magics. Ma
 
 In the unit testing suite, there are a few pytest fixtures that prepare the environment so you can get started:
 
-- `ip_empty` - Empty IPython session
-- `ip` - IPython session with some sample data and a SQLIte connection
+- `ip_empty` - Empty IPython session (no database connections, no data)
+- `ip` - IPython session with some sample data and a SQLite connection
+- To check the other available fixtures, see the `conftest.py` files
 
 So a typical test will look like this:
 
@@ -180,7 +181,7 @@ def test_something(ip):
 To see some sample tests, [click here.](https://github.com/ploomber/jupysql/blob/master/src/tests/test_magic.py)
 
 
-The `ip` object is an IPython sessions that is created like this:
+The `ip` object is an IPython session that is created like this:
 
 ```{code-cell} ipython3
 from sql._testing import TestingShell

--- a/doc/community/developer-guide.md
+++ b/doc/community/developer-guide.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.14.7
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -31,7 +31,7 @@ You can launch a new github codespace from the green "Code" button on [the JupyS
 Note that setup will take a few minutes to finish after the codespace becomes available (wait for the **postCreateCommand** step to finish).
 ![JupySQL github codespace](../static/github-codespace-setup.png)
 
-After the codespace has finished setting up, you can run `conda activate jupysql` to activate the JupySQL Conda environment. 
+After the codespace has finished setting up, you can run `conda activate jupysql` to activate the JupySQL Conda environment.
 
 +++
 
@@ -54,7 +54,6 @@ message("Some information")
 ```{code-cell} ipython3
 message_success("Some operation finished successfully!")
 ```
-
 
 ## Throwing errors
 
@@ -106,11 +105,13 @@ Currently, these common errors are handled by providing more meaningful error me
 
 ## Managing Connections
 
-In our codebase, we manage connections to databases with a `SQLAlchemy` and `DBAPIConnection` objects, this is required for the `%%sql magic` to work.
+In our codebase, we establish connections to databases with `SQLAlchemyConnection` and `DBAPIConnection` objects (they have the same interface).
+
+Furthermore, we have a `ConnectionManager` to manage all the connections.
 
 ### Working with connections
 
-`ConnectionManager` should be exclusively used to manage database connections on the user's behalf and to obtain the current connection. We can access the current connection using `current`.
+We can access the current connection using `ConnectionManager.current`.
 
 ```{code-cell} ipython3
 :tags: [remove-output]
@@ -125,47 +126,16 @@ from sql.connection import ConnectionManager
 conn = ConnectionManager.current
 conn
 ```
+
  
-Functions that expect a `conn` (sometimes named `con`) input variable should only use connections.
+Functions that expect a `conn` (sometimes named `con`) input variable should only use connection objects.
 
 ```python
 def histogram(payload, table, column, bins, with_=None, conn=None):
     pass
 ```
 
-### Tests
-
-When creating data for tests, we should use `sqlalchemy.create_engine` and avoid using native driver functions (e.g. `sqlite3.connect` or `duckdb.connect`) to ensure consistency.
-
-```{code-cell} ipython3
-from sqlalchemy import create_engine
-from sql.connection import SQLAlchemyConnection
-
-conn = SQLAlchemyConnection(engine=create_engine("sqlite://"))
-
-conn.execute("CREATE TABLE some_table (name, age)")
-```
-
-### Non SQLAlchemy supported engines
-
-When working with engines that are not supported by SQLAlchemy, e.g. `QuestDB`, we won't be able to use `sqlalchemy.create_engine`.
-Instead, we should initiate an engine using the native method and use the `DBAPIConnection` object.
-
-```python
-import psycopg as pg
-from sql.connection import DBAPIConnection
-
-engine = pg.connect("dbname='qdb' user='admin' host='127.0.0.1' port='8812' password='quest'")
-conn = DBAPIConnection(engine)
-
-plot.histogram("my_table", "column_name", bins=50, conn=conn)
-```
-
-For a full example on how to use JupySQL with a non SQLAlchemy supported engine please see [QuestDB](./../integrations/questdb).
-
-```{note}
-Please be advised that there may be some features/functionalities that won't be fully compatible with JupySQL when using `DBAPIConnection`.
-```
++++
 
 ## Unit testing
 
@@ -192,13 +162,12 @@ This guide will show you the basics of writing unit tests for JupySQL magics. Ma
 In the unit testing suite, there are a few pytest fixtures that prepare the environment so you can get started:
 
 - `ip_empty` - Empty IPython session
-- `ip` - IPython session with some sample data
+- `ip` - IPython session with some sample data and a SQLIte connection
 
 So a typical test will look like this:
 
 ```{code-cell} ipython3
 def test_something(ip):
-    ip.run_cell("%sql sqlite://")
     result = ip.run_cell(
         """%%sql
     SELECT * FROM test
@@ -211,13 +180,13 @@ def test_something(ip):
 To see some sample tests, [click here.](https://github.com/ploomber/jupysql/blob/master/src/tests/test_magic.py)
 
 
-The IPython sessions are created like this:
+The `ip` object is an IPython sessions that is created like this:
 
 ```{code-cell} ipython3
-from IPython.core.interactiveshell import InteractiveShell
+from sql._testing import TestingShell
 from sql.magic import SqlMagic
 
-ip_session = InteractiveShell()
+ip_session = TestingShell()
 ip_session.register_magics(SqlMagic)
 ```
 
@@ -233,50 +202,7 @@ To test the output:
 assert out.result == 2
 ```
 
-You can also check for execution success:
-
-```{code-cell} ipython3
-assert out.success
-```
-
-```{important}
-Always check for success! Since `run_cell` won't raise an error if the code fails
-```
-
-```{code-cell} ipython3
-try:
-    ip_session.run_cell("1 / 0")
-except Exception as e:
-    print(f"Error: {e}")
-else:
-    print("No error")
-```
-
-Note that the `run_cell` only printed the error but did not raise an exception.
-
-+++
-
-#### Capturing errors
-
-Let's see how to test that the code raises an expected error:
-
-```{code-cell} ipython3
-out = ip_session.run_cell("1 / 0")
-```
-
-```{code-cell} ipython3
-# this returns the raised exception
-out.error_in_exec
-```
-
-```{code-cell} ipython3
-:tags: [raises-exception]
-
-# this raises the error
-out.raise_error()
-```
-
-You can then use pytest to check the error:
+You can then use pytest to check for errors:
 
 ```{code-cell} ipython3
 import pytest
@@ -284,14 +210,14 @@ import pytest
 
 ```{code-cell} ipython3
 with pytest.raises(ZeroDivisionError):
-    out.raise_error()
+    ip_session.run_cell("1 / 0")
 ```
 
 To check the error message:
 
 ```{code-cell} ipython3
 with pytest.raises(ZeroDivisionError) as excinfo:
-    out.raise_error()
+    ip_session.run_cell("1 / 0")
 ```
 
 ```{code-cell} ipython3

--- a/doc/community/developer-guide.md
+++ b/doc/community/developer-guide.md
@@ -89,7 +89,7 @@ These errors that hide the traceback should only be used in the context of a mag
 
 ### Unit testing custom errors
 
-The internal implementation of `sql.exceptions` is a workaround due to some IPython limitations; in consequence, you need to test for `IPython.error.UsageError` when testing, see `test_util.py` for examples.
+The internal implementation of `sql.exceptions` is a workaround due to some IPython limitations; in consequence, you need to test for `IPython.error.UsageError` when testing, see `test_util.py` for examples, and `exceptions.py` for more details.
 
 +++
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ DEV = [
     # for running tests for %sqlcmd explore --table
     "js2py",
     "jupysql-plugin",
+    # for monitoring access to files
+    "psutil",
 ]
 
 # dependencies for running integration tests

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -1,10 +1,11 @@
+import os
 from contextlib import contextmanager
 import sys
 import time
 
 from sqlalchemy.engine import URL
-import os
 import sqlalchemy
+from IPython.core.interactiveshell import InteractiveShell
 
 from ploomber_core.dependencies import requires
 
@@ -23,6 +24,21 @@ except ModuleNotFoundError:
 
 
 TMP_DIR = "tmp"
+
+
+class TestingShell(InteractiveShell):
+    """
+    A custom InteractiveShell that raises exceptions instead of silently suppressing
+    them.
+    """
+
+    def run_cell(self, *args, **kwargs):
+        result = super().run_cell(*args, **kwargs)
+
+        if result.error_in_exec is not None:
+            raise result.error_in_exec
+
+        return result
 
 
 class DatabaseConfigHelper:

--- a/src/sql/cmd/test.py
+++ b/src/sql/cmd/test.py
@@ -174,7 +174,7 @@ def test(others):
                     _pretty.add_row(row)
                 print(_pretty)
         raise exceptions.UsageError(
-            "The above values do not not match your test requirements."
+            "The above values do not match your test requirements."
         )
     else:
         return True

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -1,9 +1,10 @@
+from pathlib import Path
 from IPython.core.magic_arguments import parse_argstring
 from jinja2 import Template
 
 from sqlalchemy.engine import Engine
 
-from sql import parse
+from sql import parse, exceptions
 from sql.store import store
 from sql.connection import ConnectionManager, is_pep249_compliant
 
@@ -57,8 +58,12 @@ class SQLCommand:
         self.command_text = " ".join(line_for_command) + "\n" + cell
 
         if self.args.file:
-            with open(self.args.file, "r") as infile:
-                self.command_text = infile.read() + "\n" + self.command_text
+            try:
+                file_contents = Path(self.args.file).read_text()
+            except FileNotFoundError as e:
+                raise exceptions.FileNotFoundError(str(e)) from e
+
+            self.command_text = file_contents + "\n" + self.command_text
 
         self.parsed = parse.parse(self.command_text, magic)
 

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -239,7 +239,6 @@ class ConnectionManager:
     @classmethod
     def close_connection_with_descriptor(cls, descriptor):
         """Close a connection with the given descriptor"""
-
         if isinstance(descriptor, SQLAlchemyConnection):
             conn = descriptor
         else:
@@ -260,7 +259,7 @@ class ConnectionManager:
                 str(conn.metadata.bind.url) if IS_SQLALCHEMY_ONE else str(conn.url)
             )
 
-        conn.connection.close()
+        conn.close()
 
     @classmethod
     def connections_table(cls):
@@ -529,6 +528,13 @@ class SQLAlchemyConnection(AbstractConnection):
     def connection(self):
         """Returns the SQLAlchemy connection object"""
         return self._connection_sqlalchemy
+
+    def close(self):
+        super().close()
+
+        # NOTE: in SQLAlchemy 2.x, we need to call engine.dispose() to completely
+        # close the connection, calling connection.close() is not enough
+        self.connection.engine.dispose()
 
     @classmethod
     @modify_exceptions

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -239,12 +239,14 @@ class ConnectionManager:
     @classmethod
     def close_connection_with_descriptor(cls, descriptor):
         """Close a connection with the given descriptor"""
+
         if isinstance(descriptor, SQLAlchemyConnection):
             conn = descriptor
         else:
             conn = cls.connections.get(descriptor) or cls.connections.get(
                 descriptor.lower()
             )
+
         if not conn:
             raise exceptions.RuntimeError(
                 "Could not close connection because it was not found amongst these: %s"
@@ -257,7 +259,8 @@ class ConnectionManager:
             cls.connections.pop(
                 str(conn.metadata.bind.url) if IS_SQLALCHEMY_ONE else str(conn.url)
             )
-            conn.connection.close()
+
+        conn.connection.close()
 
     @classmethod
     def connections_table(cls):

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -1,3 +1,15 @@
+"""
+In most scenarios, users don't care about the full Python traceback because it's
+irrelevant to them (they run SQL, not Python code). Hence, when raising errors,
+we only display the error message. This is possible via IPython.core.error.UsageError:
+IPython/Jupyter automatically detect this error and hide the traceback.
+Unfortunately, IPython.core.error.UsageError isn't the most appropriate error type for
+all scenarios, so we define our own error types here. The main caveat is that due to a
+bug in IPython (https://github.com/ipython/ipython/issues/14024), subclassing
+IPython.core.error.UsageError doesn't work, so `exception_factory` is a workaround
+to create new errors that are IPython.core.error.UsageError but with a different name.
+
+"""
 from IPython.core import error
 
 

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -26,7 +26,7 @@ MissingPackageError = exception_factory("MissingPackageError")
 TypeError = exception_factory("TypeError")
 RuntimeError = exception_factory("RuntimeError")
 ValueError = exception_factory("ValueError")
-
+FileNotFoundError = exception_factory("FileNotFoundError")
 
 # The following are internal exceptions that should not be raised directly
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -443,8 +443,7 @@ class SqlMagic(Magics, Configurable):
                         raw_args = raw_args[1:-1]
                 args.connection_arguments = json.loads(raw_args)
             except Exception as e:
-                display.message(str(e))
-                raise e
+                raise exceptions.ValueError(str(e)) from e
         else:
             args.connection_arguments = {}
         if args.creator:

--- a/src/sql/run/pgspecial.py
+++ b/src/sql/run/pgspecial.py
@@ -50,3 +50,6 @@ class FakeResultProxy(object):
                 pos += size
 
         self.fetchmany = fetchmany
+
+    def close(self):
+        pass

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -43,8 +43,6 @@ class SQLStore(MutableMapping):
         self._data[key] = value
 
     def __getitem__(self, key) -> str:
-        if not self._data:
-            raise exceptions.UsageError("No saved SQL")
         if key not in self._data:
             matches = difflib.get_close_matches(key, self._data)
             error = f'"{key}" is not a valid snippet identifier.'

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -105,32 +105,12 @@ def ip_empty():
 
 
 @pytest.fixture
-def ip_empty_testing():
-    c = Config()
-    c.HistoryAccessor.enabled = False
-    ip_session = TestingShell(config=c)
-
-    ip_session.register_magics(SqlMagic)
-    ip_session.register_magics(RenderMagic)
-    ip_session.register_magics(SqlPlotMagic)
-    ip_session.register_magics(SqlCmdMagic)
-
-    # there is some weird bug in ipython that causes this function to hang the pytest
-    # process when all tests have been executed (an internal call to gc.collect()
-    # hangs). This is a workaround.
-    ip_session.displayhook.flush = lambda: None
-
-    yield ip_session
-    ConnectionManager.close_all()
-
-
-@pytest.fixture
-def ip(ip_empty_testing):
+def ip(ip_empty):
     """Provides an IPython session in which tables have been created"""
 
     # runsql creates an inmemory sqlitedatabase
     runsql(
-        ip_empty_testing,
+        ip_empty,
         [
             "CREATE TABLE test (n INT, name TEXT)",
             "INSERT INTO test VALUES (1, 'foo')",
@@ -159,14 +139,14 @@ def ip(ip_empty_testing):
             "INSERT INTO number_table VALUES (4, 3)",
         ],
     )
-    yield ip_empty_testing
+    yield ip_empty
 
     ConnectionManager.close_all()
 
-    runsql(ip_empty_testing, "DROP TABLE IF EXISTS test")
-    runsql(ip_empty_testing, "DROP TABLE IF EXISTS author")
-    runsql(ip_empty_testing, "DROP TABLE IF EXISTS website")
-    runsql(ip_empty_testing, "DROP TABLE IF EXISTS number_table")
+    runsql(ip_empty, "DROP TABLE IF EXISTS test")
+    runsql(ip_empty, "DROP TABLE IF EXISTS author")
+    runsql(ip_empty, "DROP TABLE IF EXISTS website")
+    runsql(ip_empty, "DROP TABLE IF EXISTS number_table")
 
 
 @pytest.fixture

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -49,6 +49,7 @@ def chinook_db():
     return str(path)
 
 
+# TODO: this is legacy code, we need to remove it
 def runsql(ip_session, statements):
     if isinstance(statements, str):
         statements = [statements]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -88,7 +88,7 @@ def ip_empty():
     # disables the history recording.
     # https://ipython.readthedocs.io/en/stable/config/options/terminal.html#configtrait-HistoryAccessor.enabled
     c.HistoryAccessor.enabled = False
-    ip_session = InteractiveShell(config=c)
+    ip_session = TestingShell(config=c)
 
     ip_session.register_magics(SqlMagic)
     ip_session.register_magics(RenderMagic)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -124,12 +124,12 @@ def ip_empty_testing():
 
 
 @pytest.fixture
-def ip(ip_empty):
+def ip(ip_empty_testing):
     """Provides an IPython session in which tables have been created"""
 
     # runsql creates an inmemory sqlitedatabase
     runsql(
-        ip_empty,
+        ip_empty_testing,
         [
             "CREATE TABLE test (n INT, name TEXT)",
             "INSERT INTO test VALUES (1, 'foo')",
@@ -158,14 +158,14 @@ def ip(ip_empty):
             "INSERT INTO number_table VALUES (4, 3)",
         ],
     )
-    yield ip_empty
+    yield ip_empty_testing
 
     ConnectionManager.close_all()
 
-    runsql(ip_empty, "DROP TABLE IF EXISTS test")
-    runsql(ip_empty, "DROP TABLE IF EXISTS author")
-    runsql(ip_empty, "DROP TABLE IF EXISTS website")
-    runsql(ip_empty, "DROP TABLE IF EXISTS number_table")
+    runsql(ip_empty_testing, "DROP TABLE IF EXISTS test")
+    runsql(ip_empty_testing, "DROP TABLE IF EXISTS author")
+    runsql(ip_empty_testing, "DROP TABLE IF EXISTS website")
+    runsql(ip_empty_testing, "DROP TABLE IF EXISTS number_table")
 
 
 @pytest.fixture

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,13 +4,13 @@ import urllib.request
 from pathlib import Path
 
 import pytest
-from IPython.core.interactiveshell import InteractiveShell
 
 
 from sql.magic import SqlMagic, RenderMagic
 from sql.magic_plot import SqlPlotMagic
 from sql.magic_cmd import SqlCmdMagic
 from sql.connection import ConnectionManager
+from sql._testing import TestingShell
 from sql import connection
 
 PATH_TO_TESTS = Path(__file__).absolute().parent
@@ -63,21 +63,6 @@ def clean_conns():
     ConnectionManager.current = None
     ConnectionManager.connections = dict()
     yield
-
-
-class TestingShell(InteractiveShell):
-    """
-    A custom InteractiveShell that raises exceptions instead of silently suppressing
-    them.
-    """
-
-    def run_cell(self, *args, **kwargs):
-        result = super().run_cell(*args, **kwargs)
-
-        if result.error_in_exec is not None:
-            raise result.error_in_exec
-
-        return result
 
 
 @pytest.fixture

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -315,26 +315,26 @@ def ip_with_duckDB(ip_empty, setup_duckDB):
 
 
 @pytest.fixture
-def ip_with_duckdb_native_empty(tmp_empty, ip_empty_testing):
-    ip_empty_testing.run_cell("import duckdb; conn = duckdb.connect('my.db')")
-    ip_empty_testing.run_cell("%sql conn --alias duck")
-    yield ip_empty_testing
-    ip_empty_testing.run_cell("conn.close()")
+def ip_with_duckdb_native_empty(tmp_empty, ip_empty):
+    ip_empty.run_cell("import duckdb; conn = duckdb.connect('my.db')")
+    ip_empty.run_cell("%sql conn --alias duck")
+    yield ip_empty
+    ip_empty.run_cell("conn.close()")
 
 
 @pytest.fixture
-def ip_with_duckdb_sqlalchemy_empty(tmp_empty, ip_empty_testing):
-    ip_empty_testing.run_cell("%sql duckdb:///my.db --alias duckdb")
-    yield ip_empty_testing
-    ip_empty_testing.run_cell("%sql --close duckdb")
+def ip_with_duckdb_sqlalchemy_empty(tmp_empty, ip_empty):
+    ip_empty.run_cell("%sql duckdb:///my.db --alias duckdb")
+    yield ip_empty
+    ip_empty.run_cell("%sql --close duckdb")
 
 
 @pytest.fixture
-def ip_with_sqlite_native_empty(tmp_empty, ip_empty_testing):
-    ip_empty_testing.run_cell("import sqlite3; conn = sqlite3.connect('')")
-    ip_empty_testing.run_cell("%sql conn --alias sqlite")
-    yield ip_empty_testing
-    ip_empty_testing.run_cell("conn.close()")
+def ip_with_sqlite_native_empty(tmp_empty, ip_empty):
+    ip_empty.run_cell("import sqlite3; conn = sqlite3.connect('')")
+    ip_empty.run_cell("%sql conn --alias sqlite")
+    yield ip_empty
+    ip_empty.run_cell("conn.close()")
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -232,10 +232,11 @@ def ip_with_SQLite(ip_empty, setup_SQLite):
     connection.ConnectionManager.current.close()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def setup_duckDB_native(test_table_name_dict):
-    engine = duckdb.connect(database=":memory:", read_only=False)
-    return engine
+    conn = duckdb.connect(database=":memory:", read_only=False)
+    yield conn
+    conn.close()
 
 
 def load_generic_testing_data_duckdb_native(ip, test_table_name_dict):

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -219,7 +219,9 @@ def test_close_and_connect(
     conn_alias = get_database_config_helper.get_database_config(config_key)["alias"]
     database_url = get_database_config_helper.get_database_url(config_key)
     # Disconnect
+
     ip_with_dynamic_db.run_cell("%sql -x " + conn_alias)
+
     assert get_connection_count(ip_with_dynamic_db) == 0
     # Connect, also check there is no error on re-connecting
     with warnings.catch_warnings():

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -855,7 +855,7 @@ CREATE TABLE my_numbers AS SELECT * FROM {test_table_name_dict['numbers']}
         """%%sql
 SELECT * FROM my_numbers
         """
-    ).result
+    )
 
     ip_with_dynamic_db.run_cell(
         """%%sql

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -391,34 +391,29 @@ def test_sqlplot_boxplot(ip_with_dynamic_db, cell, request, test_table_name_dict
         ("ip_with_mariaDB"),
         ("ip_with_SQLite"),
         ("ip_with_duckDB"),
-        ("ip_with_duckDB_native"),
+        pytest.param(
+            "ip_with_duckDB_native",
+            marks=pytest.mark.xfail(reason="not supported yet for native connections"),
+        ),
         ("ip_with_MSSQL"),
         ("ip_with_Snowflake"),
         ("ip_with_oracle"),
     ],
 )
-def test_sql_cmd_magic_uno(ip_with_dynamic_db, request, capsys):
+def test_sql_cmd_magic_uno(ip_with_dynamic_db, request, test_table_name_dict):
     ip_with_dynamic_db = request.getfixturevalue(ip_with_dynamic_db)
+    table = test_table_name_dict["numbers"]
+    ip_with_dynamic_db.run_cell(f"%sql select * from {table}")
 
-    ip_with_dynamic_db.run_cell(
-        """
-    %%sql sqlite://
-    CREATE TABLE test_numbers (value);
-    INSERT INTO test_numbers VALUES (0);
-    INSERT INTO test_numbers VALUES (4);
-    INSERT INTO test_numbers VALUES (5);
-    INSERT INTO test_numbers VALUES (6);
-    """
+    with pytest.raises(UsageError) as excinfo:
+        ip_with_dynamic_db.run_cell(
+            f"%sqlcmd test --table {table} --column numbers_elements "
+            "--less-than 1 --greater 2"
+        )
+
+    assert "The above values do not not match your test requirements." in str(
+        excinfo.value
     )
-
-    ip_with_dynamic_db.run_cell(
-        "%sqlcmd test --table test_numbers --column value" " --less-than 5 --greater 1"
-    )
-
-    _out = capsys.readouterr()
-
-    assert "less_than" in _out.out
-    assert "greater" in _out.out
 
 
 @pytest.mark.parametrize(
@@ -820,14 +815,15 @@ def test_sql_query_cte(ip_with_dynamic_db, request, test_table_name_dict, cell):
 def test_sql_error_suggests_using_cte(ip_with_dynamic_db, request):
     ip_with_dynamic_db = request.getfixturevalue(ip_with_dynamic_db)
 
-    out = ip_with_dynamic_db.run_cell(
-        """
+    with pytest.raises(UsageError) as excinfo:
+        ip_with_dynamic_db.run_cell(
+            """
     %%sql
 S"""
-    )
-    assert isinstance(out.error_in_exec, UsageError)
-    assert out.error_in_exec.error_type == "RuntimeError"
-    assert CTE_MSG in str(out.error_in_exec)
+        )
+
+    assert excinfo.value.error_type == "RuntimeError"
+    assert CTE_MSG in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -417,9 +417,7 @@ def test_sql_cmd_magic_uno(ip_with_dynamic_db, request, test_table_name_dict):
             "--less-than 1 --greater 2"
         )
 
-    assert "The above values do not not match your test requirements." in str(
-        excinfo.value
-    )
+    assert "The above values do not match your test requirements." in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -397,7 +397,10 @@ def test_sqlplot_boxplot(ip_with_dynamic_db, cell, request, test_table_name_dict
             "ip_with_duckDB_native",
             marks=pytest.mark.xfail(reason="not supported yet for native connections"),
         ),
-        ("ip_with_MSSQL"),
+        pytest.param(
+            "ip_with_MSSQL",
+            marks=pytest.mark.xfail(reason="not working yet"),
+        ),
         ("ip_with_Snowflake"),
         ("ip_with_oracle"),
     ],
@@ -405,6 +408,7 @@ def test_sqlplot_boxplot(ip_with_dynamic_db, cell, request, test_table_name_dict
 def test_sql_cmd_magic_uno(ip_with_dynamic_db, request, test_table_name_dict):
     ip_with_dynamic_db = request.getfixturevalue(ip_with_dynamic_db)
     table = test_table_name_dict["numbers"]
+
     ip_with_dynamic_db.run_cell(f"%sql select * from {table}")
 
     with pytest.raises(UsageError) as excinfo:
@@ -828,6 +832,7 @@ S"""
     assert CTE_MSG in str(excinfo.value)
 
 
+@pytest.mark.xfail(reason="Not yet implemented")
 @pytest.mark.parametrize(
     "ip_with_dynamic_db",
     [

--- a/src/tests/integration/test_postgreSQL.py
+++ b/src/tests/integration/test_postgreSQL.py
@@ -1,3 +1,7 @@
+import pytest
+from IPython.core.error import UsageError
+
+
 def test_meta_cmd_display(ip_with_postgreSQL, test_table_name_dict):
     out = ip_with_postgreSQL.run_cell("%sql \d")  # noqa: W605
     assert len(out.result) > 0
@@ -22,13 +26,14 @@ def test_auto_commit_mode_on(ip_with_postgreSQL, capsys):
 def test_postgres_error(ip_empty, postgreSQL_config_incorrect_pwd):
     alias, url = postgreSQL_config_incorrect_pwd
 
-    # Select database engine
-    out = ip_empty.run_cell("%sql " + url + " --alias " + alias)
-    assert "Review our DB connection via URL strings guide" in str(out.error_in_exec)
-    assert "Original error message from DB driver" in str(out.error_in_exec)
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql " + url + " --alias " + alias)
+
+    assert "Review our DB connection via URL strings guide" in str(excinfo.value)
+    assert "Original error message from DB driver" in str(excinfo.value)
     assert (
         "If you need help solving this issue, "
-        "send us a message: https://ploomber.io/community" in str(out.error_in_exec)
+        "send us a message: https://ploomber.io/community" in str(excinfo.value)
     )
 
 

--- a/src/tests/integration/test_questDB.py
+++ b/src/tests/integration/test_questDB.py
@@ -532,9 +532,11 @@ NOT_SUPPORTED_SUFFIX = (
 )
 def test_sqlcmd_not_supported_error(ip_questdb, query, capsys):
     expected_error_message = f"%sqlcmd {NOT_SUPPORTED_SUFFIX}"
-    out = ip_questdb.run_cell(query)
-    error_message = str(out.error_in_exec)
-    assert isinstance(out.error_in_exec, UsageError)
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_questdb.run_cell(query)
+
+    error_message = str(excinfo.value)
     assert str(expected_error_message).lower() in error_message.lower()
 
 
@@ -582,10 +584,10 @@ def test_ggplot_boxplot_not_supported_error(
 def test_sqlplot_not_supported_error(
     ip_questdb, penguins_data, penguins_no_nulls_questdb, query, expected_error_message
 ):
-    ip_questdb.run_cell(query)
-    out = ip_questdb.run_cell(query)
-    error_message = str(out.error_in_exec)
-    assert isinstance(out.error_in_exec, UsageError)
+    with pytest.raises(UsageError) as excinfo:
+        ip_questdb.run_cell(query)
+
+    error_message = str(excinfo.value)
     assert str(expected_error_message).lower() in error_message.lower()
 
 

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -12,20 +12,20 @@ from sql import inspect, connection
 
 
 @pytest.fixture
-def sample_db(ip_empty_testing, tmp_empty):
-    ip_empty_testing.run_cell("%sql sqlite:///first.db --alias first")
-    ip_empty_testing.run_cell("%sql CREATE TABLE one (x INT, y TEXT)")
-    ip_empty_testing.run_cell("%sql CREATE TABLE another (i INT, j TEXT)")
-    ip_empty_testing.run_cell("%sql sqlite:///second.db --alias second")
-    ip_empty_testing.run_cell("%sql CREATE TABLE uno (x INT, y TEXT)")
-    ip_empty_testing.run_cell("%sql CREATE TABLE dos (i INT, j TEXT)")
-    ip_empty_testing.run_cell("%sql --close second")
-    ip_empty_testing.run_cell("%sql first")
-    ip_empty_testing.run_cell("%sql ATTACH DATABASE 'second.db' AS schema")
+def sample_db(ip_empty, tmp_empty):
+    ip_empty.run_cell("%sql sqlite:///first.db --alias first")
+    ip_empty.run_cell("%sql CREATE TABLE one (x INT, y TEXT)")
+    ip_empty.run_cell("%sql CREATE TABLE another (i INT, j TEXT)")
+    ip_empty.run_cell("%sql sqlite:///second.db --alias second")
+    ip_empty.run_cell("%sql CREATE TABLE uno (x INT, y TEXT)")
+    ip_empty.run_cell("%sql CREATE TABLE dos (i INT, j TEXT)")
+    ip_empty.run_cell("%sql --close second")
+    ip_empty.run_cell("%sql first")
+    ip_empty.run_cell("%sql ATTACH DATABASE 'second.db' AS schema")
 
     yield
 
-    ip_empty_testing.run_cell("%sql --close first")
+    ip_empty.run_cell("%sql --close first")
     Path("first.db").unlink()
     Path("second.db").unlink()
 

--- a/src/tests/test_inspect.py
+++ b/src/tests/test_inspect.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 from inspect import getsource
@@ -11,17 +12,22 @@ from sql import inspect, connection
 
 
 @pytest.fixture
-def sample_db(ip):
-    ip.run_cell("%sql sqlite://")
-    ip.run_cell("%sql CREATE TABLE one (x INT, y TEXT)")
-    ip.run_cell("%sql CREATE TABLE another (i INT, j TEXT)")
-    ip.run_cell("%sql sqlite:///my.db")
-    ip.run_cell("%sql CREATE TABLE uno (x INT, y TEXT)")
-    ip.run_cell("%sql CREATE TABLE dos (i INT, j TEXT)")
-    ip.run_cell("%sql --close sqlite:///my.db")
-    ip.run_cell("%sql sqlite://")
+def sample_db(ip_empty_testing, tmp_empty):
+    ip_empty_testing.run_cell("%sql sqlite:///first.db --alias first")
+    ip_empty_testing.run_cell("%sql CREATE TABLE one (x INT, y TEXT)")
+    ip_empty_testing.run_cell("%sql CREATE TABLE another (i INT, j TEXT)")
+    ip_empty_testing.run_cell("%sql sqlite:///second.db --alias second")
+    ip_empty_testing.run_cell("%sql CREATE TABLE uno (x INT, y TEXT)")
+    ip_empty_testing.run_cell("%sql CREATE TABLE dos (i INT, j TEXT)")
+    ip_empty_testing.run_cell("%sql --close second")
+    ip_empty_testing.run_cell("%sql first")
+    ip_empty_testing.run_cell("%sql ATTACH DATABASE 'second.db' AS schema")
 
-    ip.run_cell("%sql ATTACH DATABASE 'my.db' AS schema")
+    yield
+
+    ip_empty_testing.run_cell("%sql --close first")
+    Path("first.db").unlink()
+    Path("second.db").unlink()
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1074,10 +1074,10 @@ Set the environment variable $DATABASE_URL
 
 
 def test_error_on_invalid_connection_string(ip_empty, clean_conns):
-    result = ip_empty.run_cell("%sql some invalid connection string")
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql some invalid connection string")
 
-    assert invalid_connection_string.strip() == str(result.error_in_exec)
-    assert isinstance(result.error_in_exec, UsageError)
+    assert invalid_connection_string.strip() == str(excinfo.value)
 
 
 invalid_connection_string_format = f"""\
@@ -1092,18 +1092,19 @@ Ref: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
 
 
 def test_error_on_invalid_connection_string_format(ip_empty, clean_conns):
-    result = ip_empty.run_cell("%sql something://")
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql something://")
 
-    assert invalid_connection_string_format.strip() == str(result.error_in_exec)
-    assert isinstance(result.error_in_exec, UsageError)
+    assert invalid_connection_string_format.strip() == str(excinfo.value)
 
 
 def test_error_on_invalid_connection_string_with_existing_conns(ip_empty, clean_conns):
     ip_empty.run_cell("%sql sqlite://")
-    result = ip_empty.run_cell("%sql something://")
 
-    assert invalid_connection_string_format.strip() == str(result.error_in_exec)
-    assert isinstance(result.error_in_exec, UsageError)
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql something://")
+
+    assert invalid_connection_string_format.strip() == str(excinfo.value)
 
 
 invalid_connection_string_with_possible_typo = f"""
@@ -1118,12 +1119,11 @@ Perhaps you meant to use driver the dialect: "sqlite"
 
 def test_error_on_invalid_connection_string_with_possible_typo(ip_empty, clean_conns):
     ip_empty.run_cell("%sql sqlite://")
-    result = ip_empty.run_cell("%sql sqlit://")
 
-    assert invalid_connection_string_with_possible_typo.strip() == str(
-        result.error_in_exec
-    )
-    assert isinstance(result.error_in_exec, UsageError)
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql sqlit://")
+
+    assert invalid_connection_string_with_possible_typo.strip() == str(excinfo.value)
 
 
 invalid_connection_string_duckdb = f"""
@@ -1146,9 +1146,10 @@ Pass a valid connection string:
 
 
 def test_error_on_invalid_connection_string_duckdb(ip_empty, clean_conns):
-    result = ip_empty.run_cell("%sql duckdb://invalid_db")
-    assert invalid_connection_string_duckdb.strip() == str(result.error_in_exec)
-    assert isinstance(result.error_in_exec, UsageError)
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql duckdb://invalid_db")
+
+    assert invalid_connection_string_duckdb.strip() == str(excinfo.value)
 
 
 def test_jupysql_alias():

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -525,7 +525,13 @@ def test_connection_args_enforce_json(ip):
     with pytest.raises(UsageError) as excinfo:
         ip.run_cell('%sql --connection_arguments {"badlyformed":true')
 
-    assert "Expecting ',' delimiter" in str(excinfo.value)
+    expected_message = (
+        "Expecting property name enclosed in double quotes"
+        if platform.system() == "Windows"
+        else "Expecting ',' delimiter"
+    )
+
+    assert expected_message in str(excinfo.value)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="failing on windows")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -209,8 +209,12 @@ def test_persist_missing_pandas(ip, monkeypatch):
 
     ip.run_cell("results = %sql SELECT * FROM test;")
     ip.run_cell("results_dframe = results.DataFrame()")
-    result = ip.run_cell("%sql --persist sqlite:// results_dframe")
-    assert "pip install pandas" in str(result.error_in_exec)
+
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --persist sqlite:// results_dframe")
+
+    assert excinfo.value.error_type == "MissingPackageError"
+    assert "pip install pandas" in str(excinfo.value)
 
 
 def test_persist(ip):
@@ -236,28 +240,43 @@ def test_persist_no_index(ip):
     [
         ("%%sql --arg\n SELECT * FROM test", "Unrecognized argument(s): --arg"),
         ("%%sql -arg\n SELECT * FROM test", "Unrecognized argument(s): -arg"),
-        ("%%sql \n SELECT * FROM test", None),
-        ("%sql select * FROM test --some", None),
         ("%%sql --persist '--some' \n SELECT * FROM test", "not a valid identifier"),
     ],
 )
 def test_unrecognized_arguments_cell_magic(ip, sql_statement, expected_error):
-    result = ip.run_cell(sql_statement)
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(sql_statement)
 
-    if expected_error:
-        assert expected_error in str(result.error_in_exec)
-    else:
-        assert result.error_in_exec is None
+    assert expected_error in str(excinfo.value)
+
+
+def test_ignore_argument_like_strings_if_they_come_after_the_sql_query(ip):
+    assert ip.run_cell("%sql select * FROM test --some")
 
 
 def test_persist_invalid_identifier(ip):
-    result = ip.run_cell("%sql --persist sqlite:// not an identifier")
-    assert "not a valid identifier" in str(result.error_in_exec)
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --persist sqlite:// not an identifier")
+
+    assert "not a valid identifier" in str(excinfo.value)
 
 
 def test_persist_undefined_variable(ip):
-    result = ip.run_cell("%sql --persist sqlite:// not_a_variable")
-    assert "it's undefined" in str(result.error_in_exec)
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --persist sqlite:// not_a_variable")
+
+    assert "Expected 'not_a_variable' to be a pd.DataFrame but it's undefined" in str(
+        excinfo.value
+    )
+
+
+def test_persist_non_frame_raises(ip):
+    ip.run_cell("not_a_dataframe = 22")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --persist sqlite:// not_a_dataframe")
+
+    assert "is not a Pandas DataFrame or Series" in str(excinfo.value)
 
 
 def test_append(ip):
@@ -271,26 +290,13 @@ def test_append(ip):
     assert appended[0][0] == persisted[0][0] * 2
 
 
-def test_persist_nonexistent_raises(ip):
-    runsql(ip, "")
-    result = ip.run_cell("%sql --persist sqlite:// no_such_dataframe")
-    assert result.error_in_exec
+def test_persist_missing_argument(ip):
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --persist sqlite://")
 
-
-def test_persist_non_frame_raises(ip):
-    ip.run_cell("not_a_dataframe = 22")
-    runsql(ip, "")
-    result = ip.run_cell("%sql --persist sqlite:// not_a_dataframe")
-    assert isinstance(result.error_in_exec, UsageError)
-    assert (
-        "is not a Pandas DataFrame or Series".lower()
-        in str(result.error_in_exec).lower()
+    assert "Expected '' to be a pd.DataFrame but it's not a valid identifier" in str(
+        excinfo.value
     )
-
-
-def test_persist_bare(ip):
-    result = ip.run_cell("%sql --persist sqlite://")
-    assert result.error_in_exec
 
 
 def get_table_rows_as_dataframe(ip, table, name=None):
@@ -409,34 +415,42 @@ def test_persist_replace_override_reverted_order(
     table_df = get_table_rows_as_dataframe(
         ip, table=second_test_table, name=saved_df_name
     )
-    persist_out = ip.run_cell(f"%sql --persist sqlite:// {table_df}")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(f"%sql --persist sqlite:// {table_df}")
 
     # To test the second --persist executes not successfully
     assert (
         f"Table '{saved_df_name}' already exists. Consider using \
 --persist-replace to drop the table before persisting the data frame"
-        in str(persist_out.error_in_exec)
+        in str(excinfo.value)
     )
 
-    out = ip.run_cell(f"%sql SELECT * FROM {table_df}")
     # To test the persisted data is from --persist-replace
+    out = ip.run_cell(f"%sql SELECT * FROM {table_df}")
     assert out.result == expected_result
-    assert out.error_in_exec is None
 
 
 @pytest.mark.parametrize(
-    "test_table", [("test"), ("author"), ("website"), ("number_table")]
+    "test_table",
+    [
+        ("test"),
+        ("author"),
+        ("website"),
+        ("number_table"),
+    ],
 )
 def test_persist_and_append_use_together(ip, test_table):
     # Test error message when use --persist and --append together
     saved_df_name = get_table_rows_as_dataframe(ip, table=test_table)
-    out = ip.run_cell(f"%sql --persist-replace --append sqlite:// {saved_df_name}")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(f"%sql --persist-replace --append sqlite:// {saved_df_name}")
 
     assert """You cannot simultaneously persist and append data to a dataframe;
                   please choose to utilize either one or the other.""" in str(
-        out.error_in_exec
+        excinfo.value
     )
-    assert (out.error_in_exec.error_type) == "UsageError"
 
 
 @pytest.mark.parametrize(
@@ -507,8 +521,10 @@ def test_persist_replace_twice(
 
 
 def test_connection_args_enforce_json(ip):
-    result = ip.run_cell('%sql --connection_arguments {"badlyformed":true')
-    assert result.error_in_exec
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell('%sql --connection_arguments {"badlyformed":true')
+
+    assert "Expecting ',' delimiter" in str(excinfo.value)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="failing on windows")
@@ -523,15 +539,6 @@ def test_connection_args_single_quotes(ip):
     ip.run_cell("%sql --connection_arguments '{\"timeout\": 10}' sqlite:///:memory:")
     result = ip.run_cell("%sql --connections")
     assert "timeout" in result.result["sqlite:///:memory:"].connect_args
-
-
-# TODO: support
-# @with_setup(_setup_author, _teardown_author)
-# def test_persist_with_connection_info():
-#     ip.run_cell("results = %sql SELECT * FROM author;")
-#     ip.run_line_magic('sql', 'sqlite:// PERSIST results.DataFrame()')
-#     persisted = ip.run_line_magic('sql', 'SELECT * FROM results')
-#     assert 'Shakespeare' in str(persisted)
 
 
 def test_displaylimit_no_limit(ip):
@@ -790,11 +797,13 @@ def test_sql_from_file(ip):
 
 
 def test_sql_from_nonexistent_file(ip):
-    ip.run_line_magic("config", "SqlMagic.autopandas = False")
-    with tempfile.TemporaryDirectory() as tempdir:
-        fname = os.path.join(tempdir, "nonexistent.sql")
-        result = ip.run_cell("%sql --file " + fname)
-        assert isinstance(result.error_in_exec, FileNotFoundError)
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --file some_file_that_doesnt_exist.sql")
+
+    assert "No such file or directory: 'some_file_that_doesnt_exist.sql" in str(
+        excinfo.value
+    )
+    assert excinfo.value.error_type == "FileNotFoundError"
 
 
 def test_dict(ip):
@@ -1240,27 +1249,25 @@ def test_save_with_number_table(
 
 
 def test_save_with_non_existing_with(ip):
-    out = ip.run_cell(
-        "%sql --with non_existing_sub_query " "SELECT * FROM non_existing_sub_query"
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(
+            "%sql --with non_existing_sub_query SELECT * FROM non_existing_sub_query"
+        )
+
+    assert '"non_existing_sub_query" is not a valid snippet identifier.' in str(
+        excinfo.value
     )
-    assert isinstance(out.error_in_exec, UsageError)
+    assert excinfo.value.error_type == "UsageError"
 
 
 def test_save_with_non_existing_table(ip):
-    out = ip.run_cell("%sql --save my_query SELECT * FROM non_existing_table")
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell("%sql --save my_query SELECT * FROM non_existing_table")
 
-    assert isinstance(out.error_in_exec, UsageError)
-    assert out.error_in_exec.error_type == "RuntimeError"
+    assert excinfo.value.error_type == "RuntimeError"
     assert "(sqlite3.OperationalError) no such table: non_existing_table" in str(
-        out.error_in_exec
+        excinfo.value
     )
-
-
-def test_save_with_bad_query_save(ip, capsys):
-    ip.run_cell("%sql --save my_query SELECT * non_existing_table")
-    ip.run_cell("%sql --with my_query SELECT * FROM my_query")
-    out, err = capsys.readouterr()
-    assert '(sqlite3.OperationalError) near "non_existing_table": syntax error' in err
 
 
 def test_interact_basic_data_types(ip, capsys):
@@ -1301,7 +1308,12 @@ def test_interact_and_missing_ipywidgets_installed(ip):
     with patch.dict(sys.modules):
         sys.modules["ipywidgets"] = None
         ip.user_global_ns["my_variable"] = 5
-        out = ip.run_cell(
-            "%sql --interact my_variable SELECT * FROM author LIMIT {{my_variable}}"
-        )
-        assert isinstance(out.error_in_exec, ModuleNotFoundError)
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            ip.run_cell(
+                "%sql --interact my_variable SELECT * FROM author LIMIT {{my_variable}}"
+            )
+
+    assert "'ipywidgets' is required to use '--interactive argument'" in str(
+        excinfo.value
+    )

--- a/src/tests/test_magic_plot.py
+++ b/src/tests/test_magic_plot.py
@@ -41,47 +41,44 @@ WHERE x > 2
 
 
 @pytest.mark.parametrize(
-    "cell, error_type, error_message",
+    "cell, error_message",
     [
         [
             "%sqlplot someplot -t a -c b",
-            UsageError,
             f"Unknown plot 'someplot'. Must be any of: {plot_str}",
         ],
         [
             "%sqlplot -t a -c b",
-            UsageError,
             f"Missing the first argument, must be any of: {plot_str}",
         ],
     ],
 )
-def test_validate_plot_name(tmp_empty, ip, cell, error_type, error_message):
-    out = ip.run_cell(cell)
+def test_validate_plot_name(tmp_empty, ip, cell, error_message):
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(cell)
 
-    assert isinstance(out.error_in_exec, error_type)
-    assert str(error_message).lower() in str(out.error_in_exec).lower()
+    assert excinfo.value.error_type == "UsageError"
+    assert str(error_message).lower() in str(excinfo.value).lower()
 
 
 @pytest.mark.parametrize(
-    "cell, error_type, error_message",
+    "cell, error_message",
     [
         [
             "%sqlplot histogram --column a",
-            UsageError,
             "the following arguments are required: -t/--table",
         ],
         [
             "%sqlplot histogram --table a",
-            UsageError,
             "the following arguments are required: -c/--column",
         ],
     ],
 )
-def test_validate_arguments(tmp_empty, ip, cell, error_type, error_message):
-    out = ip.run_cell(cell)
+def test_validate_arguments(tmp_empty, ip, cell, error_message):
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(cell)
 
-    assert isinstance(out.error_in_exec, error_type)
-    assert str(out.error_in_exec) == (error_message)
+    assert str(error_message).lower() in str(excinfo.value).lower()
 
 
 @_cleanup_cm()

--- a/src/tests/test_magic_plot.py
+++ b/src/tests/test_magic_plot.py
@@ -424,35 +424,49 @@ def test_hist_cust(load_penguin, ip):
 
 
 @pytest.mark.parametrize(
-    "arg", ["--delete", "-d", "--delete-force-all", "-A", "--delete-force", "-D"]
+    "arg",
+    [
+        "--delete",
+        "-d",
+        "--delete-force-all",
+        "-A",
+        "--delete-force",
+        "-D",
+    ],
 )
-def test_sqlplot_snippet_deletion(ip_snippets, arg, capsys):
+def test_sqlplot_snippet_deletion(ip_snippets, arg):
     ip_snippets.run_cell(f"%sqlcmd snippets {arg} subset_another")
-    ip_snippets.run_cell("%sqlplot boxplot --table subset_another --column x")
-    out, err = capsys.readouterr()
-    assert "There is no table with name 'subset_another' in the default schema" in err
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_snippets.run_cell("%sqlplot boxplot --table subset_another --column x")
+
+    assert "There is no table with name 'subset_another' in the default schema" in str(
+        excinfo.value
+    )
 
 
 TABLE_NAME_TYPO_MSG = """
-UsageError: There is no table with name 'subst' in the default schema
+There is no table with name 'subst' in the default schema
 Did you mean : 'subset'
 If you need help solving this issue, send us a message: https://ploomber.io/community
 """
 
 
-def test_sqlplot_snippet_typo(ip_snippets, capsys):
-    ip_snippets.run_cell("%sqlplot boxplot --table subst --column x")
-    out, err = capsys.readouterr()
-    assert TABLE_NAME_TYPO_MSG.strip() == err.strip()
+def test_sqlplot_snippet_typo(ip_snippets):
+    with pytest.raises(UsageError) as excinfo:
+        ip_snippets.run_cell("%sqlplot boxplot --table subst --column x")
+
+    assert TABLE_NAME_TYPO_MSG.strip() in str(excinfo.value).strip()
 
 
 MISSING_TABLE_ERROR_MSG = """
-UsageError: There is no table with name 'missing' in the default schema
+There is no table with name 'missing' in the default schema
 If you need help solving this issue, send us a message: https://ploomber.io/community
 """
 
 
 def test_sqlplot_missing_table(ip_snippets, capsys):
-    ip_snippets.run_cell("%sqlplot boxplot --table missing --column x")
-    out, err = capsys.readouterr()
-    assert MISSING_TABLE_ERROR_MSG.strip() == err.strip()
+    with pytest.raises(UsageError) as excinfo:
+        ip_snippets.run_cell("%sqlplot boxplot --table missing --column x")
+
+    assert MISSING_TABLE_ERROR_MSG.strip() in str(excinfo.value).strip()

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -27,7 +27,10 @@ def test_sqlstore_getitem_success():
     [
         (
             "second",
-            '"second" is not a valid snippet identifier. Valid identifiers are "first".',
+            (
+                '"second" is not a valid snippet identifier.'
+                ' Valid identifiers are "first".'
+            ),
         ),
         (
             "firs",

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -16,45 +16,45 @@ def test_sqlstore_setitem():
     assert store["a"] == "SELECT * FROM a"
 
 
-def test_sqlstore_getitem():
+def test_sqlstore_getitem_success():
     store = SQLStore()
-
-    # Test case 1: Test for a valid key
     store["first"] = "SELECT * FROM a"
     assert store["first"] == "SELECT * FROM a"
 
-    # Test case 2: Test for an invalid key with no matches
+
+@pytest.mark.parametrize(
+    "key, expected_error",
+    [
+        (
+            "second",
+            '"second" is not a valid snippet identifier. Valid identifiers are "first".',
+        ),
+        (
+            "firs",
+            '"firs" is not a valid snippet identifier. Did you mean "first"?',
+        ),
+    ],
+    ids=[
+        "invalid-key",
+        "close-match-key",
+    ],
+)
+def test_sqlstore_getitem(key, expected_error):
+    store = SQLStore()
+    store["first"] = "SELECT * FROM a"
+
     with pytest.raises(UsageError) as excinfo:
-        store["second"]
+        store[key]
 
     assert excinfo.value.error_type == "UsageError"
-    assert (
-        str(excinfo.value)
-        == '"second" is not a valid snippet identifier. Valid identifiers are "first".'
-    )
+    assert str(excinfo.value) == expected_error
 
-    # Test case 3: Test for invalid key with close match
-    with pytest.raises(UsageError) as excinfo:
-        store["firs"]
 
-    assert excinfo.value.error_type == "UsageError"
-    assert (
-        str(excinfo.value)
-        == '"firs" is not a valid snippet identifier. Did you mean "first"?'
-    )
+def test_sqlstore_getitem_with_multiple_existing_snippets():
+    store = SQLStore()
+    store["first"] = "SELECT * FROM a"
+    store["first2"] = "SELECT * FROM a"
 
-    # Test case 4: Test for multiple keys with close match
-    store["first2"] = "SELECT * FROM b"
-    with pytest.raises(UsageError) as excinfo:
-        store["firs"]
-
-    assert excinfo.value.error_type == "UsageError"
-    assert (
-        str(excinfo.value)
-        == '"firs" is not a valid snippet identifier. Did you mean "first"?'
-    )
-
-    # Test case 5: Test for multiple keys with no close match
     with pytest.raises(UsageError) as excinfo:
         store["second"]
 
@@ -64,18 +64,6 @@ def test_sqlstore_getitem():
         == '"second" is not a valid snippet identifier. '
         + 'Valid identifiers are "first", "first2".'
     )
-
-    # Test case 6: Test for empty dictionary:
-    store2 = SQLStore()
-    with pytest.raises(UsageError) as excinfo:
-        store2["second"]
-
-    assert excinfo.value.error_type == "UsageError"
-    assert str(excinfo.value) == "No saved SQL"
-
-    # Test case 7: Test for special character in key:
-    store["$%#"] = "SELECT * FROM a"
-    assert store["$%#"] == "SELECT * FROM a"
 
 
 def test_hyphen():

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -159,10 +159,10 @@ ATTACH DATABASE 'my.db' AS test_schema
 """
     )
 
-    out = ip.run_cell(query)
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(query)
 
-    error_message = str(out.error_in_exec)
-    assert isinstance(out.error_in_exec, UsageError)
+    error_message = str(excinfo.value)
     assert str(expected_error_message).lower() in error_message.lower()
 
     error_suggestions_arr = error_message.split(EXPECTED_SUGGESTIONS_MESSAGE)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -66,10 +66,10 @@ FROM number_table
         "boxplot",
     ],
 )
-def test_no_errors_with_stored_query(ip_empty_testing, store_table, query):
-    ip_empty_testing.run_cell("%sql duckdb://")
+def test_no_errors_with_stored_query(ip_empty, store_table, query):
+    ip_empty.run_cell("%sql duckdb://")
 
-    ip_empty_testing.run_cell(
+    ip_empty.run_cell(
         """%%sql
 CREATE TABLE numbers (
     x FLOAT
@@ -79,7 +79,7 @@ INSERT INTO numbers (x) VALUES (1), (2), (3);
 """
     )
 
-    ip_empty_testing.run_cell(
+    ip_empty.run_cell(
         f"""
         %%sql --save {store_table} --no-execute
         SELECT *
@@ -87,7 +87,7 @@ INSERT INTO numbers (x) VALUES (1), (2), (3);
         """
     )
 
-    out = ip_empty_testing.run_cell(query.format(store_table, store_table))
+    out = ip_empty.run_cell(query.format(store_table, store_table))
     assert out.success
 
 

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -85,12 +85,13 @@ def test_no_errors_with_stored_query(ip, store_table, query):
 )
 def test_bad_table_error_message(ip, table, query, suggestions):
     query = query.format(table)
-    out = ip.run_cell(query)
+
+    with pytest.raises(UsageError) as excinfo:
+        ip.run_cell(query)
 
     expected_error_message = EXPECTED_NO_TABLE_IN_DEFAULT_SCHEMA.format(table)
 
-    error_message = str(out.error_in_exec)
-    assert isinstance(out.error_in_exec, UsageError)
+    error_message = str(excinfo.value)
     assert str(expected_error_message).lower() in error_message.lower()
 
     error_suggestions_arr = error_message.split(EXPECTED_SUGGESTIONS_MESSAGE)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -51,6 +51,12 @@ FROM number_table
         ("c_c", "%sqlplot histogram --table {} --column x"),
         ("d_d_d", "%sqlplot boxplot --table {} --column x"),
     ],
+    ids=[
+        "columns",
+        "profile",
+        "histogram",
+        "boxplot",
+    ],
 )
 def test_no_errors_with_stored_query(ip, store_table, query):
     ip.run_cell(
@@ -59,15 +65,10 @@ def test_no_errors_with_stored_query(ip, store_table, query):
         SELECT *
         FROM number_table
         """
-    ).result
+    )
 
-    query = query.format(store_table, store_table)
-    out = ip.run_cell(query)
-
-    expected_store_message = EXPECTED_STORE_SUGGESTIONS.format(store_table)
-    error_message = str(out.error_in_exec)
-    assert not isinstance(out.error_in_exec, ValueError)
-    assert str(expected_store_message).lower() not in error_message.lower()
+    out = ip.run_cell(query.format(store_table, store_table))
+    assert out.success
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I improved the fixture that creates the IPython session and fixed some bugs along the way. (also, I deleted some outdated sections in the developer documentation)

Change: calling `run_cell` now automatically raises exceptions, if any:

```python
# this will raise an exception
ip.run_cell("%sql select * from some_unknown_table")
```

Why?

In many of our tests, we create an IPython session and run stuff like this:


```python
ip.run_cell("%sql select * from some_table")
```

The caveat is that `ip.run_cell` won't raise any exceptions automatically, so we had to add this pattern over and over again to ensure there were no issues:

```python
result = ip.run_cell("%sql select * from some_table")
assert result.error_in_exec is None
```

However, many tests require several calls:

```python
ip.run_cell("%sql select * from some_table")
ip.run_cell("%sql select * from table_that_doesnt_exist")
ip.run_cell("%sql select * from another_table")
```

This made the tests hard to debug since we wouldn't know which calls were failing unless we inspected them individually.



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--757.org.readthedocs.build/en/757/

<!-- readthedocs-preview jupysql end -->