### PR TITLE
Issue#845

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.2dev
 
+* [Doc] Fixed typo in the `./doc/integrations/postgres-connect.ipynb` file (Line 180) (#845)
 * [Feature] Improved messages when loading configurations from `pyproject.toml` file.
 * [Feature] Add `--schema/-s` for `%sqlcmd` commands that support `--table/-t` and ensure `--table schema.table` works (#519)
 * [Feature] Show feedback when starting a new connection (#807)

--- a/doc/integrations/postgres-connect.ipynb
+++ b/doc/integrations/postgres-connect.ipynb
@@ -177,7 +177,7 @@
    "source": [
     "## Query\n",
     "\n",
-    "Now, let's start JuppySQL, authenticate and start querying the data!"
+    "Now, let's start JupySQL, authenticate and start querying the data!"
    ]
   },
   {


### PR DESCRIPTION
## Describe your changes
Changed spelling error in `/docs/integrations/postgres-connect.html` (Juppy -> Jupy)

## Issue number

Closes #845

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--860.org.readthedocs.build/en/860/

<!-- readthedocs-preview jupysql end -->