### PR TITLE
Renamed con to conn for uniform naming (Issue#759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.2dev
 
+* [Fix] Changed variable name in `./src/sql/plot.py` file (#759)
 * [Doc] Fixed typo in the `./doc/integrations/postgres-connect.ipynb` file (Line 180) (#845)
 * [Feature] Improved messages when loading configurations from `pyproject.toml` file.
 * [Feature] Add `--schema/-s` for `%sqlcmd` commands that support `--table/-t` and ensure `--table schema.table` works (#519)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.10.2dev
 
-* [Fix] Changed variable name in `./src/sql/plot.py` file (#759)
 * [Doc] Fixed typo in the `./doc/integrations/postgres-connect.ipynb` file (Line 180) (#845)
 * [Feature] Improved messages when loading configurations from `pyproject.toml` file.
 * [Feature] Add `--schema/-s` for `%sqlcmd` commands that support `--table/-t` and ensure `--table schema.table` works (#519)

--- a/src/sql/plot.py
+++ b/src/sql/plot.py
@@ -250,9 +250,9 @@ def boxplot(payload, table, column, *, orient="v", with_=None, conn=None, ax=Non
     return ax
 
 
-def _min_max(con, table, column, with_=None, use_backticks=False):
-    if not con:
-        con = sql.connection.ConnectionManager.current
+def _min_max(conn, table, column, with_=None, use_backticks=False):
+    if not conn:
+        conn = sql.connection.ConnectionManager.current
     template_ = """
 SELECT
     MIN("{{column}}"),
@@ -265,7 +265,7 @@ FROM "{{table}}"
     template = Template(template_)
     query = template.render(table=table, column=column)
 
-    min_, max_ = con.execute(query, with_).fetchone()
+    min_, max_ = conn.execute(query, with_).fetchone()
     return min_, max_
 
 


### PR DESCRIPTION
## Describe your changes
Renamed con -> conn for uniformity

## Issue number

Closes #759

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--863.org.readthedocs.build/en/863/

<!-- readthedocs-preview jupysql end -->