### PR TITLE
loading from `.ini` files API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# db connection files
+*.ini
+
 # profiling data
 *.lprof
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * [Fix] Current connection and switching connections message only displayed when `feedback>=1`
 * [Fix] `--persist/--persist-replace` perform `ROLLBACK` automatically when needed
 * [Fix] `ResultSet` footer (when `displaylimit` truncates results and when showing how to convert to a data frame) now appears in the `ResultSet` plain text representation (#682)
-* [API Change] When loading connections from a `.ini` file via `--section section_name`, the connection alias is set to the section name automatically
+* [API Change] When loading connections from a `.ini` file via `%sql --section section_name`, the connection alias is set to the section name automatically
+* [API Change] Starting connections from a `.ini` file via `%sql [section_name]` has been deprecated
 
 ## 0.9.1 (2023-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [Fix] Current connection and switching connections message only displayed when `feedback>=1`
 * [Fix] `--persist/--persist-replace` perform `ROLLBACK` automatically when needed
 * [Fix] `ResultSet` footer (when `displaylimit` truncates results and when showing how to convert to a data frame) now appears in the `ResultSet` plain text representation (#682)
-* [API Change] When loading connections from a `.ini` file via `%sql --section section_name`, the connection alias is set to the section name automatically
+* [API Change] When loading connections from a `.ini` file via `%sql --section section_name`, the section name is set as the connection alias
 * [API Change] Starting connections from a `.ini` file via `%sql [section_name]` has been deprecated
 
 ## 0.9.1 (2023-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [Fix] Current connection and switching connections message only displayed when `feedback>=1`
 * [Fix] `--persist/--persist-replace` perform `ROLLBACK` automatically when needed
 * [Fix] `ResultSet` footer (when `displaylimit` truncates results and when showing how to convert to a data frame) now appears in the `ResultSet` plain text representation (#682)
+* [API Change] When loading connections from a `.ini` file via `--section section_name`, the connection alias is set to the section name automatically
 
 ## 0.9.1 (2023-08-10)
 

--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -13,6 +13,7 @@ parts:
     - file: user-guide/tables-columns
     - file: user-guide/ggplot
     - file: user-guide/template
+    - file: user-guide/connection-file
     - file: user-guide/table_explorer
     - file: user-guide/data-profiling
 

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -7,7 +7,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.7
+    jupytext_version: 1.15.0
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python

--- a/doc/api/magic-sql.md
+++ b/doc/api/magic-sql.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.6
+    jupytext_version: 1.15.0
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -33,7 +33,7 @@ You can view the documentation and command line arguments by running `%sql?`
     Specify creator function for new connection ([example](#specify-creator-function))
 
 ``-s`` / ``--section <section-name>``
-    Section of dsn_file to be used for generating a connection string
+    Section of dsn_file to be used for generating a connection string ([example](#start-a-connection-from-ini-file))
 
 ``-p`` / ``--persist``
     Create a table name in the database from the named DataFrame ([example](#create-table))
@@ -161,6 +161,31 @@ def creator():
 
 ```{code-cell} ipython3
 %sql --creator creator
+```
+
+## Start a connection from `.ini file`
+
+Use `--section` to start a connection from the `dsn_filename`. To learn more, see: [](../user-guide/connection-file.md)
+
+```{code-cell} ipython3
+%config SqlMagic.dsn_filename
+```
+
+```{code-cell} ipython3
+from pathlib import Path
+
+Path("odbc.ini").write_text("""
+[duck]
+drivername = duckdb
+""")
+```
+
+```{code-cell} ipython3
+%sql --section duck
+```
+
+```{code-cell} ipython3
+%sql --connections
 ```
 
 ## Create table

--- a/doc/community/vs.md
+++ b/doc/community/vs.md
@@ -8,6 +8,8 @@ If you're migrating from `ipython-sql` to JupySQL, these are the differences (in
 
 - Since `0.6` JupySQL no longer supports old versions of IPython
 - Variable expansion is replaced from `{variable}`, `${variable}` to `{{variable}}`
+- Variable expansion via `:variable` has been disable by default, but can be enabled with [`%config SqlMagic.named_parameters = True`](../api/configuration)
+- Since `0.10.0`, loading connections from a `.ini` file using `%sql [section_name]` has been deprecated. Use `%sql --section section_name` instead.
 
 ## New features
 

--- a/doc/user-guide/connection-file.md
+++ b/doc/user-guide/connection-file.md
@@ -98,9 +98,10 @@ Loading connections from the `.ini` (`%sql [section_name]`) file has been deprec
 from urllib.request import urlretrieve
 from pathlib import Path
 
+url = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv"
+
 if not Path("penguins.csv").exists():
-    urlretrieve("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv",
-                "penguins.csv")
+    urlretrieve(url, "penguins.csv")
 ```
 
 ```{code-cell} ipython3

--- a/doc/user-guide/connection-file.md
+++ b/doc/user-guide/connection-file.md
@@ -1,0 +1,159 @@
+---
+jupytext:
+  notebook_metadata_filter: myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.15.0
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+myst:
+  html_meta:
+    description lang=en: Using a connection file
+    keywords: jupyter, jupysql, sqlalchemy
+    property=og:locale: en_US
+---
+
+# Using a connection file
+
+Using a connection file is the recommended way to manage connections, it helps you to:
+
+- Avoid storing your credentials in your notebook
+- Manage multiple database connections
+- Define them in a single place to use it in all your notebooks
+
+```{code-cell} ipython3
+%load_ext sql
+```
+
+By default, connections are read/stored in a `odbc.ini` file:
+
+```{code-cell} ipython3
+%config SqlMagic.dsn_filename
+```
+
+However, you can change this:
+
+```{code-cell} ipython3
+%config SqlMagic.dsn_filename = "my-connections.ini"
+```
+
+The `.ini` format defines sections and you can define key-value pairs within each section. For example:
+
+```ini
+[section_name]
+key = value
+```
+
+Add a section and set the key-value pairs to add a new connection. When JupySQL loads them, it'll initialize a [`sqlalchemy.engine.URL`](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create) object and then start the connection. Valid keys are:
+
+- `drivername`: the name of the database backend
+- `username`: the username
+- `password`: database password
+- `host`: name of the host
+- `port`: the port number
+- `database`: the database name
+- `query`: a dictionary of string keys to be passed to the connection upon connect (learn more [here](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create))
+
+For example, to configure an in-memory DuckDB database:
+
+```ini
+[duck]
+drivername = duckdb
+```
+
+```{code-cell} ipython3
+from pathlib import Path
+
+_ = Path("my-connections.ini").write_text("""
+[duck]
+drivername = duckdb
+""")
+```
+
+To connect to a database defined in the connections file, use `--section` and pass the section name:
+
+```{code-cell} ipython3
+%sql --section duck
+```
+
+```{versionchanged} 0.10.0
+The connection alias is automatically set when using `%sql --section`
+```
+
+Note that the alias is set to the section name:
+
+```{code-cell} ipython3
+%sql --connections
+```
+
+```{versionchanged} 0.10.0
+Loading connections from the `.ini` (`%sql [section_name]`) file has been deprecated. Use `%sql --section section_name` instead.
+```
+
+```{code-cell} ipython3
+%%sql
+drop table if exists penguins;
+
+create table penguins as
+select * from
+'https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv'
+```
+
+```{code-cell} ipython3
+%%sql
+select * from penguins
+```
+
+Let's now define another connection so we can show how we can manage multiple ones:
+
+```{code-cell} ipython3
+from pathlib import Path
+
+_ = Path("my-connections.ini").write_text("""
+[duck]
+drivername = duckdb
+
+[second_duck]
+drivername = duckdb
+""")
+```
+
+Start a new connection from the `second_duck` section name:
+
+```{code-cell} ipython3
+%sql --section second_duck
+```
+
+```{code-cell} ipython3
+%sql --connections
+```
+
+There are no tables since this is a new database:
+
+```{code-cell} ipython3
+%sqlcmd tables
+```
+
+If we switch to the first connection (by passing the alias), we'll see the table:
+
+```{code-cell} ipython3
+%sql duck
+```
+
+```{code-cell} ipython3
+%sqlcmd tables
+```
+
+We can change back to the other connection:
+
+```{code-cell} ipython3
+%sql second_duck
+```
+
+```{code-cell} ipython3
+%sqlcmd tables
+```

--- a/doc/user-guide/connection-file.md
+++ b/doc/user-guide/connection-file.md
@@ -95,12 +95,20 @@ Loading connections from the `.ini` (`%sql [section_name]`) file has been deprec
 ```
 
 ```{code-cell} ipython3
+from urllib.request import urlretrieve
+from pathlib import Path
+
+if not Path("penguins.csv").exists():
+    urlretrieve("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv",
+                "penguins.csv")
+```
+
+```{code-cell} ipython3
 %%sql
 drop table if exists penguins;
 
 create table penguins as
-select * from
-'https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv'
+select * from penguins.csv
 ```
 
 ```{code-cell} ipython3
@@ -111,8 +119,6 @@ select * from penguins
 Let's now define another connection so we can show how we can manage multiple ones:
 
 ```{code-cell} ipython3
-from pathlib import Path
-
 _ = Path("my-connections.ini").write_text("""
 [duck]
 drivername = duckdb

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -161,6 +161,15 @@ def rough_dict_get(dct, sought, default=None):
     return default
 
 
+def _error_invalid_connection_info(e, connect_str):
+    err = UsageError(
+        "An error happened while creating the connection: "
+        f"{e}.{_suggest_fix(env_var=False, connect_str=connect_str)}"
+    )
+    err.modify_exception = True
+    return err
+
+
 class ConnectionManager:
     """A class to manage and create database connections"""
 
@@ -371,7 +380,7 @@ class ConnectionManager:
                 )
             ) from e
         except Exception as e:
-            raise cls._error_invalid_connection_info(e, connect_str) from e
+            raise _error_invalid_connection_info(e, connect_str) from e
 
         connection = SQLAlchemyConnection(engine, alias=alias, config=config)
         connection.connect_args = connect_args
@@ -864,16 +873,7 @@ class SQLAlchemyConnection(AbstractConnection):
             else:
                 print(e)
         except Exception as e:
-            raise cls._error_invalid_connection_info(e, connect_str) from e
-
-    @classmethod
-    def _error_invalid_connection_info(cls, e, connect_str):
-        err = UsageError(
-            "An error happened while creating the connection: "
-            f"{e}.{_suggest_fix(env_var=False, connect_str=connect_str)}"
-        )
-        err.modify_exception = True
-        return err
+            raise _error_invalid_connection_info(e, connect_str) from e
 
     def to_table(self, table_name, data_frame, if_exists, index):
         """Create a table from a pandas DataFrame"""

--- a/src/sql/exceptions.py
+++ b/src/sql/exceptions.py
@@ -38,6 +38,7 @@ MissingPackageError = exception_factory("MissingPackageError")
 TypeError = exception_factory("TypeError")
 RuntimeError = exception_factory("RuntimeError")
 ValueError = exception_factory("ValueError")
+KeyError = exception_factory("KeyError")
 FileNotFoundError = exception_factory("FileNotFoundError")
 NotImplementedError = exception_factory("NotImplementedError")
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -422,6 +422,12 @@ class SqlMagic(Magics, Configurable):
 
         args = command.args
 
+        if args.section and args.alias:
+            raise exceptions.UsageError(
+                "Cannot use --section with --alias since the section name "
+                "is automatically set as the connection alias"
+            )
+
         is_cte = command.sql_original.strip().lower().startswith("with ")
 
         # only expand CTE if this is not a CTE itself
@@ -494,7 +500,7 @@ class SqlMagic(Magics, Configurable):
             displaycon=self.displaycon,
             connect_args=args.connection_arguments,
             creator=args.creator,
-            alias=args.alias,
+            alias=args.section if args.section else args.alias,
             config=self,
         )
         payload["connection_info"] = conn._get_database_information()

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -467,7 +467,7 @@ class SqlMagic(Magics, Configurable):
         connect_arg = command.connection
 
         if args.section:
-            connect_arg = sql.parse.connection_from_dsn_section(args.section, self)
+            connect_arg = sql.parse.connection_str_from_dsn_section(args.section, self)
 
         if args.connection_arguments:
             try:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -8,7 +8,7 @@ from sqlalchemy.engine.url import URL
 from IPython.core.magic_arguments import parse_argstring
 
 
-def connection_from_dsn_section(section, config):
+def connection_str_from_dsn_section(section, config):
     parser = CP.ConfigParser()
     parser.read(config.dsn_filename)
     cfg_dict = dict(parser.items(section))

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -24,9 +24,10 @@ def connection_str_from_dsn_section(section, config):
         The config object, must have a dsn_filename attribute
     """
     parser = ConfigParser()
+    dsn_file = Path(config.dsn_filename)
 
     try:
-        cfg_content = Path(config.dsn_filename).read_text()
+        cfg_content = dsn_file.read_text()
     except FileNotFoundError as e:
         raise exceptions.FileNotFoundError(
             f"%config SqlMagic.dsn_filename ({config.dsn_filename!r}) not found."

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -4,6 +4,7 @@ import shlex
 from os.path import expandvars
 from pathlib import Path
 from configparser import ConfigParser, NoSectionError
+import warnings
 
 from sqlalchemy.engine.url import URL
 from IPython.core.magic_arguments import parse_argstring
@@ -84,7 +85,16 @@ def _connection_string(s, config):
         parser.read(config.dsn_filename)
         cfg_dict = dict(parser.items(section))
         url = URL.create(**cfg_dict)
-        return str(url.render_as_string(hide_password=False))
+        url_ = str(url.render_as_string(hide_password=False))
+
+        warnings.warn(
+            "Starting connections with: %sql [section_name] is deprecated "
+            "and will be removed in a future release. "
+            "Please use: %sql --section section_name instead.",
+            category=FutureWarning,
+        )
+
+        return url_
 
     return ""
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -60,13 +60,9 @@ def connection_str_from_dsn_section(section, config):
     return str(url.render_as_string(hide_password=False))
 
 
-# NOTE: this is legacy code. I noted that the behavior is inconsistency since it'll
-# pass the raw connection string (password visible) if the input is a raw string
-# but it'll hide the password if the input is a section in the DSN file.
 def _connection_string(s, config):
     """
-    Given a string, return a SQLAlchemy connection string if
-    possible.
+    Given a string, return a SQLAlchemy connection string if possible.
 
     Scenarios:
 
@@ -87,7 +83,8 @@ def _connection_string(s, config):
         parser = ConfigParser()
         parser.read(config.dsn_filename)
         cfg_dict = dict(parser.items(section))
-        return str(URL.create(**cfg_dict))
+        url = URL.create(**cfg_dict)
+        return str(url.render_as_string(hide_password=False))
 
     return ""
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -44,7 +44,20 @@ def connection_str_from_dsn_section(section, config):
         ) from e
 
     cfg_dict = dict(cfg)
-    return str(URL.create(**cfg_dict).render_as_string(hide_password=False))
+
+    try:
+        url = URL.create(**cfg_dict)
+    except TypeError as e:
+        if "unexpected keyword argument" in str(e):
+            raise exceptions.TypeError(
+                f"%config SqlMagic.dsn_filename ({config.dsn_filename!r}) is invalid. "
+                "It must only contain the following keys: drivername, username, "
+                "password, host, port, database, query"
+            ) from e
+        else:
+            raise
+
+    return str(url.render_as_string(hide_password=False))
 
 
 # NOTE: this is legacy code. I noted that the behavior is inconsistency since it'll

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -25,8 +25,13 @@ def connection_str_from_dsn_section(section, config):
     return str(URL.create(**cfg_dict).render_as_string(hide_password=False))
 
 
+# NOTE: this is legacy code. I noted that the behavior is inconsistency since it'll
+# pass the raw connection string (password visible) if the input is a raw string
+# but it'll hide the password if the input is a section in the DSN file.
 def _connection_string(s, config):
-    """Given a string, return a SQLAlchemy connection string if possible.
+    """
+    Given a string, return a SQLAlchemy connection string if
+    possible.
 
     Scenarios:
 

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1881,7 +1881,6 @@ drivername = duckdb
     assert conns == {"duck": ANY}
 
 
-# TODO: set the alias as well?
 def test_connect_to_db_in_connections_file_using_section_name_between_square_brackets(
     ip_empty, tmp_empty
 ):
@@ -1893,8 +1892,14 @@ drivername = duckdb
     )
 
     ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
-    ip_empty.run_cell("%sql [duck]")
 
+    with pytest.warns(FutureWarning) as record:
+        ip_empty.run_cell("%sql [duck]")
+
+    assert "Starting connections with: %sql [section_name] is deprecated" in str(
+        record[0].message
+    )
+    assert len(record) == 1
     conns = ConnectionManager.connections
     assert conns == {"duckdb://": ANY}
 

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1,3 +1,4 @@
+from unittest.mock import ANY
 import uuid
 import logging
 import platform
@@ -20,6 +21,7 @@ from sql.magic import SqlMagic
 from sql.run.resultset import ResultSet
 from sql import magic
 from sql.warnings import JupySQLQuotedNamedParametersWarning
+
 
 from conftest import runsql
 from sql.connection import PLOOMBER_DOCS_LINK_STR
@@ -1770,3 +1772,108 @@ def test_persist_uses_error_handling_method(ip, monkeypatch, cell):
     # ensure this got called because this function handles several sqlalchemy edge
     # cases
     execute_with_error_handling_mock.assert_called_once()
+
+
+def test_error_when_using_section_argument_but_dsn_is_missing(ip_empty, tmp_empty):
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'path/to/connections.ini'")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql --section some_section")
+
+    assert excinfo.value.error_type == "FileNotFoundError"
+    assert "%config SqlMagic.dsn_filename ('path/to/connections.ini') not found" in str(
+        excinfo.value
+    )
+
+
+def test_error_when_using_section_argument_but_dsn_section_is_missing(
+    ip_empty, tmp_empty
+):
+    Path("connections.ini").write_text(
+        """
+[section]
+key = value
+"""
+    )
+
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql --section another_section")
+
+    assert excinfo.value.error_type == "KeyError"
+
+    message = (
+        "The section 'another_section' does not exist in the "
+        "connections file 'connections.ini'"
+    )
+    assert message in str(excinfo.value)
+
+
+def test_error_when_using_section_argument_but_keys_are_invalid(ip_empty, tmp_empty):
+    Path("connections.ini").write_text(
+        """
+[section]
+key = value
+"""
+    )
+
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql --section section")
+
+    assert excinfo.value.error_type == "TypeError"
+
+    message = "%config SqlMagic.dsn_filename ('connections.ini') is invalid"
+    assert message in str(excinfo.value)
+
+
+def test_error_when_using_section_argument_but_values_are_invalid(ip_empty, tmp_empty):
+    Path("connections.ini").write_text(
+        """
+[section]
+drivername = not-a-driver
+"""
+    )
+
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell("%sql --section section")
+
+    message = "Could not parse SQLAlchemy URL from string 'not-a-driver://'"
+    assert message in str(excinfo.value)
+
+
+def test_connect_to_db_in_connections_file_using_section_argument(ip_empty, tmp_empty):
+    Path("connections.ini").write_text(
+        """
+[duck]
+drivername = duckdb
+"""
+    )
+
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
+
+    ip_empty.run_cell("%sql --section duck")
+
+    conns = ConnectionManager.connections
+    assert conns == {"duckdb://": ANY}
+
+
+def test_connect_to_db_in_connections_file_using_section_name_between_square_brackets(
+    ip_empty, tmp_empty
+):
+    Path("connections.ini").write_text(
+        """
+[duck]
+drivername = duckdb
+"""
+    )
+
+    ip_empty.run_cell("%config SqlMagic.dsn_filename = 'connections.ini'")
+    ip_empty.run_cell("%sql [duck]")
+
+    conns = ConnectionManager.connections
+    assert conns == {"duckdb://": ANY}

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -178,7 +178,7 @@ def test_connection_from_dsn_section(section, expected):
 
 
 @pytest.mark.parametrize(
-    "s, expected",
+    "input_, expected",
     [
         ("", ""),
         (
@@ -186,7 +186,10 @@ def test_connection_from_dsn_section(section, expected):
             "drivername://user:pass@host:port/db",
         ),
         ("drivername://", "drivername://"),
-        ("[DB_CONFIG_1]", "postgres://goesto11:***@my.remote.host:5432/pgmain"),
+        (
+            "[DB_CONFIG_1]",
+            "postgres://goesto11:seentheelephant@my.remote.host:5432/pgmain",
+        ),
         ("DB_CONFIG_1", ""),
         ("not-a-url", ""),
     ],
@@ -199,8 +202,8 @@ def test_connection_from_dsn_section(section, expected):
         "not-a-url",
     ],
 )
-def test_connection_string(s, expected):
-    assert _connection_string(s, DummyConfig) == expected
+def test_connection_string(input_, expected):
+    assert _connection_string(input_, DummyConfig) == expected
 
 
 class Bunch:

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from sql.parse import (
-    connection_from_dsn_section,
+    connection_str_from_dsn_section,
     parse,
     without_sql_comment,
     magic_args,
@@ -159,9 +159,13 @@ class DummyConfig:
 
 
 def test_connection_from_dsn_section():
-    result = connection_from_dsn_section(section="DB_CONFIG_1", config=DummyConfig())
+    result = connection_str_from_dsn_section(
+        section="DB_CONFIG_1", config=DummyConfig()
+    )
     assert result == "postgres://goesto11:seentheelephant@my.remote.host:5432/pgmain"
-    result = connection_from_dsn_section(section="DB_CONFIG_2", config=DummyConfig())
+    result = connection_str_from_dsn_section(
+        section="DB_CONFIG_2", config=DummyConfig()
+    )
     assert result == "mysql://thefin:fishputsfishonthetable@127.0.0.1/dolfin"
 
 


### PR DESCRIPTION
## Describe your changes

* [API Change] When loading connections from a `.ini` file via `%sql --section section_name`, the section name is set as the connection alias
* [API Change] Starting connections from a `.ini` file via `%sql [section_name]` has been deprecated


Also:

* Added missing documentation about reading `.ini` files
* Added missing unit tests

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--803.org.readthedocs.build/en/803/

<!-- readthedocs-preview jupysql end -->