### PR TITLE
dependent snippet deletion bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.3dev
 
+* [Fix] Remove force deleted snippets from dependent snippet's `with` (#717)
+
 ## 0.10.2 (2023-09-22)
 
 * [Feature] Improved messages when loading configurations from `pyproject.toml` file.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ DEV = [
     "pkgmt",
     "twine",
     # tests
-    "duckdb",
+    "duckdb<0.9.0",
     "duckdb-engine",
     "pyodbc",
     # sql.plot module tests

--- a/src/sql/cmd/snippets.py
+++ b/src/sql/cmd/snippets.py
@@ -104,6 +104,8 @@ def snippets(others):
         key = args.delete_force
         deps = store.get_key_dependents(key)
         remaining_keys = store.del_saved_key(key)
+        for dep in deps:
+            store[dep].remove_snippet_dependency(key)
         return _modify_display_msg(key, remaining_keys, deps)
 
     elif args.delete_force_all:

--- a/src/sql/cmd/snippets.py
+++ b/src/sql/cmd/snippets.py
@@ -26,7 +26,7 @@ def _modify_display_msg(key, remaining_keys, dependent_keys=None):
     if dependent_keys:
         msg = f"{msg}{', '.join(dependent_keys)} depend on {key}\n"
     if remaining_keys:
-        msg = f"{msg}Stored snippets : {', '.join(remaining_keys)}"
+        msg = f"{msg}Stored snippets: {', '.join(remaining_keys)}"
     else:
         msg = f"{msg}There are no stored snippets"
     return msg

--- a/src/sql/cmd/snippets.py
+++ b/src/sql/cmd/snippets.py
@@ -105,7 +105,7 @@ def snippets(others):
         deps = store.get_key_dependents(key)
         remaining_keys = store.del_saved_key(key)
         for dep in deps:
-            store[dep].remove_snippet_dependency(key)
+            store.store[dep].remove_snippet_dependency(key)
         return _modify_display_msg(key, remaining_keys, deps)
 
     elif args.delete_force_all:

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -140,6 +140,10 @@ class SQLQuery:
             rts=_remove_trailing_semicolon,
         )
 
+    def remove_snippet_dependency(self, snippet):
+        if snippet in self._with_:
+            self._with_.remove(snippet)
+
 
 def _remove_trailing_semicolon(query):
     query_ = query.rstrip()

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -789,6 +789,13 @@ def test_delete_invalid_snippet(arg, ip_snippets):
     assert str(excinfo.value) == "No such saved snippet found : non_existent_snippet"
 
 
+@pytest.mark.parametrize("arg", ["--delete-force", "-D"])
+def test_delete_snippet_when_dependency_force_deleted(ip_snippets, arg):
+    ip_snippets.run_cell(f"%sqlcmd snippets {arg} high_price")
+    out = ip_snippets.run_cell("%sqlcmd snippets --delete high_price_a").result
+    assert "high_price_a has been deleted.Stored snippets : high_price_b" in out
+
+
 @pytest.mark.parametrize(
     "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]
 )

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -793,7 +793,7 @@ def test_delete_invalid_snippet(arg, ip_snippets):
 def test_delete_snippet_when_dependency_force_deleted(ip_snippets, arg):
     ip_snippets.run_cell(f"%sqlcmd snippets {arg} high_price")
     out = ip_snippets.run_cell("%sqlcmd snippets --delete high_price_a").result
-    assert "high_price_a has been deleted.Stored snippets : high_price_b" in out
+    assert "high_price_a has been deleted.\nStored snippets: high_price_b" in out
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -794,7 +794,7 @@ def test_delete_snippet_when_dependency_force_deleted(ip_snippets, arg):
     ip_snippets.run_cell(f"%sqlcmd snippets {arg} high_price")
     out = ip_snippets.run_cell("%sqlcmd snippets --delete high_price_a").result
     assert "high_price_a has been deleted.Stored snippets : high_price_b" in out
-
+    
 
 @pytest.mark.parametrize(
     "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]

--- a/src/tests/test_magic_cmd.py
+++ b/src/tests/test_magic_cmd.py
@@ -794,7 +794,7 @@ def test_delete_snippet_when_dependency_force_deleted(ip_snippets, arg):
     ip_snippets.run_cell(f"%sqlcmd snippets {arg} high_price")
     out = ip_snippets.run_cell("%sqlcmd snippets --delete high_price_a").result
     assert "high_price_a has been deleted.Stored snippets : high_price_b" in out
-    
+
 
 @pytest.mark.parametrize(
     "arguments", ["--table schema1.table1", "--table table1 --schema schema1"]


### PR DESCRIPTION
## Describe your changes

Fixing bug: Cannot delete a snippet after the snippet it is dependent on is force deleted.

## Issue number

Closes #717 

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--896.org.readthedocs.build/en/896/

<!-- readthedocs-preview jupysql end -->