### PR TITLE
adds `:variable` parameter substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [Fix] Fixed vertical color breaks in histograms (#702)
 * [Fix] Showing feedback when switching connections (#727)
 * [Fix] Fix error that caused some connections not to be closed when calling `--close/-x`
+* [Fix] Fix error that caused literals like `':something'` to be interpreted as query parameters
+* [Feature] allows parametrizing queries with `:variable` with `%config SqlMagic.named_paramstyle = True`
 
 ## 0.8.0 (2023-07-18)
 

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -242,7 +242,31 @@ res = %sql SELECT * FROM languages LIMIT 2
 print(res)
 ```
 
-## Loading configuration settings
+## `named_paramstyle`
+
+Default: `False`
+
+If True, it enables named parameters `:variable`. Learn more in the [tutorial.](../user-guide/template.md)
+
+```{code-cell} ipython3
+%config SqlMagic.named_paramstyle=True
+```
+
+```{code-cell} ipython3
+rating = 12
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM languages
+WHERE rating > :rating
+```
+
+## Loading configuration from a `pyproject.toml` file
+
+```{versionadded} 0.9
+```
 
 You can define configurations in a `pyproject.toml` file and automatically load the configurations when you run `%load_ext sql`. If the file is not found in the current or parent directories, default values will be used. A sample `pyproject.toml` could look like this:
 

--- a/doc/user-guide/template.md
+++ b/doc/user-guide/template.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.6
+    jupytext_version: 1.14.7
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -28,7 +28,7 @@ The legacy formats of parametrization, namely `{variable}`, `:variable`, and `$v
 ```
 
 
-## Variable Expansion
+## Parametrization via `{{variable}}`
 
 JupySQL supports variable expansion in the form of `{{variable}}`. This allows the user to write a query with placeholders that can be replaced by variables dynamically.
 
@@ -42,6 +42,11 @@ Let's load some data and connect to the in-memory DuckDB instance:
 
 ```{code-cell} ipython3
 %load_ext sql
+%sql duckdb://
+%config SqlMagic.displaylimit = 3
+```
+
+```{code-cell} ipython3
 from pathlib import Path
 from urllib.request import urlretrieve
 
@@ -50,10 +55,30 @@ if not Path("penguins.csv").is_file():
         "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv",
         "penguins.csv",
     )
-%sql duckdb://
 ```
 
-Now, let's define a simple query template with placeholders, and substitute the placeholders with a couple of variables using variable expansion.
+The simplest use case is to use a variable to determine which data to filter:
+
++++
+
+### Data filtering
+
+```{code-cell} ipython3
+sex = "MALE"
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM penguins.csv
+WHERE  sex = '{{sex}}'
+```
+
+Note that we have to add quotes around `{{sex}}`, since the literal is replaced.
+
++++
+
+`{{variable}}` parameters are not limited to `WHERE` clauses, you can use them anywhere:
 
 ```{code-cell} ipython3
 dynamic_limit = 5
@@ -64,11 +89,15 @@ dynamic_column = "island, sex"
 %sql SELECT {{dynamic_column}} FROM penguins.csv LIMIT {{dynamic_limit}}
 ```
 
-Note that the variables substituted in the SQL statement are fetched from the local namespace.
+### SQL generation
 
-## Variable expansion using loops
+```{note}
+We use [jinja](https://jinja.palletsprojects.com/en/3.1.x/) to parametrize queries, to learn more about the syntax, check our their docs.
+```
 
-Now, let's look at parametrizing queries using a for loop. First, we'll create a set of unique `sex` values. This is required since the dataset contains samples for which `sex` couldn't be determined (`null`).
+Since there are no restrictions on where you can use `{{variable}}` you can use it to dynamically generate SQL if you also use advanced control structures. 
+
+Let's look at generating SQL queries using a `{% for %}` loop. First, we'll create a set of unique `sex` values. This is required since the dataset contains samples for which `sex` couldn't be determined (`null`).
 
 ```{code-cell} ipython3
 sex = ("MALE", "FEMALE")
@@ -96,9 +125,11 @@ final = %sqlcmd snippets avg_body_mass
 print(final)
 ```
 
-## Macros + variable expansion
+### SQL generation with macros
 
-`Macros` is a construct analogous to functions that promote re-usability. We'll first define a macro for converting a value from `millimetre` to `centimetre`. And then use this macro in the query using variable expansion.
+If `{% for %}` lops are not enough, you can modularize your code generation even more with macros.
+
+macros is a construct analogous to functions that promote re-usability. We'll first define a macro for converting a value from `millimetre` to `centimetre`. And then use this macro in the query using variable expansion.
 
 ```{code-cell} ipython3
 %%sql --save convert
@@ -120,13 +151,45 @@ final = %sqlcmd snippets convert
 print(final)
 ```
 
+### Using snippets
+
+You can combine the snippets feature with `{{variable}}`:
+
 ```{code-cell} ipython3
-%sqlcmd snippets -d convert
+species = "Adelie"
 ```
 
-## Create tables in loop
+```{code-cell} ipython3
+%%sql --save one_species --no-execute
+SELECT * FROM penguins.csv
+WHERE species = '{{species}}'
+```
 
-We can also create multiple tables in a loop using parametrized queries. Let's segregate the dataset by `island`.
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM one_species
+```
+
+```{important}
+When storing a snippet with `{{variable}}`, the values are replaced upon saving, so assigning a new value to `variable` won't have any effect.
+```
+
+```{code-cell} ipython3
+species = "Gentoo"
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM one_species
+```
+
+### Combining Python and `{{variable}}`
+
+You can combine Python code with the `%sql` magic to execute parametrized queries.
+
+Let's see how we can create multiple tables, each one containing the penguins for a given `island`.
 
 ```{code-cell} ipython3
 for island in ("Torgersen", "Biscoe", "Dream"):
@@ -140,7 +203,93 @@ for island in ("Torgersen", "Biscoe", "Dream"):
 Let's verify data in one of the tables:
 
 ```{code-cell} ipython3
+%sql SELECT * FROM Dream;
+```
+
+```{code-cell} ipython3
 %sql SELECT * FROM Torgersen;
 ```
 
-[Click here](https://jupysql.ploomber.io/en/latest/intro.html?highlight=variable#variable-substitution) for more details.
+## Parametrization via `:variable`
+
+```{versionadded} 0.9
+```
+
+There is a second method to parametrize variables via `:variable`. This method has the following limitations
+
+- Only available for SQLAlchemy connections
+- Only works for data filtering parameters (`WHERE`, `IN`, `>=`, etc.)
+
+
+To enable it:
+
+```{code-cell} ipython3
+%config SqlMagic.named_paramstyle = True
+```
+
+```{code-cell} ipython3
+sex = "MALE"
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM penguins.csv
+WHERE sex = :sex
+```
+
+Note that we don't have to quote `:sex`. When using `:variable`, if `variable` is a string, it'll automatically be quoted. 
+
+Here's another example where we use the parameters for an `IN` and a `>=` clauses:
+
+```{code-cell} ipython3
+one = "Adelie"
+another = "Chinstrap"
+min_body_mass_g = 4500
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM penguins.csv
+WHERE species IN (:one, :another)
+AND body_mass_g >= :min_body_mass_g
+```
+
+Parametrizing other parts of the query like table names or column names won't work.
+
+```{code-cell} ipython3
+tablename = "penguins.csv"
+```
+
+```{code-cell} ipython3
+:tags: [raise-exception]
+
+%%sql
+SELECT *
+FROM :tablename
+```
+
+### Using snippets and `:variable`
+
+Unlike `{{variable}`, `:variable` parameters are evaluated at execution time, meaning you can `--save` a query and the output will change depending on the value of `variable` when the query is executed:
+
+```{code-cell} ipython3
+sex = "MALE"
+```
+
+```{code-cell} ipython3
+%%sql --save one_sex
+SELECT *
+FROM penguins.csv
+WHERE sex = :sex
+```
+
+```{code-cell} ipython3
+sex = "FEMALE"
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT * FROM one_sex
+```

--- a/doc/user-guide/template.md
+++ b/doc/user-guide/template.md
@@ -263,7 +263,7 @@ tablename = "penguins.csv"
 ```
 
 ```{code-cell} ipython3
-:tags: [raise-exception]
+:tags: [raises-exception]
 
 %%sql
 SELECT *

--- a/src/sql/_testing.py
+++ b/src/sql/_testing.py
@@ -34,10 +34,7 @@ class TestingShell(InteractiveShell):
 
     def run_cell(self, *args, **kwargs):
         result = super().run_cell(*args, **kwargs)
-
-        if result.error_in_exec is not None:
-            raise result.error_in_exec
-
+        result.raise_error()
         return result
 
 

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -568,9 +568,7 @@ class SQLAlchemyConnection(AbstractConnection):
                             "but the named parameters feature is disabled. Enable it "
                             "with: %config SqlMagic.named_paramstyle=True"
                         )
-                        raise
-
-                raise exceptions.QueryError(str(e))
+                raise
 
     def _get_database_information(self):
         dialect = self.connection_sqlalchemy.dialect

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -525,7 +525,7 @@ class SQLAlchemyConnection(AbstractConnection):
             intersection = set(quoted_named_parameters) & set(parameters)
 
             if intersection:
-                intersection_ = ", ".join(intersection)
+                intersection_ = ", ".join(sorted(intersection))
                 warnings.warn(
                     f"The following variables are defined: {intersection_}. However "
                     "the parameters are quoted in the query, if you want to use "

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -533,9 +533,14 @@ class SQLAlchemyConnection(AbstractConnection):
                     "variables are undefined: {}".format(", ".join(missing_parameters))
                 )
 
-            return self.connection.execute(
-                sqlalchemy.text(query), parameters=parameters
-            )
+            if IS_SQLALCHEMY_ONE:
+                results = self.connection.execute(sqlalchemy.text(query), **parameters)
+            else:
+                results = self.connection.execute(
+                    sqlalchemy.text(query), parameters=parameters
+                )
+
+            return results
         else:
             return self.connection.execute(sqlalchemy.text(query))
 

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -47,3 +47,6 @@ TableNotFoundError = exception_factory("TableNotFoundError")
 
 # raise it when there is an error in parsing pyproject.toml file
 ConfigurationError = exception_factory("ConfigurationError")
+
+
+InvalidQueryParameters = exception_factory("InvalidQueryParameters")

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -15,7 +15,12 @@ from IPython.core.magic import (
     no_var_expand,
 )
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
-from sqlalchemy.exc import OperationalError, ProgrammingError, DatabaseError
+from sqlalchemy.exc import (
+    OperationalError,
+    ProgrammingError,
+    DatabaseError,
+    StatementError,
+)
 from traitlets.config.configurable import Configurable
 from traitlets import Bool, Int, TraitError, Unicode, Dict, observe, validate
 
@@ -563,7 +568,13 @@ class SqlMagic(Magics, Configurable):
                 return result
 
         # JA: added DatabaseError for MySQL
-        except (ProgrammingError, OperationalError, DatabaseError) as e:
+        except (
+            ProgrammingError,
+            OperationalError,
+            DatabaseError,
+            # raised when they query has :parameters but no parameters are given
+            StatementError,
+        ) as e:
             # Sqlite apparently return all errors as OperationalError :/
             self._error_handling(e, command.sql)
         except Exception as e:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -125,7 +125,23 @@ def escape_string_literals_with_colon_prefix(query):
     single_quoted_variable_pattern = r"(?<!\\)':(" + identifier_pattern + r")(?<!\\)\'"
 
     # Replace ":variable" and ':variable' with "\:variable"
-    query = re.sub(double_quoted_variable_pattern, r'"\\:\1"', query)
-    query = re.sub(single_quoted_variable_pattern, r"'\\:\1'", query)
+    query_quoted = re.sub(double_quoted_variable_pattern, r'"\\:\1"', query)
+    query_quoted = re.sub(single_quoted_variable_pattern, r"'\\:\1'", query_quoted)
 
-    return query
+    double_found = re.findall(double_quoted_variable_pattern, query)
+    single_found = re.findall(single_quoted_variable_pattern, query)
+
+    return query_quoted, double_found + single_found
+
+
+def find_named_parameters(input_string):
+    # Define the regular expression pattern for valid Python identifiers
+    identifier_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
+
+    # Define the regular expression pattern for matching :variable format
+    variable_pattern = r'(?<!["\'])\:(' + identifier_pattern + ")"
+
+    # Use findall to extract all matches of :variable from the input string
+    matches = re.findall(variable_pattern, input_string)
+
+    return matches

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -110,10 +110,10 @@ def magic_args(magic_execute, line):
 
 def escape_string_literals_with_colon_prefix(query):
     """
-    Given a query, replaces all ocurrences of ':variable' with '\:variable' and
+    Given a query, replaces all occurrences of ':variable' with '\:variable' and
     ":variable" with "\:variable" so that the query can be passed to sqlalchemy.text
     without the literals being interpreted as bind parameters. It doesn't replace
-    the ocurrences of :variable (without quotes)
+    the occurrences of :variable (without quotes)
     """  # noqa
 
     # Define the regular expression pattern for valid Python identifiers

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -114,7 +114,8 @@ def escape_string_literals_with_colon_prefix(query):
     ":variable" with "\:variable" so that the query can be passed to sqlalchemy.text
     without the literals being interpreted as bind parameters. It doesn't replace
     the ocurrences of :variable (without quotes)
-    """
+    """  # noqa
+
     # Define the regular expression pattern for valid Python identifiers
     identifier_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -1,3 +1,4 @@
+import re
 import itertools
 import shlex
 from os.path import expandvars
@@ -105,3 +106,25 @@ def without_sql_comment(parser, line):
 def magic_args(magic_execute, line):
     line = without_sql_comment(parser=magic_execute.parser, line=line)
     return parse_argstring(magic_execute, line)
+
+
+def escape_string_literals_with_colon_prefix(query):
+    """
+    Given a query, replaces all ocurrences of ':variable' with '\:variable' and
+    ":variable" with "\:variable" so that the query can be passed to sqlalchemy.text
+    without the literals being interpreted as bind parameters. It doesn't replace
+    the ocurrences of :variable (without quotes)
+    """
+    # Define the regular expression pattern for valid Python identifiers
+    identifier_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
+
+    double_quoted_variable_pattern = r'(?<!\\)":(' + identifier_pattern + r')(?<!\\)"'
+
+    # Define the regular expression pattern for matching ':variable' format
+    single_quoted_variable_pattern = r"(?<!\\)':(" + identifier_pattern + r")(?<!\\)\'"
+
+    # Replace ":variable" and ':variable' with "\:variable"
+    query = re.sub(double_quoted_variable_pattern, r'"\\:\1"', query)
+    query = re.sub(single_quoted_variable_pattern, r"'\\:\1'", query)
+
+    return query

--- a/src/sql/run/run.py
+++ b/src/sql/run/run.py
@@ -17,7 +17,7 @@ _COMMIT_BLACKLIST_DIALECTS = (
 )
 
 
-def run_statements(conn, sql, config):
+def run_statements(conn, sql, config, parameters=None):
     """
     Run a SQL query (supports running multiple SQL statements) with the given
     connection. This is the function that's called when executing SQL magic.
@@ -63,7 +63,7 @@ def run_statements(conn, sql, config):
             if is_select and conn.dialect == "duckdb":
                 manual_commit_call_required = False
 
-            result = conn.raw_execute(statement)
+            result = conn.raw_execute(statement, parameters=parameters)
 
             if manual_commit_call_required:
                 _commit_if_needed(conn=conn, config=config)

--- a/src/sql/warnings.py
+++ b/src/sql/warnings.py
@@ -1,2 +1,6 @@
 class JupySQLDataFramePerformanceWarning(UserWarning):
     pass
+
+
+class JupySQLQuotedNamedParametersWarning(UserWarning):
+    pass

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -89,49 +89,58 @@ def ip_empty():
     ConnectionManager.close_all()
 
 
+def insert_sample_data(ip):
+    ip.run_cell(
+        """%%sql
+CREATE TABLE test (n INT, name TEXT);
+INSERT INTO test VALUES (1, 'foo');
+INSERT INTO test VALUES (2, 'bar');
+CREATE TABLE [table with spaces] (first INT, second TEXT);
+CREATE TABLE author (first_name, last_name, year_of_death);
+INSERT INTO author VALUES ('William', 'Shakespeare', 1616);
+INSERT INTO author VALUES ('Bertold', 'Brecht', 1956);
+CREATE TABLE empty_table (column INT, another INT);
+CREATE TABLE website (person, link, birthyear INT);
+INSERT INTO website VALUES ('Bertold Brecht',
+    'https://en.wikipedia.org/wiki/Bertolt_Brecht', 1954 );
+INSERT INTO website VALUES ('William Shakespeare',
+    'https://en.wikipedia.org/wiki/William_Shakespeare', 1564);
+INSERT INTO website VALUES ('Steve Steve', 'google_link', 2023);
+CREATE TABLE number_table (x INT, y INT);
+INSERT INTO number_table VALUES (4, (-2));
+INSERT INTO number_table VALUES ((-5), 0);
+INSERT INTO number_table VALUES (2, 4);
+INSERT INTO number_table VALUES (0, 2);
+INSERT INTO number_table VALUES ((-5), (-1));
+INSERT INTO number_table VALUES ((-2), (-3));
+INSERT INTO number_table VALUES ((-2), (-3));
+INSERT INTO number_table VALUES ((-4), 2);
+INSERT INTO number_table VALUES (2, (-5));
+INSERT INTO number_table VALUES (4, 3);
+"""
+    )
+
+
 @pytest.fixture
 def ip(ip_empty):
     """Provides an IPython session in which tables have been created"""
+    ip_empty.run_cell("%sql sqlite://")
+    insert_sample_data(ip_empty)
 
-    # runsql creates an inmemory sqlitedatabase
-    runsql(
-        ip_empty,
-        [
-            "CREATE TABLE test (n INT, name TEXT)",
-            "INSERT INTO test VALUES (1, 'foo')",
-            "INSERT INTO test VALUES (2, 'bar')",
-            "CREATE TABLE [table with spaces] (first INT, second TEXT)",
-            "CREATE TABLE author (first_name, last_name, year_of_death)",
-            "INSERT INTO author VALUES ('William', 'Shakespeare', 1616)",
-            "INSERT INTO author VALUES ('Bertold', 'Brecht', 1956)",
-            "CREATE TABLE empty_table (column INT, another INT)",
-            "CREATE TABLE website (person, link, birthyear INT)",
-            """INSERT INTO website VALUES ('Bertold Brecht',
-            'https://en.wikipedia.org/wiki/Bertolt_Brecht', 1954 )""",
-            """INSERT INTO website VALUES ('William Shakespeare',
-            'https://en.wikipedia.org/wiki/William_Shakespeare', 1564)""",
-            "INSERT INTO website VALUES ('Steve Steve', 'google_link', 2023)",
-            "CREATE TABLE number_table (x INT, y INT)",
-            "INSERT INTO number_table VALUES (4, (-2))",
-            "INSERT INTO number_table VALUES ((-5), 0)",
-            "INSERT INTO number_table VALUES (2, 4)",
-            "INSERT INTO number_table VALUES (0, 2)",
-            "INSERT INTO number_table VALUES ((-5), (-1))",
-            "INSERT INTO number_table VALUES ((-2), (-3))",
-            "INSERT INTO number_table VALUES ((-2), (-3))",
-            "INSERT INTO number_table VALUES ((-4), 2)",
-            "INSERT INTO number_table VALUES (2, (-5))",
-            "INSERT INTO number_table VALUES (4, 3)",
-        ],
-    )
     yield ip_empty
 
     ConnectionManager.close_all()
 
-    runsql(ip_empty, "DROP TABLE IF EXISTS test")
-    runsql(ip_empty, "DROP TABLE IF EXISTS author")
-    runsql(ip_empty, "DROP TABLE IF EXISTS website")
-    runsql(ip_empty, "DROP TABLE IF EXISTS number_table")
+
+@pytest.fixture
+def ip_dbapi(ip_empty):
+    ip_empty.run_cell("import sqlite3; conn = sqlite3.connect(':memory:');")
+    ip_empty.run_cell("%sql conn")
+    insert_sample_data(ip_empty)
+
+    yield ip_empty
+
+    ConnectionManager.close_all()
 
 
 @pytest.fixture

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1641,7 +1641,7 @@ def test_error_suggests_turning_feature_on_if_it_detects_named_params(ip):
         (
             "%sql SELECT * FROM author where last_name = ':last_name' "
             "and first_name = ':first_name'",
-            "The following variables are defined: last_name, first_name.",
+            "The following variables are defined: first_name, last_name.",
         ),
     ],
     ids=[

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -708,7 +708,7 @@ def test_autopolars(ip):
     ip.run_line_magic("config", "SqlMagic.autopolars = True")
     dframe = runsql(ip, "SELECT * FROM test;")
 
-    assert type(dframe) == pl.DataFrame
+    assert isinstance(dframe, pl.DataFrame)
     assert not dframe.is_empty()
     assert len(dframe.shape) == 2
     assert dframe["name"][0] == "foo"
@@ -747,27 +747,27 @@ def test_autopolars_infer_schema_length(ip):
 
 def test_mutex_autopolars_autopandas(ip):
     dframe = runsql(ip, "SELECT * FROM test;")
-    assert type(dframe) == ResultSet
+    assert isinstance(dframe, ResultSet)
 
     ip.run_line_magic("config", "SqlMagic.autopolars = True")
     dframe = runsql(ip, "SELECT * FROM test;")
-    assert type(dframe) == pl.DataFrame
+    assert isinstance(dframe, pl.DataFrame)
 
     import pandas as pd
 
     ip.run_line_magic("config", "SqlMagic.autopandas = True")
     dframe = runsql(ip, "SELECT * FROM test;")
-    assert type(dframe) == pd.DataFrame
+    assert isinstance(dframe, pd.DataFrame)
 
     # Test that re-enabling autopolars works
     ip.run_line_magic("config", "SqlMagic.autopolars = True")
     dframe = runsql(ip, "SELECT * FROM test;")
-    assert type(dframe) == pl.DataFrame
+    assert isinstance(dframe, pl.DataFrame)
 
     # Disabling autopolars at this point should result in the default behavior
     ip.run_line_magic("config", "SqlMagic.autopolars = False")
     dframe = runsql(ip, "SELECT * FROM test;")
-    assert type(dframe) == ResultSet
+    assert isinstance(dframe, ResultSet)
 
 
 def test_csv(ip):

--- a/src/tests/test_testing.py
+++ b/src/tests/test_testing.py
@@ -1,0 +1,18 @@
+import pytest
+
+from sql._testing import TestingShell
+
+
+@pytest.fixture(scope="module")
+def ip():
+    return TestingShell()
+
+
+def test_testingshell_raises_code_errors(ip):
+    with pytest.raises(ZeroDivisionError):
+        ip.run_cell("1 / 0")
+
+
+def test_testingshell_raises_syntax_errors(ip):
+    with pytest.raises(SyntaxError):
+        ip.run_cell("SELECT * FROM penguins.csv where species = :species")


### PR DESCRIPTION
## Describe your changes

also fixing flake8 lint issues since version 6.1.0 added new rules

## Issue number

Closes #671

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--770.org.readthedocs.build/en/770/

<!-- readthedocs-preview jupysql end -->