### PR TITLE
fix schema error in integration

### DIFF
--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -514,8 +514,8 @@ def test_sqlplot_using_schema(ip_with_dynamic_db, request):
     plt.cla()
     ip_with_dynamic_db.run_cell(
         """%%sql
-CREATE SCHEMA schema1;
-CREATE TABLE schema1.table1 (
+CREATE SCHEMA IF NOT EXISTS schema1;
+CREATE TABLE IF NOT EXISTS schema1.table1 (
     x INTEGER,
     y INTEGER
 );

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -484,7 +484,10 @@ def test_sqlplot_pie(ip_with_dynamic_db, request, test_table_name_dict):
         ("ip_with_duckDB"),
         ("ip_with_Snowflake"),
         ("ip_with_duckDB_native"),
-        ("ip_with_redshift"),
+        pytest.param(
+            "ip_with_redshift",
+            marks=pytest.mark.xfail(reason="permission denied for database dev"),
+        ),
         pytest.param(
             "ip_with_SQLite",
             marks=pytest.mark.xfail(reason="does not support schema"),


### PR DESCRIPTION
## Describe your changes

using [snowflake](https://github.com/ploomber/jupysql/actions/runs/6114228487/job/16595383276#step:6:1309) and [redshift](https://github.com/ploomber/jupysql/actions/runs/6114228487/job/16595383276#step:6:1314) fails in `test_sqlplot_using_schema` function. It passed in a PR but continues to fail when the PR is merged

So I changed `CREATE` to `CREATE ~ IF NOT EXISTS` to deal with snowflake error and added `pytest.mark.xfail` for redshift

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--872.org.readthedocs.build/en/872/

<!-- readthedocs-preview jupysql end -->