### PR TITLE
Rearranged code and documentation alphabetically for uniformity

### DIFF
--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -69,20 +69,17 @@ If you have autopandas set to true, the displaylimit option will not apply. You 
 %config SqlMagic.feedback = 0
 ```
 
-## `displaycon`
-
+## `autocommit`
 Default: `True`
 
-Show connection string after execution.
+Commits each executed query to the database automatically.
+
+Set to `False` to disable this behavior.
+This may be needed when commits are not supported by the database 
+(for example in sqlalchemy 1.x does not support commits)
 
 ```{code-cell} ipython3
-%config SqlMagic.displaycon = True
-%sql SELECT * FROM languages LIMIT 2
-```
-
-```{code-cell} ipython3
-%config SqlMagic.displaycon = False
-%sql SELECT * FROM languages LIMIT 2
+%config SqlMagic.autocommit = False
 ```
 
 ## `autolimit`
@@ -104,67 +101,6 @@ Automatically limit the size of the returned result sets (e.g., add a `LIMIT` at
 ```{code-cell} ipython3
 %config SqlMagic.autolimit = 0
 ```
-
-## `displaylimit`
-
-Default: `10`
-
-Automatically limit the number of rows displayed (full result set is still stored).
-
-(To display all rows: set to `0` or `None`)
-
-```{code-cell} ipython3
-%config SqlMagic.displaylimit = None
-%sql SELECT * FROM languages
-```
-
-```{code-cell} ipython3
-%config SqlMagic.displaylimit = 1
-res = %sql SELECT * FROM languages
-res
-```
-
-One displayed, but all results fetched:
-
-```{code-cell} ipython3
-len(res)
-```
-
-## `column_local_vars`
-Default: `False`
-Returns data into local variable corresponding to column name.
-To enable this behavior, set to `True`.
-
-```{code-cell} ipython3
-%config SqlMagic.column_local_vars = True
-%sql SELECT * FROM languages
-```
-You can now access columns returned through variables with the same name.
-
-```{code-cell} ipython3
-print(f"Name: {name}")
-print(f"Rating: {rating}")
-print(f"Change: {change}")
-```
-
-Note that ```column_local_vars``` cannot be used when either of
-```autopandas``` or ```autopolars``` is enabled, and vice-versa.
-
-```{code-cell} ipython3
-%config SqlMagic.column_local_vars = False
-```
-
-## `dsn_filename`
-
-```{versionchanged} 0.10.0
-`dsn_filename` default changed from `odbc.ini` to `~/.jupysql/connections.ini`.
-```
-
-Default: `~/.jupysql/connections.ini`
-
-File to load connections configuration from. For an example, see: [](../user-guide/connection-file.md)
-
-+++
 
 ## `autopandas`
 
@@ -202,6 +138,126 @@ df = %sql SELECT * FROM languages
 type(df)
 ```
 
+## `column_local_vars`
+Default: `False`
+Returns data into local variable corresponding to column name.
+To enable this behavior, set to `True`.
+
+```{code-cell} ipython3
+%config SqlMagic.column_local_vars = True
+%sql SELECT * FROM languages
+```
+You can now access columns returned through variables with the same name.
+
+```{code-cell} ipython3
+print(f"Name: {name}")
+print(f"Rating: {rating}")
+print(f"Change: {change}")
+```
+
+Note that ```column_local_vars``` cannot be used when either of
+```autopandas``` or ```autopolars``` is enabled, and vice-versa.
+
+```{code-cell} ipython3
+%config SqlMagic.column_local_vars = False
+```
+
+## `displaycon`
+
+Default: `True`
+
+Show connection string after execution.
+
+```{code-cell} ipython3
+%config SqlMagic.displaycon = True
+%sql SELECT * FROM languages LIMIT 2
+```
+
+```{code-cell} ipython3
+%config SqlMagic.displaycon = False
+%sql SELECT * FROM languages LIMIT 2
+```
+
+## `displaylimit`
+
+Default: `10`
+
+Automatically limit the number of rows displayed (full result set is still stored).
+
+(To display all rows: set to `0` or `None`)
+
+```{code-cell} ipython3
+%config SqlMagic.displaylimit = None
+%sql SELECT * FROM languages
+```
+
+```{code-cell} ipython3
+%config SqlMagic.displaylimit = 1
+res = %sql SELECT * FROM languages
+res
+```
+
+One displayed, but all results fetched:
+
+```{code-cell} ipython3
+len(res)
+```
+
+## `dsn_filename`
+
+```{versionchanged} 0.10.0
+`dsn_filename` default changed from `odbc.ini` to `~/.jupysql/connections.ini`.
+```
+
+Default: `~/.jupysql/connections.ini`
+
+File to load connections configuration from. For an example, see: [](../user-guide/connection-file.md)
+
++++
+
+## `feedback`
+
+```{versionchanged} 0.10
+`feedback` takes values `0`, `1`, and `2` instead of `True`/`False`
+```
+
+Default: `1`
+
+Control the quantity of messages displayed when performing certain operations. Each
+value enables the ones from previous values plus new ones:
+
+- `0`: Minimal feedback
+- `1`: Normal feedback (default)
+  - Connection name when switching
+  - Connection name when running a query
+  - Number of rows afffected by DML (e.g., `INSERT`, `UPDATE`, `DELETE`)
+- `2`: All feedback
+  - Footer to distinguish pandas/polars data frames from JupySQL's result sets
+
+## `named_parameters`
+
+```{versionadded} 0.9
+```
+
+Default: `False`
+
+If True, it enables named parameters `:variable`. Learn more in the [tutorial.](../user-guide/template.md)
+
+```{code-cell} ipython3
+%config SqlMagic.named_parameters=True
+```
+
+```{code-cell} ipython3
+rating = 12
+```
+
+```{code-cell} ipython3
+%%sql
+SELECT *
+FROM languages
+WHERE rating > :rating
+```
+
 ## `polars_dataframe_kwargs`
 
 Default: `{}`
@@ -232,24 +288,16 @@ To unset:
 %config SqlMagic.polars_dataframe_kwargs = {}
 ```
 
-## `feedback`
+## `short_errors`
 
-```{versionchanged} 0.10
-`feedback` takes values `0`, `1`, and `2` instead of `True`/`False`
+DEFAULT: `True`
+
+Set the error description size.
+If `False`, displays entire traceback.
+
+```{code-cell} ipython3
+%config SqlMagic.short_errors = False
 ```
-
-Default: `1`
-
-Control the quantity of messages displayed when performing certain operations. Each
-value enables the ones from previous values plus new ones:
-
-- `0`: Minimal feedback
-- `1`: Normal feedback (default)
-  - Connection name when switching
-  - Connection name when running a query
-  - Number of rows afffected by DML (e.g., `INSERT`, `UPDATE`, `DELETE`)
-- `2`: All feedback
-  - Footer to distinguish pandas/polars data frames from JupySQL's result sets
 
 ## `style`
 
@@ -267,54 +315,6 @@ print(res)
 %config SqlMagic.style = "SINGLE_BORDER"
 res = %sql SELECT * FROM languages LIMIT 2
 print(res)
-```
-
-## `named_parameters`
-
-```{versionadded} 0.9
-```
-
-Default: `False`
-
-If True, it enables named parameters `:variable`. Learn more in the [tutorial.](../user-guide/template.md)
-
-```{code-cell} ipython3
-%config SqlMagic.named_parameters=True
-```
-
-```{code-cell} ipython3
-rating = 12
-```
-
-```{code-cell} ipython3
-%%sql
-SELECT *
-FROM languages
-WHERE rating > :rating
-```
-
-## `autocommit`
-Default: `True`
-
-Commits each executed query to the database automatically.
-
-Set to `False` to disable this behavior.
-This may be needed when commits are not supported by the database 
-(for example in sqlalchemy 1.x does not support commits)
-
-```{code-cell} ipython3
-%config SqlMagic.autocommit = False
-```
-
-## `short_errors`
-
-DEFAULT: `True`
-
-Set the error description size.
-If `False`, displays entire traceback.
-
-```{code-cell} ipython3
-%config SqlMagic.short_errors = False
 ```
 
 ## Loading from `pyproject.toml`

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -110,9 +110,9 @@ Return Pandas DataFrames instead of regular result sets.
 
 ```{code-cell} ipython3
 %config SqlMagic.autopandas = True
-    df = %sql SELECT * FROM languages
+df = %sql SELECT * FROM languages
 type(df)
-    ```
+```
 
 ```{code-cell} ipython3
 %config SqlMagic.autopandas = False

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -134,9 +134,9 @@ type(df)
 
 ```{code-cell} ipython3
 %config SqlMagic.autopolars = False
-    res = %sql SELECT * FROM languages
+res = %sql SELECT * FROM languages
 type(res)
-    ```
+```
 
 ## `column_local_vars`
 Default: `False`

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -109,15 +109,15 @@ Default: `False`
 Return Pandas DataFrames instead of regular result sets.
 
 ```{code-cell} ipython3
+%config SqlMagic.autopandas = True
+    df = %sql SELECT * FROM languages
+type(df)
+    ```
+
+```{code-cell} ipython3
 %config SqlMagic.autopandas = False
 res = %sql SELECT * FROM languages
 type(res)
-```
-
-```{code-cell} ipython3
-%config SqlMagic.autopandas = True
-df = %sql SELECT * FROM languages
-type(df)
 ```
 
 ## `autopolars`
@@ -127,16 +127,16 @@ Default: `False`
 Return Polars DataFrames instead of regular result sets.
 
 ```{code-cell} ipython3
-%config SqlMagic.autopolars = False
-res = %sql SELECT * FROM languages
-type(res)
-```
-
-```{code-cell} ipython3
 %config SqlMagic.autopolars = True
 df = %sql SELECT * FROM languages
 type(df)
 ```
+
+```{code-cell} ipython3
+%config SqlMagic.autopolars = False
+    res = %sql SELECT * FROM languages
+type(res)
+    ```
 
 ## `column_local_vars`
 Default: `False`
@@ -169,12 +169,12 @@ Default: `True`
 Show connection string after execution.
 
 ```{code-cell} ipython3
-%config SqlMagic.displaycon = True
+%config SqlMagic.displaycon = False
 %sql SELECT * FROM languages LIMIT 2
 ```
 
 ```{code-cell} ipython3
-%config SqlMagic.displaycon = False
+%config SqlMagic.displaycon = True
 %sql SELECT * FROM languages LIMIT 2
 ```
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -95,11 +95,7 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
-    autocommit = Bool(
-        default_value=True,
-        config=True,
-        help="Set autocommit mode"
-    )
+    autocommit = Bool(default_value=True, config=True, help="Set autocommit mode")
     autolimit = Int(
         default_value=0,
         config=True,
@@ -122,9 +118,7 @@ class SqlMagic(Magics, Configurable):
         help="Return data into local variables from column names",
     )
     displaycon = Bool(
-        default_value=True,
-        config=True,
-        help="Show connection string after execution"
+        default_value=True, config=True, help="Show connection string after execution"
     )
     displaylimit = Int(
         default_value=10,
@@ -202,20 +196,17 @@ class SqlMagic(Magics, Configurable):
     @validate("displaylimit")
     def _valid_displaylimit(self, proposal):
         if proposal["value"] is None:
-            display.message(
-                "displaylimit: Value None will be treated as 0 (no limit)")
+            display.message("displaylimit: Value None will be treated as 0 (no limit)")
             return 0
         try:
             value = int(proposal["value"])
             if value < 0:
                 raise TraitError(
-                    "{}: displaylimit cannot be a negative integer".format(
-                        value)
+                    "{}: displaylimit cannot be a negative integer".format(value)
                 )
             return value
         except ValueError:
-            raise TraitError(
-                "{}: displaylimit is not an integer".format(value))
+            raise TraitError("{}: displaylimit is not an integer".format(value))
 
     @observe("autopandas", "autopolars")
     def _mutex_autopandas_autopolars(self, change):
@@ -246,8 +237,7 @@ class SqlMagic(Magics, Configurable):
                     if breakLoop:
                         break
 
-            declared_argument = _option_strings_from_parser(
-                SqlMagic.execute.parser)
+            declared_argument = _option_strings_from_parser(SqlMagic.execute.parser)
             for check_argument in arguments:
                 if check_argument not in declared_argument:
                     raise exceptions.UsageError(
@@ -418,8 +408,7 @@ class SqlMagic(Magics, Configurable):
             if args.with_:
                 with_ = args.with_
             else:
-                with_ = self._store.infer_dependencies(
-                    command.sql_original, args.save)
+                with_ = self._store.infer_dependencies(command.sql_original, args.save)
                 if with_:
                     command.set_sql_with(with_)
                     display.message(
@@ -457,8 +446,7 @@ class SqlMagic(Magics, Configurable):
         connect_arg = command.connection
 
         if args.section:
-            connect_arg = sql.parse.connection_str_from_dsn_section(
-                args.section, self)
+            connect_arg = sql.parse.connection_str_from_dsn_section(args.section, self)
 
         if args.connection_arguments:
             try:
@@ -566,8 +554,7 @@ class SqlMagic(Magics, Configurable):
 
                 if self.feedback:
                     display.message(
-                        "Returning data to local variables [{}]".format(
-                            ", ".join(keys))
+                        "Returning data to local variables [{}]".format(", ".join(keys))
                     )
 
                 self.shell.user_ns.update(result)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -95,37 +95,16 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
-    displaycon = Bool(
-        default_value=True, config=True, help="Show connection string after execution"
+    autocommit = Bool(
+        default_value=True,
+        config=True,
+        help="Set autocommit mode"
     )
     autolimit = Int(
         default_value=0,
         config=True,
         allow_none=True,
         help="Automatically limit the size of the returned result sets",
-    )
-    style = Unicode(
-        default_value="DEFAULT",
-        config=True,
-        help=(
-            "Set the table printing style to any of prettytable's "
-            "defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, "
-            "RANDOM, SINGLE_BORDER, DOUBLE_BORDER, MARKDOWN )"
-        ),
-    )
-    short_errors = Bool(
-        default_value=True,
-        config=True,
-        help="Don't display the full traceback on SQL Programming Error",
-    )
-    displaylimit = Int(
-        default_value=10,
-        config=True,
-        allow_none=True,
-        help=(
-            "Automatically limit the number of rows "
-            "displayed (full result set is still stored)"
-        ),
     )
     autopandas = Bool(
         default_value=False,
@@ -137,26 +116,25 @@ class SqlMagic(Magics, Configurable):
         config=True,
         help="Return Polars DataFrames instead of regular result sets",
     )
-    polars_dataframe_kwargs = Dict(
-        default_value={},
-        config=True,
-        help=(
-            "Polars DataFrame constructor keyword arguments"
-            "(e.g. infer_schema_length, nan_to_null, schema_overrides, etc)"
-        ),
-    )
     column_local_vars = Bool(
         default_value=False,
         config=True,
         help="Return data into local variables from column names",
     )
-
-    feedback = Int(
-        default_value=1,
+    displaycon = Bool(
+        default_value=True,
         config=True,
-        help="Verbosity level. 0=minimal, 1=normal, 2=all",
+        help="Show connection string after execution"
     )
-
+    displaylimit = Int(
+        default_value=10,
+        config=True,
+        allow_none=True,
+        help=(
+            "Automatically limit the number of rows "
+            "displayed (full result set is still stored)"
+        ),
+    )
     dsn_filename = Unicode(
         default_value=str(Path("~/.jupysql/connections.ini").expanduser()),
         config=True,
@@ -165,15 +143,39 @@ class SqlMagic(Magics, Configurable):
         "a sqlalchemy connection string is formed from the "
         "matching section in the DSN file.",
     )
-
-    autocommit = Bool(default_value=True, config=True, help="Set autocommit mode")
-
+    feedback = Int(
+        default_value=1,
+        config=True,
+        help="Verbosity level. 0=minimal, 1=normal, 2=all",
+    )
     named_parameters = Bool(
         default_value=False,
         config=True,
         help=(
             "Allow named parameters in queries "
             "(i.e., 'SELECT * FROM foo WHERE bar = :bar')"
+        ),
+    )
+    polars_dataframe_kwargs = Dict(
+        default_value={},
+        config=True,
+        help=(
+            "Polars DataFrame constructor keyword arguments"
+            "(e.g. infer_schema_length, nan_to_null, schema_overrides, etc)"
+        ),
+    )
+    short_errors = Bool(
+        default_value=True,
+        config=True,
+        help="Don't display the full traceback on SQL Programming Error",
+    )
+    style = Unicode(
+        default_value="DEFAULT",
+        config=True,
+        help=(
+            "Set the table printing style to any of prettytable's "
+            "defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, "
+            "RANDOM, SINGLE_BORDER, DOUBLE_BORDER, MARKDOWN )"
         ),
     )
 
@@ -200,17 +202,20 @@ class SqlMagic(Magics, Configurable):
     @validate("displaylimit")
     def _valid_displaylimit(self, proposal):
         if proposal["value"] is None:
-            display.message("displaylimit: Value None will be treated as 0 (no limit)")
+            display.message(
+                "displaylimit: Value None will be treated as 0 (no limit)")
             return 0
         try:
             value = int(proposal["value"])
             if value < 0:
                 raise TraitError(
-                    "{}: displaylimit cannot be a negative integer".format(value)
+                    "{}: displaylimit cannot be a negative integer".format(
+                        value)
                 )
             return value
         except ValueError:
-            raise TraitError("{}: displaylimit is not an integer".format(value))
+            raise TraitError(
+                "{}: displaylimit is not an integer".format(value))
 
     @observe("autopandas", "autopolars")
     def _mutex_autopandas_autopolars(self, change):
@@ -241,7 +246,8 @@ class SqlMagic(Magics, Configurable):
                     if breakLoop:
                         break
 
-            declared_argument = _option_strings_from_parser(SqlMagic.execute.parser)
+            declared_argument = _option_strings_from_parser(
+                SqlMagic.execute.parser)
             for check_argument in arguments:
                 if check_argument not in declared_argument:
                     raise exceptions.UsageError(
@@ -412,7 +418,8 @@ class SqlMagic(Magics, Configurable):
             if args.with_:
                 with_ = args.with_
             else:
-                with_ = self._store.infer_dependencies(command.sql_original, args.save)
+                with_ = self._store.infer_dependencies(
+                    command.sql_original, args.save)
                 if with_:
                     command.set_sql_with(with_)
                     display.message(
@@ -450,7 +457,8 @@ class SqlMagic(Magics, Configurable):
         connect_arg = command.connection
 
         if args.section:
-            connect_arg = sql.parse.connection_str_from_dsn_section(args.section, self)
+            connect_arg = sql.parse.connection_str_from_dsn_section(
+                args.section, self)
 
         if args.connection_arguments:
             try:
@@ -558,7 +566,8 @@ class SqlMagic(Magics, Configurable):
 
                 if self.feedback:
                     display.message(
-                        "Returning data to local variables [{}]".format(", ".join(keys))
+                        "Returning data to local variables [{}]".format(
+                            ", ".join(keys))
                     )
 
                 self.shell.user_ns.update(result)


### PR DESCRIPTION
## Describe your changes
Rearranged code (magic.py) and documentation (configuration.md) alphabetically for uniformity

## Issue number

Closes #868 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)


<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--869.org.readthedocs.build/en/869/

<!-- readthedocs-preview jupysql end -->