### PR TITLE
add `--schema` to %sqlcmd commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Feature] Automatically connect if the `dsn_filename` (defaults to `~/.jupysql/connections.ini`) contains a `default` section
 * [Feature] Add `%sqlcmd connect` to see existing connections and create new ones (#632)
+* [Feature] Add `--schema/-s` for `%sqlcmd` commands that support `--table/-t` and ensure `--table schema.table` works (#519)
 * [Fix] Clearer error messages when failing to initialize a connection
 * [Doc] Added section on installing database drivers
 * [Fix] Improve error when passing a non-identifier to start a connection (#764)

--- a/src/sql/cmd/explore.py
+++ b/src/sql/cmd/explore.py
@@ -1,5 +1,4 @@
 from sql.widgets import TableWidget
-from IPython.display import display
 from sql.cmd.cmd_utils import CmdParser
 
 
@@ -21,4 +20,4 @@ def explore(others):
     parser.add_argument("-s", "--schema", type=str, help="Schema name", required=False)
     args = parser.parse_args(others)
     table_widget = TableWidget(args.table, args.schema)
-    display(table_widget)
+    return table_widget

--- a/src/sql/cmd/explore.py
+++ b/src/sql/cmd/explore.py
@@ -18,7 +18,7 @@ def explore(others):
     """
     parser = CmdParser()
     parser.add_argument("-t", "--table", type=str, help="Table name", required=True)
+    parser.add_argument("-s", "--schema", type=str, help="Schema name", required=False)
     args = parser.parse_args(others)
-
-    table_widget = TableWidget(args.table)
+    table_widget = TableWidget(args.table, args.schema)
     display(table_widget)

--- a/src/sql/cmd/test.py
+++ b/src/sql/cmd/test.py
@@ -23,7 +23,11 @@ def return_test_results(args, conn, query):
 
 
 def run_each_individually(args, conn):
-    base_query = select("*").from_(args.table)
+    if args.schema:
+        table_ = f"{args.schema}.{args.table}"
+    else:
+        table_ = args.table
+    base_query = select("*").from_(table_)
 
     storage = {}
 
@@ -99,6 +103,7 @@ def test(others):
     parser = CmdParser()
 
     parser.add_argument("-t", "--table", type=str, help="Table name", required=True)
+    parser.add_argument("-s", "--schema", type=str, help="Schema name", required=False)
     parser.add_argument("-c", "--column", type=str, help="Column name", required=False)
     parser.add_argument(
         "-g",

--- a/src/sql/inspect.py
+++ b/src/sql/inspect.py
@@ -180,6 +180,8 @@ class Columns(DatabaseInspection):
         # this returns a list of dictionaries. e.g.,
         # [{"name": "column_a", "type": "INT"}
         #  {"name": "column_b", "type": "FLOAT"}]
+        if not schema and "." in name:
+            schema, name = name.split(".")
         columns = inspector.get_columns(name, schema) or []
 
         self._table = PrettyTable()

--- a/src/sql/widgets/table_widget/table_widget.py
+++ b/src/sql/widgets/table_widget/table_widget.py
@@ -16,7 +16,7 @@ BASE_DIR = os.path.dirname(__file__)
 
 class TableWidget:
     @telemetry.log_call("TableWidget-init")
-    def __init__(self, table, schema):
+    def __init__(self, table, schema=None):
         """
         Creates an HTML table element and populates it with SQL table
 

--- a/src/sql/widgets/table_widget/table_widget.py
+++ b/src/sql/widgets/table_widget/table_widget.py
@@ -16,7 +16,7 @@ BASE_DIR = os.path.dirname(__file__)
 
 class TableWidget:
     @telemetry.log_call("TableWidget-init")
-    def __init__(self, table):
+    def __init__(self, table, schema):
         """
         Creates an HTML table element and populates it with SQL table
 
@@ -28,13 +28,13 @@ class TableWidget:
 
         self.html = ""
 
-        is_table_exists(table)
+        is_table_exists(table, schema)
 
         # load css
         html_style = utils.load_css(f"{BASE_DIR}/css/tableWidget.css")
         self.add_to_html(html_style)
 
-        self.create_table(table)
+        self.create_table(table, schema)
 
         # register listener for jupyter lab
         self.register_comm()
@@ -48,17 +48,22 @@ class TableWidget:
     def add_to_html(self, html):
         self.html += html
 
-    def create_table(self, table):
+    def create_table(self, table, schema):
         """
         Creates an HTML table with default data
         """
+        if schema:
+            table_ = f"{schema}.{table}"
+        else:
+            table_ = table
+
         rows_per_page = 10
-        rows, columns = fetch_sql_with_pagination(table, 0, rows_per_page)
+        rows, columns = fetch_sql_with_pagination(table_, 0, rows_per_page)
         rows = parse_sql_results_to_json(rows, columns)
 
-        query = f"SELECT count(*) FROM {table}"
+        query = f"SELECT count(*) FROM {table_}"
         n_total = ConnectionManager.current.raw_execute(query).fetchone()[0]
-        table_name = table.strip('"').strip("'")
+        table_name = table_.strip('"').strip("'")
 
         n_pages = math.ceil(n_total / rows_per_page)
 
@@ -81,7 +86,7 @@ class TableWidget:
                     n_total=n_total,
                     table_name=table_name,
                     table_container_id=table_container_id,
-                    table=table,
+                    table=table_,
                     initialRows=rows,
                 ),
             ]

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -592,13 +592,21 @@ def test_test_error(ip, cell, error_message):
 @pytest.mark.parametrize(
     "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]
 )
-def test_test_with_schema(ip_empty, sample_schema_with_table, arguments):
+def test_failing_test_with_schema(ip_empty, sample_schema_with_table, arguments):
     expected_error_message = "The above values do not match your test requirements."
 
     with pytest.raises(UsageError) as excinfo:
         ip_empty.run_cell(f"%sqlcmd test {arguments} --column x --less-than 2")
 
     assert expected_error_message in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]
+)
+def test_passing_test_with_schema(ip_empty, sample_schema_with_table, arguments):
+    out = ip_empty.run_cell(f"%sqlcmd test {arguments} --column x --less-than 3").result
+    assert out is True
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sql.connection import SQLAlchemyConnection
 from sql.inspect import _is_numeric
 from sql.display import Table, Message
+from sql.widgets import TableWidget
 from jupysql_plugin.widgets import ConnectorWidget
 import duckdb
 import sqlite3
@@ -79,6 +80,19 @@ def ip_with_connections(ip_empty):
 def test_snippet_ip(ip):
     ip.run_cell("%sql sqlite://")
     yield ip
+
+
+@pytest.fixture
+def sample_schema_with_table(ip_empty):
+    ip_empty.run_cell("%sql duckdb://")
+    ip_empty.run_cell(
+        """%%sql
+CREATE SCHEMA schema1;
+CREATE TABLE schema1.table1 (x INT, y TEXT);
+INSERT INTO schema1.table1 VALUES (1, 'one');
+INSERT INTO schema1.table1 VALUES (2, 'two');
+"""
+    )
 
 
 @pytest.mark.parametrize(
@@ -210,7 +224,10 @@ def test_columns(ip, cmd, cols):
     assert all(col in out for col in cols)
 
 
-def test_columns_with_schema(ip, tmp_empty):
+@pytest.mark.parametrize(
+    "arguments", ["--table numbers --schema some_schema", "--table some_schema.numbers"]
+)
+def test_columns_with_schema(ip, tmp_empty, arguments):
     conn = SQLAlchemyConnection(engine=create_engine("sqlite:///my.db"))
     conn.execute("CREATE TABLE numbers (some_number FLOAT)")
 
@@ -220,9 +237,7 @@ ATTACH DATABASE 'my.db' AS some_schema
 """
     )
 
-    out = ip.run_cell(
-        "%sqlcmd columns --table numbers --schema some_schema"
-    ).result._repr_html_()
+    out = ip.run_cell(f"%sqlcmd columns {arguments}").result._repr_html_()
 
     assert "some_number" in out
 
@@ -345,7 +360,10 @@ def test_table_profile_with_stdev(ip_with_connections, tmp_empty, conn):
     assert "position: sticky;" in out._table_html
 
 
-def test_table_schema_profile(ip, tmp_empty):
+@pytest.mark.parametrize(
+    "arguments", ["--table t --schema b_schema", "--table b_schema.t"]
+)
+def test_table_schema_profile(ip, tmp_empty, arguments):
     ip.run_cell("%sql sqlite:///a.db")
     ip.run_cell("%sql CREATE TABLE t (n FLOAT)")
     ip.run_cell("%sql INSERT INTO t VALUES (1)")
@@ -379,7 +397,7 @@ def test_table_schema_profile(ip, tmp_empty):
         "top": [math.nan],
     }
 
-    out = ip.run_cell("%sqlcmd profile -t t --schema b_schema").result
+    out = ip.run_cell(f"%sqlcmd profile {arguments}").result
 
     stats_table = out._table
 
@@ -392,7 +410,11 @@ def test_table_schema_profile(ip, tmp_empty):
             assert cell == str(expected[profile_metric][0])
 
 
-def test_sqlcmd_profile_with_schema_argument_and_dbapi(ip_empty, tmp_empty):
+@pytest.mark.parametrize(
+    "arguments",
+    ["--table sample_table --schema test_schema", "--table test_schema.sample_table"],
+)
+def test_sqlcmd_profile_with_schema_argument_and_dbapi(ip_empty, tmp_empty, arguments):
     sqlite_dbapi_testdb_conn = sqlite3.connect("test.db")
     ip_empty.push({"sqlite_dbapi_testdb_conn": sqlite_dbapi_testdb_conn})
 
@@ -423,9 +445,7 @@ INSERT INTO sample_table VALUES (33);
         "top": [math.nan],
     }
 
-    out = ip_empty.run_cell(
-        "%sqlcmd profile --table sample_table --schema test_schema"
-    ).result
+    out = ip_empty.run_cell(f"%sqlcmd profile {arguments}").result
 
     stats_table = out._table
 
@@ -567,6 +587,18 @@ def test_test_error(ip, cell, error_message):
 
     assert excinfo.value.error_type == "UsageError"
     assert str(excinfo.value) == error_message
+
+
+@pytest.mark.parametrize(
+    "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]
+)
+def test_test_with_schema(ip_empty, sample_schema_with_table, arguments):
+    expected_error_message = "The above values do not match your test requirements."
+
+    with pytest.raises(UsageError) as excinfo:
+        ip_empty.run_cell(f"%sqlcmd test {arguments} --column x --less-than 2")
+
+    assert expected_error_message in str(excinfo.value)
 
 
 @pytest.mark.parametrize(
@@ -747,6 +779,17 @@ def test_delete_invalid_snippet(arg, ip_snippets):
 
     assert excinfo.value.error_type == "UsageError"
     assert str(excinfo.value) == "No such saved snippet found : non_existent_snippet"
+
+
+@pytest.mark.parametrize(
+    "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]
+)
+def test_explore_with_schema(ip_empty, sample_schema_with_table, arguments):
+    expected_rows = ['"x": 1', '"y": "one"', '"x": 2', '"y": "two"']
+
+    out = ip_empty.run_cell(f"%sqlcmd explore {arguments}").result
+    assert isinstance(out, TableWidget)
+    assert [row in out._repr_html_() for row in expected_rows]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Describe your changes

Add `--schema/-s` for `%sqlcmd` commands that support `--table/-t` and ensure `--table schema.table` works. This includes `columns`, `explore`, `profile`, and `test` commands from `%sqlcmd`.

## Issue number

Closes #519 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--852.org.readthedocs.build/en/852/

<!-- readthedocs-preview jupysql end -->