### PR TITLE
error when passing a non-identifier to connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Feature] Automatically connect if the `dsn_filename` (defaults to `~/.jupysql/connections.ini`) contains a `default` section
 * [Feature] Add `%sqlcmd connect` to see existing connections and create new ones (#632)
+* [Fix] Improve error when passing a non-identifier to start a connection (#764)
 
 ## 0.10.0 (2023-08-19)
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -104,7 +104,7 @@ class SQLCommand:
         # print("end")
 
         # if not (add_conn or add_alias) and one_arg:
-        if self.sql and len(self.sql.split(" ")) > 0:
+        if not (add_conn or add_alias) and one_arg and self.sql:
             first_arg = self.sql.split(" ")[0]
             # Getting variable value when `%sql {{variable}}` is passed
             # if first_arg.startswith("{{") and first_arg.endswith("}}"):

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -56,6 +56,7 @@ class SQLCommand:
         else:
             add_alias = False
 
+        '''
         if not (add_conn or add_alias) and one_arg:
             first_arg = self.args.line[0]
             # Getting variable value when `%sql {{variable}}` is passed
@@ -70,6 +71,7 @@ class SQLCommand:
                 )
             ):
                 validate_nonidentifier_connection(first_arg)
+        '''
 
         self.command_text = " ".join(line_for_command) + "\n" + cell
 
@@ -96,6 +98,26 @@ class SQLCommand:
         if self.args.with_:
             final = store.render(self.parsed["sql"], with_=self.args.with_)
             self.parsed["sql"] = str(final)
+
+        # print(self.sql)
+
+        # print("end")
+
+        # if not (add_conn or add_alias) and one_arg:
+        if self.sql and len(self.sql.split(" ")) > 0:
+            first_arg = self.sql.split(" ")[0]
+            # Getting variable value when `%sql {{variable}}` is passed
+            # if first_arg.startswith("{{") and first_arg.endswith("}}"):
+            #     first_arg = user_ns[first_arg[2:-2]]
+
+            if (
+                # FIXME Can be removed after %sql [section_name] is removed
+                not (first_arg.startswith("[") and first_arg.endswith("]"))
+                and not (
+                    self.args.persist_replace or self.args.persist or self.args.append
+                )
+            ):
+                validate_nonidentifier_connection(first_arg)
 
     @property
     def sql(self):

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -82,17 +82,13 @@ class SQLCommand:
             final = store.render(self.parsed["sql"], with_=self.args.with_)
             self.parsed["sql"] = str(final)
 
-        if not (add_conn or add_alias) and one_arg and self.sql:
-            first_arg = self.sql.split(" ")[0]
-
-            if (
-                # FIXME Can be removed after %sql [section_name] is removed
-                not (first_arg.startswith("[") and first_arg.endswith("]"))
-                and not (
-                    self.args.persist_replace or self.args.persist or self.args.append
-                )
-            ):
-                validate_nonidentifier_connection(first_arg)
+        if (
+            one_arg
+            and self.sql
+            and not (add_conn or add_alias)
+            and not (self.args.persist_replace or self.args.persist or self.args.append)
+        ):
+            validate_nonidentifier_connection(self.sql.split(" ")[0])
 
     @property
     def sql(self):

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -56,7 +56,7 @@ class SQLCommand:
         else:
             add_alias = False
 
-        '''
+        """
         if not (add_conn or add_alias) and one_arg:
             first_arg = self.args.line[0]
             # Getting variable value when `%sql {{variable}}` is passed
@@ -71,7 +71,7 @@ class SQLCommand:
                 )
             ):
                 validate_nonidentifier_connection(first_arg)
-        '''
+        """
 
         self.command_text = " ".join(line_for_command) + "\n" + cell
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -56,23 +56,6 @@ class SQLCommand:
         else:
             add_alias = False
 
-        """
-        if not (add_conn or add_alias) and one_arg:
-            first_arg = self.args.line[0]
-            # Getting variable value when `%sql {{variable}}` is passed
-            if first_arg.startswith("{{") and first_arg.endswith("}}"):
-                first_arg = user_ns[first_arg[2:-2]]
-
-            if (
-                # FIXME Can be removed after %sql [section_name] is removed
-                not (first_arg.startswith("[") and first_arg.endswith("]"))
-                and not (
-                    self.args.persist_replace or self.args.persist or self.args.append
-                )
-            ):
-                validate_nonidentifier_connection(first_arg)
-        """
-
         self.command_text = " ".join(line_for_command) + "\n" + cell
 
         if self.args.file:
@@ -99,16 +82,8 @@ class SQLCommand:
             final = store.render(self.parsed["sql"], with_=self.args.with_)
             self.parsed["sql"] = str(final)
 
-        # print(self.sql)
-
-        # print("end")
-
-        # if not (add_conn or add_alias) and one_arg:
         if not (add_conn or add_alias) and one_arg and self.sql:
             first_arg = self.sql.split(" ")[0]
-            # Getting variable value when `%sql {{variable}}` is passed
-            # if first_arg.startswith("{{") and first_arg.endswith("}}"):
-            #     first_arg = user_ns[first_arg[2:-2]]
 
             if (
                 # FIXME Can be removed after %sql [section_name] is removed

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -27,7 +27,6 @@ from traitlets import Bool, Int, TraitError, Unicode, Dict, observe, validate
 
 import warnings
 import shlex
-import ast
 from difflib import get_close_matches
 import sql.connection
 import sql.parse
@@ -499,22 +498,6 @@ class SqlMagic(Magics, Configurable):
             args.connection_arguments = {}
         if args.creator:
             args.creator = user_ns[args.creator]
-
-        if (
-            len(args.line) == 1
-            and not args.line[0].isidentifier()
-            and not command.connection  # When passing connection as a variable
-            and not (args.persist_replace or args.persist or args.append)
-        ):
-            try:
-                ast.parse(args.line[0])
-                raise exceptions.UsageError(
-                    f"'{args.line[0]}' is not a valid connection identifier. "
-                    "Please pass the variable's name directly, as passing "
-                    "object attributes, dictionaries or lists won't work."
-                )
-            except SyntaxError:
-                pass
 
         # this creates a new connection or use an existing one
         # depending on the connect_arg value

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -27,6 +27,7 @@ from traitlets import Bool, Int, TraitError, Unicode, Dict, observe, validate
 
 import warnings
 import shlex
+import ast
 from difflib import get_close_matches
 import sql.connection
 import sql.parse
@@ -498,6 +499,22 @@ class SqlMagic(Magics, Configurable):
             args.connection_arguments = {}
         if args.creator:
             args.creator = user_ns[args.creator]
+
+        if (
+            len(args.line) == 1
+            and not args.line[0].isidentifier()
+            and not command.connection  # When passing connection as a variable
+            and not (args.persist_replace or args.persist or args.append)
+        ):
+            try:
+                ast.parse(args.line[0])
+                raise exceptions.UsageError(
+                    f"'{args.line[0]}' is not a valid connection identifier. "
+                    "Please pass the variable's name directly, as passing "
+                    "object attributes, dictionaries or lists won't work."
+                )
+            except SyntaxError:
+                pass
 
         # this creates a new connection or use an existing one
         # depending on the connect_arg value

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -7,6 +7,7 @@ from sql import exceptions, display
 import json
 from pathlib import Path
 from ploomber_core.dependencies import requires
+import ast
 
 try:
     import toml
@@ -527,3 +528,29 @@ def validate_mutually_exclusive_args(arg_names, args):
             f"{pretty_print(specified_args)} are specified. "
             "You can only specify one of them."
         )
+
+
+def validate_nonidentifier_connection(arg):
+    """
+    Raises UsageError if a connection is passed to `%sql/%%sql` through
+    object property, list, or dictionary.
+
+    Parameters
+    ----------
+    arg : str
+        argument to check whether it is a valid connection or not
+    """
+    if not arg.isidentifier() and is_valid_python_code(arg):
+        raise exceptions.UsageError(
+            f"'{arg}' is not a valid connection identifier. "
+            "Please pass the variable's name directly, as passing "
+            "object attributes, dictionaries or lists won't work."
+        )
+
+
+def is_valid_python_code(code):
+    try:
+        ast.parse(code)
+        return True
+    except SyntaxError:
+        return False


### PR DESCRIPTION
## Describe your changes

When a connection is pass through dictionary, list, or object, it raises an error with a more detailed message.

For instance, when `%sql some_list[0]` is passed to connect, it raises the following error.
```
UsageError: 'some_list[0]' is not a valid connection identifier. Please pass the variable's name directly, as passing object attributes, dictionaries or lists won't work.
```

## Issue number

Closes #764 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--821.org.readthedocs.build/en/821/

<!-- readthedocs-preview jupysql end -->