### PR TITLE
improves postgres compatibility + more granular feedback config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.9.2dev
 
+* [Fix] Perform `ROLLBACK` when SQLALchemy raises `PendingRollbackError`
+* [Fix] Perform `ROLLBACK` when `psycopg2` raises `current transaction is aborted, commands ignored until end of transaction block`
+* [Fix] Perform `ROLLBACK` when `psycopg2` raises `server closed the connection unexpectedly` (#677)
 * [Fix] Fix a bug that caused a cell with a CTE to fail if it referenced a table/view with the same name as an existing snippet (#753)
 
 ## 0.9.1 (2023-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.9.2dev
+## 0.10.0dev
 
 * [Fix] Perform `ROLLBACK` when SQLAlchemy raises `PendingRollbackError`
 * [Fix] Perform `ROLLBACK` when `psycopg2` raises `current transaction is aborted, commands ignored until end of transaction block`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [API Change] `%config SqlMagic.feedback` now takes values `0` (disabled), `1` (normal), `2` (verbose)
 * [Fix] `ResultSet` footer only displayed when `feedback=2`
 * [Fix] Current connection and switching connections message only displayed when `feedback>=1`
+* [Fix] `--persist/--persist-replace` now perform `ROLLBACK` automatically when needed
 
 ## 0.9.1 (2023-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.2dev
 
-* [Fix] Perform `ROLLBACK` when SQLALchemy raises `PendingRollbackError`
+* [Fix] Perform `ROLLBACK` when SQLAlchemy raises `PendingRollbackError`
 * [Fix] Perform `ROLLBACK` when `psycopg2` raises `current transaction is aborted, commands ignored until end of transaction block`
 * [Fix] Perform `ROLLBACK` when `psycopg2` raises `server closed the connection unexpectedly` (#677)
 * [Fix] Fix a bug that caused a cell with a CTE to fail if it referenced a table/view with the same name as an existing snippet (#753)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * [Fix] Perform `ROLLBACK` when `psycopg2` raises `current transaction is aborted, commands ignored until end of transaction block`
 * [Fix] Perform `ROLLBACK` when `psycopg2` raises `server closed the connection unexpectedly` (#677)
 * [Fix] Fix a bug that caused a cell with a CTE to fail if it referenced a table/view with the same name as an existing snippet (#753)
+* [Fix] Shorter `displaylimit` footer
+* [API Change] `%config SqlMagic.feedback` now takes values `0` (disabled), `1` (normal), `2` (verbose)
+* [Fix] `ResultSet` footer only displayed when `feedback=2`
+* [Fix] Current connection and switching connections message only displayed when `feedback>=1`
 
 ## 0.9.1 (2023-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [API Change] `%config SqlMagic.feedback` now takes values `0` (disabled), `1` (normal), `2` (verbose)
 * [Fix] `ResultSet` footer only displayed when `feedback=2`
 * [Fix] Current connection and switching connections message only displayed when `feedback>=1`
-* [Fix] `--persist/--persist-replace` now perform `ROLLBACK` automatically when needed
+* [Fix] `--persist/--persist-replace` perform `ROLLBACK` automatically when needed
 
 ## 0.9.1 (2023-08-10)
 

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -199,16 +199,21 @@ To unset:
 ## `feedback`
 
 ```{versionchanged} 0.10
-`feedback` takes values `0`, `2`, and `2` instead of `True`/`False`
+`feedback` takes values `0`, `1`, and `2` instead of `True`/`False`
 ```
 
 Default: `1`
 
-Control the quantity of feedback displayed when performing certain operations:
+Control the quantity of messages displayed when performing certain operations. Each
+value enables the ones from previous values plus new ones:
 
-- `0`: No feedback
+- `0`: Minimal feedback
 - `1`: Normal feedback (default)
+  - Connection name when switching
+  - Connection name when running a query
+  - Number of rows afffected by DML (e.g., `INSERT`, `UPDATE`, `DELETE`)
 - `2`: All feedback
+  - Footer to distinguish pandas/polars data frames from JupySQL's result sets
 
 ## `style`
 

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -66,7 +66,7 @@ If you have autopandas set to true, the displaylimit option will not apply. You 
 ## Changing configuration
 
 ```{code-cell} ipython3
-%config SqlMagic.feedback = False
+%config SqlMagic.feedback = 0
 ```
 
 ## `displaycon`
@@ -198,31 +198,17 @@ To unset:
 
 ## `feedback`
 
-Default: `True`
-
-Print number of rows affected by DML.
-
-```{code-cell} ipython3
-%config SqlMagic.feedback = True
+```{versionchanged} 0.10
+`feedback` takes values `0`, `2`, and `2` instead of `True`/`False`
 ```
 
-```{code-cell} ipython3
-%%sql
-CREATE TABLE my_points (x, y);
-INSERT INTO my_points VALUES (0, 0);
-INSERT INTO my_points VALUES (1, 1);
-```
+Default: `1`
 
-```{code-cell} ipython3
-%config SqlMagic.feedback = False
-```
+Control the quantity of feedback displayed when performing certain operations:
 
-```{code-cell} ipython3
-%%sql
-CREATE TABLE more_points (x, y);
-INSERT INTO more_points VALUES (0, 0);
-INSERT INTO more_points VALUES (1, 1);
-```
+- `0`: No feedback
+- `1`: Normal feedback (default)
+- `2`: All feedback
 
 ## `style`
 
@@ -244,6 +230,9 @@ print(res)
 
 ## `named_parameters`
 
+```{versionadded} 0.9
+```
+
 Default: `False`
 
 If True, it enables named parameters `:variable`. Learn more in the [tutorial.](../user-guide/template.md)
@@ -263,7 +252,7 @@ FROM languages
 WHERE rating > :rating
 ```
 
-## Loading configuration from a `pyproject.toml` file
+## Loading from `pyproject.toml`
 
 ```{versionadded} 0.9
 ```

--- a/src/sql/__init__.py
+++ b/src/sql/__init__.py
@@ -2,7 +2,7 @@
 from sql.magic import RenderMagic, SqlMagic, load_ipython_extension
 from sql.connection import PLOOMBER_DOCS_LINK_STR
 
-__version__ = "0.9.2dev"
+__version__ = "0.10.0dev"
 
 
 __all__ = [

--- a/src/sql/__init__.py
+++ b/src/sql/__init__.py
@@ -1,13 +1,7 @@
-# I dont think we need all these imports
-from sql.magic import RenderMagic, SqlMagic, load_ipython_extension
-from sql.connection import PLOOMBER_DOCS_LINK_STR
+from sql.magic import load_ipython_extension
+
 
 __version__ = "0.10.0dev"
 
 
-__all__ = [
-    "RenderMagic",
-    "SqlMagic",
-    "load_ipython_extension",
-    "PLOOMBER_DOCS_LINK_STR",
-]
+__all__ = ["load_ipython_extension"]

--- a/src/sql/__init__.py
+++ b/src/sql/__init__.py
@@ -1,3 +1,4 @@
+# I dont think we need all these imports
 from sql.magic import RenderMagic, SqlMagic, load_ipython_extension
 from sql.connection import PLOOMBER_DOCS_LINK_STR
 

--- a/src/sql/_current.py
+++ b/src/sql/_current.py
@@ -1,0 +1,17 @@
+__sql_magic = None
+
+
+def _get_sql_magic():
+    if __sql_magic is None:
+        raise RuntimeError("SqlMagic has not been loaded yet.")
+
+    return __sql_magic
+
+
+def _set_sql_magic(sql_magic):
+    global __sql_magic
+    __sql_magic = sql_magic
+
+
+def _config_feedback_all():
+    return _get_sql_magic().feedback >= 2

--- a/src/sql/_current.py
+++ b/src/sql/_current.py
@@ -1,21 +1,27 @@
+"""Get/set the current SqlMagic instance."""
+
 __sql_magic = None
 
 
 def _get_sql_magic():
+    """Returns the current SqlMagic instance."""
     if __sql_magic is None:
-        raise RuntimeError("SqlMagic has not been loaded yet.")
+        raise RuntimeError("%sql has not been loaded yet. Run %load_ext sql")
 
     return __sql_magic
 
 
 def _set_sql_magic(sql_magic):
+    """Sets the current SqlMagic instance."""
     global __sql_magic
     __sql_magic = sql_magic
 
 
 def _config_feedback_all():
+    """Returns True if the current feedback level is >=2"""
     return _get_sql_magic().feedback >= 2
 
 
 def _config_feedback_normal_or_more():
+    """Returns True if the current feedback level is >=1"""
     return _get_sql_magic().feedback >= 1

--- a/src/sql/_current.py
+++ b/src/sql/_current.py
@@ -15,3 +15,7 @@ def _set_sql_magic(sql_magic):
 
 def _config_feedback_all():
     return _get_sql_magic().feedback >= 2
+
+
+def _config_feedback_normal_or_more():
+    return _get_sql_magic().feedback >= 1

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -680,6 +680,8 @@ class SQLAlchemyConnection(AbstractConnection):
                     category=JupySQLRollbackPerformed,
                 )
                 rollback_needed = True
+            else:
+                raise
 
         if rollback_needed:
             self._connection.rollback()

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -652,7 +652,7 @@ class SQLAlchemyConnection(AbstractConnection):
         # not be a SELECT
         is_select = first_word_statement in {"select", "with", "from"}
 
-        operation = partial(self._connection_sqlalchemy.execute, query, parameters)
+        operation = partial(self._execute_with_parameters, query, parameters)
         out = self._execute_with_error_handling(operation)
 
         if self._requires_manual_commit:

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -21,7 +21,6 @@ import sqlparse
 from ploomber_core.exceptions import modify_exceptions
 
 
-from sql import exceptions
 from sql.store import store
 from sql.telemetry import telemetry
 from sql import exceptions, display

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -873,11 +873,16 @@ class SQLAlchemyConnection(AbstractConnection):
 
     def to_table(self, table_name, data_frame, if_exists, index):
         """Create a table from a pandas DataFrame"""
-        # TODO: perform a rollback automatically if needed
+        operation = partial(
+            data_frame.to_sql,
+            table_name,
+            self.connection_sqlalchemy,
+            if_exists=if_exists,
+            index=index,
+        )
+
         try:
-            data_frame.to_sql(
-                table_name, self.connection_sqlalchemy, if_exists=if_exists, index=index
-            )
+            self._execute_with_error_handling(operation)
         except ValueError:
             raise exceptions.ValueError(
                 f"Table {table_name!r} already exists. Consider using "

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -21,6 +21,7 @@ import sqlparse
 from ploomber_core.exceptions import modify_exceptions
 
 
+from sql import exceptions
 from sql.store import store
 from sql.telemetry import telemetry
 from sql import exceptions, display
@@ -983,7 +984,7 @@ class DBAPIConnection(AbstractConnection):
         )
 
     def to_table(self, table_name, data_frame, if_exists, index):
-        raise NotImplementedError(
+        raise exceptions.NotImplementedError(
             "--persist/--persist-replace is not available for DBAPI connections"
             " (only available for SQLAlchemy connections)"
         )

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -26,6 +26,7 @@ from sql import exceptions, display
 from sql.error_message import detail
 from sql.parse import escape_string_literals_with_colon_prefix, find_named_parameters
 from sql.warnings import JupySQLQuotedNamedParametersWarning, JupySQLRollbackPerformed
+from sql import _current
 
 
 PLOOMBER_DOCS_LINK_STR = (
@@ -214,7 +215,10 @@ class ConnectionManager:
                 # passing an existing descriptor and not alias: use existing connection
                 elif existing and alias is None:
                     cls.current = existing
-                    display.message(f"Switching to connection {descriptor}")
+
+                    if _current._config_feedback_normal_or_more():
+                        display.message(f"Switching to connection {descriptor}")
+
                 # passing the same URL but different alias: create a new connection
                 elif existing is None or existing.alias != alias:
                     cls.current = cls.from_connect_str(
@@ -227,7 +231,7 @@ class ConnectionManager:
 
         else:
             if cls.connections:
-                if displaycon:
+                if displaycon and _current._config_feedback_normal_or_more():
                     cls.display_current_connection()
             elif os.getenv("DATABASE_URL"):
                 cls.current = cls.from_connect_str(

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -37,9 +37,9 @@ MissingPackageError = exception_factory("MissingPackageError")
 # https://docs.python.org/3/library/exceptions.html#bltin-exceptions
 TypeError = exception_factory("TypeError")
 RuntimeError = exception_factory("RuntimeError")
-
 ValueError = exception_factory("ValueError")
 FileNotFoundError = exception_factory("FileNotFoundError")
+NotImplementedError = exception_factory("NotImplementedError")
 
 # The following are internal exceptions that should not be raised directly
 

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -37,6 +37,7 @@ MissingPackageError = exception_factory("MissingPackageError")
 # https://docs.python.org/3/library/exceptions.html#bltin-exceptions
 TypeError = exception_factory("TypeError")
 RuntimeError = exception_factory("RuntimeError")
+
 ValueError = exception_factory("ValueError")
 FileNotFoundError = exception_factory("FileNotFoundError")
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -696,11 +696,6 @@ def load_SqlMagic_configs(ip):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    # this fails in both Firefox and Chrome for OS X.
-    # I get the error: TypeError: IPython.CodeCell.config_defaults is undefined
-
-    # js = "IPython.CodeCell.config_defaults.highlight_modes['magic_sql'] = {'reg':[/^%%sql/]};" # noqa
-    # display_javascript(js, raw=True)
     ip.register_magics(SqlMagic)
     ip.register_magics(RenderMagic)
     ip.register_magics(SqlPlotMagic)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -696,7 +696,6 @@ def load_SqlMagic_configs(ip):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-
     # this fails in both Firefox and Chrome for OS X.
     # I get the error: TypeError: IPython.CodeCell.config_defaults is undefined
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -96,15 +96,17 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
-    displaycon = Bool(True, config=True, help="Show connection string after execution")
+    displaycon = Bool(
+        default_value=True, config=True, help="Show connection string after execution"
+    )
     autolimit = Int(
-        0,
+        default_value=0,
         config=True,
         allow_none=True,
         help="Automatically limit the size of the returned result sets",
     )
     style = Unicode(
-        "DEFAULT",
+        default_value="DEFAULT",
         config=True,
         help=(
             "Set the table printing style to any of prettytable's "
@@ -113,12 +115,12 @@ class SqlMagic(Magics, Configurable):
         ),
     )
     short_errors = Bool(
-        True,
+        default_value=True,
         config=True,
         help="Don't display the full traceback on SQL Programming Error",
     )
     displaylimit = Int(
-        10,
+        default_value=10,
         config=True,
         allow_none=True,
         help=(
@@ -127,17 +129,17 @@ class SqlMagic(Magics, Configurable):
         ),
     )
     autopandas = Bool(
-        False,
+        default_value=False,
         config=True,
         help="Return Pandas DataFrames instead of regular result sets",
     )
     autopolars = Bool(
-        False,
+        default_value=False,
         config=True,
         help="Return Polars DataFrames instead of regular result sets",
     )
     polars_dataframe_kwargs = Dict(
-        {},
+        default_value={},
         config=True,
         help=(
             "Polars DataFrame constructor keyword arguments"
@@ -145,27 +147,32 @@ class SqlMagic(Magics, Configurable):
         ),
     )
     column_local_vars = Bool(
-        False, config=True, help="Return data into local variables from column names"
+        default_value=False,
+        config=True,
+        help="Return data into local variables from column names",
     )
 
     # TODO: check the existing place where we are using this
     # TODO: update documentation
     feedback = Int(
-        default_value=1, config=True, help="Verbosity level. 0=minimal, 1=normal, 2=all"
+        default_value=1,
+        config=True,
+        help="Verbosity level. 0=disabled, 1=normal, 2=verbose",
     )
 
     dsn_filename = Unicode(
-        "odbc.ini",
+        default_value="odbc.ini",
         config=True,
         help="Path to DSN file. "
         "When the first argument is of the form [section], "
         "a sqlalchemy connection string is formed from the "
         "matching section in the DSN file.",
     )
-    autocommit = Bool(True, config=True, help="Set autocommit mode")
+
+    autocommit = Bool(default_value=True, config=True, help="Set autocommit mode")
 
     named_parameters = Bool(
-        False,
+        default_value=False,
         config=True,
         help=(
             "Allow named parameters in queries "

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -647,6 +647,7 @@ class SqlMagic(Magics, Configurable):
         else:
             if_exists = "fail"
 
+        # TODO: perform a rollback automatically if needed
         try:
             frame.to_sql(
                 table_name, conn.connection_sqlalchemy, if_exists=if_exists, index=index

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -152,8 +152,6 @@ class SqlMagic(Magics, Configurable):
         help="Return data into local variables from column names",
     )
 
-    # TODO: check the existing place where we are using this
-    # TODO: update documentation
     feedback = Int(
         default_value=1,
         config=True,

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -659,18 +659,7 @@ class SqlMagic(Magics, Configurable):
         else:
             if_exists = "fail"
 
-        # TODO: perform a rollback automatically if needed
-        try:
-            frame.to_sql(
-                table_name, conn.connection_sqlalchemy, if_exists=if_exists, index=index
-            )
-        except ValueError:
-            raise exceptions.ValueError(
-                f"""Table {table_name!r} already exists. Consider using \
---persist-replace to drop the table before persisting the data frame"""
-            )
-
-        display.message_success(f"Success! Persisted {table_name} to the database.")
+        conn.to_table(name=table_name, data=frame, if_exists=if_exists, index=index)
 
 
 def set_configs(ip, file_path):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -659,7 +659,9 @@ class SqlMagic(Magics, Configurable):
         else:
             if_exists = "fail"
 
-        conn.to_table(name=table_name, data=frame, if_exists=if_exists, index=index)
+        conn.to_table(
+            table_name=table_name, data_frame=frame, if_exists=if_exists, index=index
+        )
 
 
 def set_configs(ip, file_path):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -155,7 +155,7 @@ class SqlMagic(Magics, Configurable):
     feedback = Int(
         default_value=1,
         config=True,
-        help="Verbosity level. 0=disabled, 1=normal, 2=verbose",
+        help="Verbosity level. 0=minimal, 1=normal, 2=all",
     )
 
     dsn_filename = Unicode(

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -41,6 +41,7 @@ from sql import query_util, util
 from sql.util import get_suggestions_message, pretty_print
 from sql.exceptions import RuntimeError
 from sql.error_message import detail
+from sql._current import _set_sql_magic
 
 
 from ploomber_core.dependencies import check_installed
@@ -146,7 +147,13 @@ class SqlMagic(Magics, Configurable):
     column_local_vars = Bool(
         False, config=True, help="Return data into local variables from column names"
     )
-    feedback = Bool(True, config=True, help="Print number of rows affected by DML")
+
+    # TODO: check the existing place where we are using this
+    # TODO: update documentation
+    feedback = Int(
+        default_value=1, config=True, help="Verbosity level. 0=minimal, 1=normal, 2=all"
+    )
+
     dsn_filename = Unicode(
         "odbc.ini",
         config=True,
@@ -695,8 +702,11 @@ def load_SqlMagic_configs(ip):
 
 
 def load_ipython_extension(ip):
-    """Load the extension in IPython."""
-    ip.register_magics(SqlMagic)
+    """Load the magics, this function is executed when the user runs: %load_ext sql"""
+    sql_magic = SqlMagic(ip)
+    _set_sql_magic(sql_magic)
+
+    ip.register_magics(sql_magic)
     ip.register_magics(RenderMagic)
     ip.register_magics(SqlPlotMagic)
     ip.register_magics(SqlCmdMagic)

--- a/src/sql/run/resultset.py
+++ b/src/sql/run/resultset.py
@@ -12,6 +12,7 @@ from sql.column_guesser import ColumnGuesserMixin
 from sql.run.csv import CSVWriter, CSVResultDescriptor
 from sql.telemetry import telemetry
 from sql.run.table import CustomPrettyTable
+from sql._current import _config_feedback_all
 
 
 class ResultSet(ColumnGuesserMixin):
@@ -146,15 +147,16 @@ class ResultSet(ColumnGuesserMixin):
 
         result = self._pretty_table.get_html_string()
 
-        HTML = (
-            "%s\n<span style='font-style:italic;font-size:11px'>"
-            "<code>ResultSet</code> : to convert to pandas, call <a href="
-            "'https://jupysql.ploomber.io/en/latest/integrations/pandas.html'>"
-            "<code>.DataFrame()</code></a> or to polars, call <a href="
-            "'https://jupysql.ploomber.io/en/latest/integrations/polars.html'>"
-            "<code>.PolarsDataFrame()</code></a></span><br>"
-        )
-        result = HTML % (result)
+        if _config_feedback_all():
+            HTML = (
+                "%s\n<span style='font-style:italic;font-size:11px'>"
+                "<code>ResultSet</code>: to convert to pandas, call <a href="
+                "'https://jupysql.ploomber.io/en/latest/integrations/pandas.html'>"
+                "<code>.DataFrame()</code></a> or to polars, call <a href="
+                "'https://jupysql.ploomber.io/en/latest/integrations/polars.html'>"
+                "<code>.PolarsDataFrame()</code></a></span><br>"
+            )
+            result = HTML % (result)
 
         # to create clickable links
         result = html.unescape(result)

--- a/src/sql/run/resultset.py
+++ b/src/sql/run/resultset.py
@@ -165,13 +165,11 @@ class ResultSet(ColumnGuesserMixin):
         if self._config.displaylimit != 0 and not self._done_fetching():
             HTML = (
                 '%s\n<span style="font-style:italic;text-align:center;">'
-                "Truncated to displaylimit of %d</span>"
-                "<br>"
-                '<span style="font-style:italic;text-align:center;">'
-                "If you want to see more, please visit "
-                '<a href="https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit">displaylimit</a>'  # noqa: E501
-                " configuration</span>"
+                'Truncated to <a href="https://jupysql.ploomber.io/en/'
+                'latest/api/configuration.html#displaylimit">'
+                "displaylimit</a> of %d.</span>"
             )
+
             result = HTML % (result, self._config.displaylimit)
         return result
 

--- a/src/sql/run/run.py
+++ b/src/sql/run/run.py
@@ -40,7 +40,11 @@ def run_statements(conn, sql, config, parameters=None):
         else:
             result = conn.raw_execute(statement, parameters=parameters)
 
-            if config.feedback and hasattr(result, "rowcount") and result.rowcount > 0:
+            if (
+                config.feedback >= 1
+                and hasattr(result, "rowcount")
+                and result.rowcount > 0
+            ):
                 display.message_success(f"{result.rowcount} rows affected.")
 
     result_set = ResultSet(result, config, statement, conn)

--- a/src/sql/warnings.py
+++ b/src/sql/warnings.py
@@ -1,2 +1,6 @@
 class JupySQLQuotedNamedParametersWarning(UserWarning):
     pass
+
+
+class JupySQLRollbackPerformed(UserWarning):
+    pass

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -20,7 +20,6 @@ PATH_TO_TMP_ASSETS = PATH_TO_TESTS / "tmp"
 PATH_TO_TMP_ASSETS.mkdir(exist_ok=True)
 
 
-# TODO: reset config as well (note that we have two copies of this fixture)
 @pytest.fixture(scope="function", autouse=True)
 def isolate_tests(monkeypatch):
     """
@@ -29,13 +28,17 @@ def isolate_tests(monkeypatch):
 
     Also clear up any stored snippets.
     """
+    # reset connections
     connections = {}
     monkeypatch.setattr(connection.ConnectionManager, "connections", connections)
     monkeypatch.setattr(connection.ConnectionManager, "current", None)
 
+    # reset store
     store.store = store.SQLStore()
 
     yield
+
+    # close connections
     connection.ConnectionManager.close_all()
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -13,12 +13,14 @@ from sql.connection import ConnectionManager
 from sql._testing import TestingShell
 from sql import connection
 from sql import store
+from sql import _current
 
 PATH_TO_TESTS = Path(__file__).absolute().parent
 PATH_TO_TMP_ASSETS = PATH_TO_TESTS / "tmp"
 PATH_TO_TMP_ASSETS.mkdir(exist_ok=True)
 
 
+# TODO: reset config as well (note that we have two copies of this fixture)
 @pytest.fixture(scope="function", autouse=True)
 def isolate_tests(monkeypatch):
     """
@@ -81,7 +83,10 @@ def ip_empty():
     c.HistoryAccessor.enabled = False
     ip_session = TestingShell(config=c)
 
-    ip_session.register_magics(SqlMagic)
+    sql_magic = SqlMagic(ip_session)
+    _current._set_sql_magic(sql_magic)
+
+    ip_session.register_magics(sql_magic)
     ip_session.register_magics(RenderMagic)
     ip_session.register_magics(SqlPlotMagic)
     ip_session.register_magics(SqlCmdMagic)

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -28,9 +28,12 @@ def isolate_tests(monkeypatch):
 
     Also clear up any stored snippets.
     """
+    # reset connections
     connections = {}
     monkeypatch.setattr(connection.ConnectionManager, "connections", connections)
     monkeypatch.setattr(connection.ConnectionManager, "current", None)
+
+    # reset store
     store.store = store.SQLStore()
 
     yield

--- a/src/tests/test_column_guesser.py
+++ b/src/tests/test_column_guesser.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sql.magic import SqlMagic
+from sql import _current
 from IPython.core.interactiveshell import InteractiveShell
 
 ip = InteractiveShell()
@@ -20,6 +21,7 @@ sql_env = SqlEnv("sqlite://")
 @pytest.fixture
 def tbl():
     sqlmagic = SqlMagic(shell=ip)
+    _current._set_sql_magic(sqlmagic)
     ip.register_magics(sqlmagic)
     creator = """
         DROP TABLE IF EXISTS manycoltbl;

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -560,7 +560,12 @@ def test_set_no_descriptor_database_url(monkeypatch):
     assert ConnectionManager.current == conn
 
 
-def test_feedback_when_switching_connection_with_alias(ip_empty, tmp_empty, capsys):
+@pytest.mark.parametrize("feedback", [1, 2])
+def test_feedback_when_switching_connection_with_alias(
+    ip_empty, tmp_empty, capsys, feedback
+):
+    ip_empty.run_cell(f"%config SqlMagic.feedback = {feedback}")
+
     ip_empty.run_cell("%load_ext sql")
     ip_empty.run_cell("%sql duckdb:// --alias one")
     ip_empty.run_cell("%sql duckdb:// --alias two")
@@ -570,7 +575,12 @@ def test_feedback_when_switching_connection_with_alias(ip_empty, tmp_empty, caps
     assert "Switching to connection one" == captured.out.replace("\n", "")
 
 
-def test_feedback_when_switching_connection_without_alias(ip_empty, tmp_empty, capsys):
+@pytest.mark.parametrize("feedback", [1, 2])
+def test_feedback_when_switching_connection_without_alias(
+    ip_empty, tmp_empty, capsys, feedback
+):
+    ip_empty.run_cell(f"%config SqlMagic.feedback = {feedback}")
+
     ip_empty.run_cell("%load_ext sql")
     ip_empty.run_cell("%sql duckdb://")
     ip_empty.run_cell("%sql duckdb:// --alias one")
@@ -579,6 +589,18 @@ def test_feedback_when_switching_connection_without_alias(ip_empty, tmp_empty, c
 
     captured = capsys.readouterr()
     assert "Switching to connection duckdb://" == captured.out.replace("\n", "")
+
+
+def test_no_switching_connection_feedback_if_disabled(ip_empty, capsys):
+    ip_empty.run_cell("%config SqlMagic.feedback = 0")
+
+    ip_empty.run_cell("%sql duckdb://")
+    ip_empty.run_cell("%sql duckdb:// --alias one")
+    ip_empty.run_cell("%sql duckdb:// --alias two")
+    ip_empty.run_cell("%sql duckdb://")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 @pytest.fixture

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -11,7 +11,7 @@ import sqlalchemy
 import sqlite3
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import ResourceClosedError
+from sqlalchemy import exc
 
 import sql.connection
 from sql.connection import (
@@ -22,6 +22,7 @@ from sql.connection import (
     default_alias_for_engine,
     ResultSetCollection,
 )
+from sql.warnings import JupySQLRollbackPerformed
 
 
 @pytest.fixture
@@ -366,10 +367,10 @@ def test_close_all(ip_empty, monkeypatch):
 
     ConnectionManager.close_all()
 
-    with pytest.raises(ResourceClosedError):
+    with pytest.raises(exc.ResourceClosedError):
         connections_copy["sqlite://"].execute("").fetchall()
 
-    with pytest.raises(ResourceClosedError):
+    with pytest.raises(exc.ResourceClosedError):
         connections_copy["duckdb://"].execute("").fetchall()
 
     assert not ConnectionManager.connections
@@ -828,3 +829,118 @@ def test_result_set_collection_is_last():
     assert len(collection) == 2
     assert collection.is_last(first)
     assert not collection.is_last(second)
+
+
+def test_execute_rollback_if_pendingrollbackerror_is_raised(monkeypatch):
+    conn = SQLAlchemyConnection(engine=create_engine("duckdb://"))
+
+    mock_execute = Mock(
+        side_effect=[
+            exc.PendingRollbackError("rollback"),
+            "RESULTS",
+        ]
+    )
+    mock_rollback = Mock()
+
+    conn._connection_sqlalchemy.execute = mock_execute
+    conn._connection_sqlalchemy.rollback = mock_rollback
+
+    with pytest.warns(JupySQLRollbackPerformed) as record:
+        results = conn.execute("SELECT * FROM table")
+
+    assert results == "RESULTS"
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "Found invalid transaction. JupySQL executed a ROLLBACK operation."
+    )
+
+
+def test_execute_rollback_if_current_transaction_aborted(monkeypatch):
+    conn = SQLAlchemyConnection(engine=create_engine("duckdb://"))
+
+    class InFailedSqlTransaction:
+        def __str__(self) -> str:
+            return (
+                "current transaction is aborted, "
+                "commands ignored until end of transaction block"
+            )
+
+    orig = InFailedSqlTransaction()
+    sqlalchemy_error = exc.InternalError("internal error", params={}, orig=orig)
+
+    mock_execute = Mock(
+        side_effect=[
+            sqlalchemy_error,
+            "RESULTS",
+        ]
+    )
+    mock_rollback = Mock()
+
+    conn._connection_sqlalchemy.execute = mock_execute
+    # TODO: check this was called
+    conn._connection_sqlalchemy.rollback = mock_rollback
+
+    with pytest.warns(JupySQLRollbackPerformed) as record:
+        results = conn.execute("SELECT * FROM table")
+
+    assert results == "RESULTS"
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "Current transaction is aborted. JupySQL executed a ROLLBACK operation."
+    )
+
+
+def test_execute_rollback_if_server_closes_connection(monkeypatch):
+    conn = SQLAlchemyConnection(engine=create_engine("duckdb://"))
+
+    class OperationalError:
+        def __str__(self) -> str:
+            return "server closed the connection unexpectedly"
+
+    orig = OperationalError()
+    sqlalchemy_error = exc.OperationalError("internal error", params={}, orig=orig)
+
+    mock_execute = Mock(
+        side_effect=[
+            sqlalchemy_error,
+            "RESULTS",
+        ]
+    )
+    mock_rollback = Mock()
+
+    conn._connection_sqlalchemy.execute = mock_execute
+    # TODO: check this was called
+    conn._connection_sqlalchemy.rollback = mock_rollback
+
+    with pytest.warns(JupySQLRollbackPerformed) as record:
+        results = conn.execute("SELECT * FROM table")
+
+    assert results == "RESULTS"
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "Server closed connection. JupySQL executed a ROLLBACK operation."
+    )
+
+
+def test_ignore_internalerror_if_it_doesnt_match_the_selected_patterns(monkeypatch):
+    conn = SQLAlchemyConnection(engine=create_engine("duckdb://"))
+
+    class SomeError:
+        def __str__(self) -> str:
+            return "message"
+
+    orig = SomeError()
+    internal_error = exc.InternalError("internal error", params={}, orig=orig)
+
+    mock_execute = Mock(side_effect=internal_error)
+    conn._connection_sqlalchemy.execute = mock_execute
+
+    with pytest.raises(exc.InternalError) as excinfo:
+        conn.execute("SELECT * FROM table")
+
+    assert "(test_connection.SomeError) message" in str(excinfo.value)
+    assert isinstance(excinfo.value.orig, SomeError)
+    assert str(excinfo.value.orig) == "message"

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -854,6 +854,7 @@ def test_execute_rollback_if_pendingrollbackerror_is_raised(monkeypatch):
         record[0].message.args[0]
         == "Found invalid transaction. JupySQL executed a ROLLBACK operation."
     )
+    mock_rollback.assert_called_once_with()
 
 
 def test_execute_rollback_if_current_transaction_aborted(monkeypatch):
@@ -878,7 +879,6 @@ def test_execute_rollback_if_current_transaction_aborted(monkeypatch):
     mock_rollback = Mock()
 
     conn._connection_sqlalchemy.execute = mock_execute
-    # TODO: check this was called
     conn._connection_sqlalchemy.rollback = mock_rollback
 
     with pytest.warns(JupySQLRollbackPerformed) as record:
@@ -890,6 +890,7 @@ def test_execute_rollback_if_current_transaction_aborted(monkeypatch):
         record[0].message.args[0]
         == "Current transaction is aborted. JupySQL executed a ROLLBACK operation."
     )
+    mock_rollback.assert_called_once_with()
 
 
 def test_execute_rollback_if_server_closes_connection(monkeypatch):
@@ -911,7 +912,6 @@ def test_execute_rollback_if_server_closes_connection(monkeypatch):
     mock_rollback = Mock()
 
     conn._connection_sqlalchemy.execute = mock_execute
-    # TODO: check this was called
     conn._connection_sqlalchemy.rollback = mock_rollback
 
     with pytest.warns(JupySQLRollbackPerformed) as record:
@@ -923,6 +923,7 @@ def test_execute_rollback_if_server_closes_connection(monkeypatch):
         record[0].message.args[0]
         == "Server closed connection. JupySQL executed a ROLLBACK operation."
     )
+    mock_rollback.assert_called_once_with()
 
 
 def test_ignore_internalerror_if_it_doesnt_match_the_selected_patterns(monkeypatch):

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1738,3 +1738,21 @@ select * from author_subset
     assert "Cannot use --with with CTEs, remove --with and re-run the cell" in str(
         excinfo.value
     )
+
+
+def test_error_if_using_persist_with_dbapi_connection(ip_dbapi):
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    ip_dbapi.push({"df": df})
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_dbapi.run_cell("%sql --persist df")
+
+    message = (
+        "--persist/--persist-replace is not available for "
+        "DBAPI connections (only available for SQLAlchemy connections)"
+    )
+    assert message in str(excinfo.value)
+
+
+def test_persist_uses_error_handling_method():
+    pass

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -28,6 +28,11 @@ import psutil
 
 COMMUNITY = COMMUNITY.strip()
 
+DISPLAYLIMIT_LINK = (
+    '<a href="https://jupysql.ploomber.io/en/'
+    'latest/api/configuration.html#displaylimit">displaylimit</a>'
+)
+
 
 def test_memory_db(ip):
     assert runsql(ip, "SELECT * FROM test;")[0][0] == 1
@@ -576,7 +581,7 @@ def test_displaylimit_default(ip):
 
     out = ip.run_cell("%sql SELECT * FROM number_table;").result
 
-    assert "Truncated to displaylimit of 10" in out._repr_html_()
+    assert f"Truncated to {DISPLAYLIMIT_LINK} of 10" in out._repr_html_()
 
 
 def test_displaylimit(ip):
@@ -599,7 +604,7 @@ def test_displaylimit_enabled_truncated_length(ip, config_value, expected_length
 
     ip.run_cell(f"%config SqlMagic.displaylimit = {config_value}")
     out = runsql(ip, "SELECT * FROM number_table;")
-    assert f"Truncated to displaylimit of {expected_length}" in out._repr_html_()
+    assert f"Truncated to {DISPLAYLIMIT_LINK} of {expected_length}" in out._repr_html_()
 
 
 @pytest.mark.parametrize("config_value", [(None), (0)])
@@ -667,7 +672,7 @@ def test_displaylimit_with_conditional_clause(
         out = runsql(ip, query_clause)
 
     if expected_truncated_length:
-        assert "Truncated to displaylimit of 10" in out._repr_html_()
+        assert f"Truncated to {DISPLAYLIMIT_LINK} of 10" in out._repr_html_()
 
 
 def test_column_local_vars(ip):

--- a/src/tests/test_magic_display.py
+++ b/src/tests/test_magic_display.py
@@ -1,4 +1,10 @@
-def test_connection_string_displayed(ip_empty, capsys):
+import pytest
+
+
+@pytest.mark.parametrize("feedback", [1, 2])
+def test_connection_string_displayed(ip_empty, capsys, feedback):
+    ip_empty.run_cell(f"%config SqlMagic.feedback  = {feedback}")
+
     ip_empty.run_cell("%sql duckdb://")
     ip_empty.run_cell("%sql show tables")
 
@@ -6,7 +12,10 @@ def test_connection_string_displayed(ip_empty, capsys):
     assert "Running query in 'duckdb://'" in captured.out
 
 
-def test_dbapi_connection_display(ip_empty, capsys, tmp_empty):
+@pytest.mark.parametrize("feedback", [1, 2])
+def test_dbapi_connection_display(ip_empty, capsys, tmp_empty, feedback):
+    ip_empty.run_cell(f"%config SqlMagic.feedback  = {feedback}")
+
     ip_empty.run_cell("import duckdb")
     ip_empty.run_cell("custom = duckdb.connect('anotherdb')")
     ip_empty.run_cell("%sql custom")
@@ -16,13 +25,26 @@ def test_dbapi_connection_display(ip_empty, capsys, tmp_empty):
     assert "Running query in 'DuckDBPyConnection'" in captured.out
 
 
-def test_connection_string_hidden_when_passing_alias(ip_empty, capsys):
+@pytest.mark.parametrize("feedback", [1, 2])
+def test_connection_string_hidden_when_passing_alias(ip_empty, capsys, feedback):
+    ip_empty.run_cell(f"%config SqlMagic.feedback  = {feedback}")
+
     ip_empty.run_cell("%sql duckdb:// --alias myduckdbconn")
     ip_empty.run_cell("%sql show tables")
 
     captured = capsys.readouterr()
     assert "duckdb://" not in captured.out
     assert "Running query in 'myduckdbconn'" in captured.out
+
+
+def test_no_display_connection_if_feedback_disabled(ip_empty, capsys):
+    ip_empty.run_cell("%config SqlMagic.feedback  = 0")
+
+    ip_empty.run_cell("%sql duckdb://")
+    ip_empty.run_cell("%sql show tables")
+
+    captured = capsys.readouterr()
+    assert "Running query in" not in captured.out
 
 
 def test_display_message_when_persisting_data_frames(ip_empty, capsys):

--- a/src/tests/test_resultset.py
+++ b/src/tests/test_resultset.py
@@ -82,16 +82,27 @@ def test_resultset_str(result_set):
     assert str(result_set) == "+---+\n| x |\n+---+\n| 0 |\n| 1 |\n| 2 |\n+---+"
 
 
-def test_resultset_repr_html(result_set):
+def test_resultset_repr_html_when_feedback_is_2(result_set, ip_empty):
+    ip_empty.run_cell("%config SqlMagic.feedback = 2")
+
     html_ = result_set._repr_html_()
     assert (
         "<span style='font-style:italic;font-size:11px'>"
-        "<code>ResultSet</code> : to convert to pandas, call <a href="
+        "<code>ResultSet</code>: to convert to pandas, call <a href="
         "'https://jupysql.ploomber.io/en/latest/integrations/pandas.html'>"
         "<code>.DataFrame()</code></a> or to polars, call <a href="
         "'https://jupysql.ploomber.io/en/latest/integrations/polars.html'>"
         "<code>.PolarsDataFrame()</code></a></span><br>"
     ) in html_
+
+
+@pytest.mark.parametrize("feedback", [0, 1])
+def test_resultset_repr_html_with_reduced_feedback(result_set, ip_empty, feedback):
+    ip_empty.run_cell(f"%config SqlMagic.feedback = {feedback}")
+
+    html = result_set._repr_html_()
+    assert "pandas" not in html
+    assert "polars" not in html
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_resultset.py
+++ b/src/tests/test_resultset.py
@@ -1,3 +1,4 @@
+import string
 from unittest.mock import Mock, call
 
 import duckdb
@@ -507,11 +508,18 @@ def test_display_limit_respected_even_when_feched_all(results):
 @pytest.mark.parametrize(
     "displaylimit, message",
     [
-        (1, "Truncated to displaylimit of 1"),
-        (2, "Truncated to displaylimit of 2"),
+        (1, "Truncated to $HTML_LINK of 1."),
+        (2, "Truncated to $HTML_LINK of 2."),
     ],
 )
 def test_displaylimit_message(displaylimit, message, results):
+    HTML_LINK = (
+        '<a href="https://jupysql.ploomber.io/en/'
+        'latest/api/configuration.html#displaylimit">displaylimit</a>'
+    )
+
+    message = string.Template(message).substitute(HTML_LINK=HTML_LINK)
+
     mock = Mock()
     mock.displaylimit = displaylimit
     mock.autolimit = 0


### PR DESCRIPTION
## Describe your changes

* [Fix] Perform `ROLLBACK` when SQLAlchemy raises `PendingRollbackError`
* [Fix] Perform `ROLLBACK` when `psycopg2` raises `current transaction is aborted, commands ignored until end of transaction block`
* [Fix] Perform `ROLLBACK` when `psycopg2` raises `server closed the connection unexpectedly` (closes #677)
* [Fix] Shorter `displaylimit` footer
* [API Change] `%config SqlMagic.feedback` now takes values `0` (disabled), `1` (normal), `2` (verbose)
* [Fix] `ResultSet` footer only displayed when `feedback=2`
* [Fix] Current connection and switching connections message only displayed when `feedback>=1`
* [Fix] `--persist/--persist-replace` perform `ROLLBACK` automatically when needed

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--798.org.readthedocs.build/en/798/

<!-- readthedocs-preview jupysql end -->