### PR TITLE
Added guards to check and raise errors when arguments are entered twice in `%sql`, `%sqlcmd` and `%sqlplot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.10.4dev
 * [Fix] Fix bug causing empty result on SQL with trailing semicolon and comment (#907)
 * [Fix] Fix bug %sql not parsing JSON arrow operators correctly (#918)
-
 * [Fix] Fixed bug that returns empty results when exception is raised from DB driver
+* [Fix] Added guards to check and raise errors when arguments are entered twice in %sql, %sqlcmd and %sqlplot (#806)
 
 ## 0.10.3 (2023-11-06)
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -11,7 +11,20 @@ from sql.util import validate_nonidentifier_connection
 
 class SQLPlotCommand:
     def __init__(self, magic, line) -> None:
-        self.args = parse.magic_args(magic.execute, line, "sqlplot")
+        ALLOWED_DUPLICATES = ["-w", "--with"]
+        DISALLOWED_ALIASES = {
+            "-t": "--table",
+            "-s": "--schema",
+            "-c": "--column",
+            "-o": "--orient",
+            "-b": "--bins",
+            "-B": "--breaks",
+            "-W": "--binwidth",
+            "-S": "--show-numbers",
+        }
+        self.args = parse.magic_args(
+            magic.execute, line, "sqlplot", ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+        )
 
 
 class SQLCommand:
@@ -24,7 +37,23 @@ class SQLCommand:
         self._line = line
         self._cell = cell
 
-        self.args = parse.magic_args(magic.execute, line, "sql")
+        ALLOWED_DUPLICATES = ["-w", "--with", "--append", "--interact"]
+        DISALLOWED_ALIASES = {
+            "-l": "--connections",
+            "-x": "--close",
+            "-c": "--creator",
+            "-s": "--section",
+            "-p": "--persist",
+            "-a": "--connection-arguments",
+            "-f": "--file",
+            "-n": "--no-index",
+            "-S": "--save",
+            "-A": "--alias",
+        }
+        self.args = parse.magic_args(
+            magic.execute, line, "sql", ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+        )
+
         # self.args.line (everything that appears after %sql/%%sql in the first line)
         # is split in tokens (delimited by spaces), this checks if we have one arg
         one_arg = len(self.args.line) == 1

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -12,9 +12,7 @@ from sql.util import validate_nonidentifier_connection
 class SQLPlotCommand:
     def __init__(self, magic, line) -> None:
         ALLOWED_DUPLICATES = ["-w", "--with"]
-        self.args = parse.magic_args(
-            magic.execute, line, "sqlplot", ALLOWED_DUPLICATES
-        )
+        self.args = parse.magic_args(magic.execute, line, "sqlplot", ALLOWED_DUPLICATES)
 
 
 class SQLCommand:
@@ -28,9 +26,7 @@ class SQLCommand:
         self._cell = cell
 
         ALLOWED_DUPLICATES = ["-w", "--with", "--append", "--interact"]
-        self.args = parse.magic_args(
-            magic.execute, line, "sql", ALLOWED_DUPLICATES
-        )
+        self.args = parse.magic_args(magic.execute, line, "sql", ALLOWED_DUPLICATES)
 
         # self.args.line (everything that appears after %sql/%%sql in the first line)
         # is split in tokens (delimited by spaces), this checks if we have one arg

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -11,8 +11,9 @@ from sql.util import validate_nonidentifier_connection
 
 class SQLPlotCommand:
     def __init__(self, magic, line) -> None:
-        ALLOWED_DUPLICATES = ["-w", "--with"]
-        self.args = parse.magic_args(magic.execute, line, "sqlplot", ALLOWED_DUPLICATES)
+        self.args = parse.magic_args(
+            magic.execute, line, "sqlplot", allowed_duplicates=["-w", "--with"]
+        )
 
 
 class SQLCommand:
@@ -25,8 +26,12 @@ class SQLCommand:
         self._line = line
         self._cell = cell
 
-        ALLOWED_DUPLICATES = ["-w", "--with", "--append", "--interact"]
-        self.args = parse.magic_args(magic.execute, line, "sql", ALLOWED_DUPLICATES)
+        self.args = parse.magic_args(
+            magic.execute,
+            line,
+            "sql",
+            allowed_duplicates=["-w", "--with", "--append", "--interact"],
+        )
 
         # self.args.line (everything that appears after %sql/%%sql in the first line)
         # is split in tokens (delimited by spaces), this checks if we have one arg

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -11,7 +11,7 @@ from sql.util import validate_nonidentifier_connection
 
 class SQLPlotCommand:
     def __init__(self, magic, line) -> None:
-        self.args = parse.magic_args(magic.execute, line)
+        self.args = parse.magic_args(magic.execute, line, "sqlplot")
 
 
 class SQLCommand:
@@ -24,7 +24,7 @@ class SQLCommand:
         self._line = line
         self._cell = cell
 
-        self.args = parse.magic_args(magic.execute, line)
+        self.args = parse.magic_args(magic.execute, line, "sql")
         # self.args.line (everything that appears after %sql/%%sql in the first line)
         # is split in tokens (delimited by spaces), this checks if we have one arg
         one_arg = len(self.args.line) == 1

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -12,18 +12,8 @@ from sql.util import validate_nonidentifier_connection
 class SQLPlotCommand:
     def __init__(self, magic, line) -> None:
         ALLOWED_DUPLICATES = ["-w", "--with"]
-        DISALLOWED_ALIASES = {
-            "-t": "--table",
-            "-s": "--schema",
-            "-c": "--column",
-            "-o": "--orient",
-            "-b": "--bins",
-            "-B": "--breaks",
-            "-W": "--binwidth",
-            "-S": "--show-numbers",
-        }
         self.args = parse.magic_args(
-            magic.execute, line, "sqlplot", ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+            magic.execute, line, "sqlplot", ALLOWED_DUPLICATES
         )
 
 
@@ -38,20 +28,8 @@ class SQLCommand:
         self._cell = cell
 
         ALLOWED_DUPLICATES = ["-w", "--with", "--append", "--interact"]
-        DISALLOWED_ALIASES = {
-            "-l": "--connections",
-            "-x": "--close",
-            "-c": "--creator",
-            "-s": "--section",
-            "-p": "--persist",
-            "-a": "--connection-arguments",
-            "-f": "--file",
-            "-n": "--no-index",
-            "-S": "--save",
-            "-A": "--alias",
-        }
         self.args = parse.magic_args(
-            magic.execute, line, "sql", ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+            magic.execute, line, "sql", ALLOWED_DUPLICATES
         )
 
         # self.args.line (everything that appears after %sql/%%sql in the first line)

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -75,7 +75,7 @@ class SqlCmdMagic(Magics, Configurable):
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments(others, "sqlcmd")
+            check_duplicate_arguments("sqlcmd", split)
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -69,13 +69,22 @@ class SqlCmdMagic(Magics, Configurable):
             f"Valid commands are: {', '.join(AVAILABLE_SQLCMD_COMMANDS)}"
         )
 
+        ALLOWED_DUPLICATES = []
+        DISALLOWED_ALIASES = {
+            "-t": "--table",
+            "-s": "--schema",
+            "-o": "--output",
+        }
+
         if line == "":
             raise exceptions.UsageError(VALID_COMMANDS_MSG)
         else:
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments("sqlcmd", split)
+            check_duplicate_arguments(
+                "sqlcmd", split, ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+            )
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -75,9 +75,7 @@ class SqlCmdMagic(Magics, Configurable):
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments(
-                self.execute, "sqlcmd", split, allowed_duplicates=[]
-            )
+            check_duplicate_arguments(self.execute, "sqlcmd", split)
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -77,9 +77,7 @@ class SqlCmdMagic(Magics, Configurable):
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments(
-                self.execute, "sqlcmd", split, ALLOWED_DUPLICATES
-            )
+            check_duplicate_arguments(self.execute, "sqlcmd", split, ALLOWED_DUPLICATES)
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -13,6 +13,7 @@ from sql.cmd.explore import explore
 from sql.cmd.snippets import snippets
 from sql.cmd.connect import connect
 from sql.connection import ConnectionManager
+from sql.util import check_duplicate_arguments
 
 try:
     from traitlets.config.configurable import Configurable
@@ -74,6 +75,7 @@ class SqlCmdMagic(Magics, Configurable):
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
+            check_duplicate_arguments(others, "sqlcmd")
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -70,11 +70,6 @@ class SqlCmdMagic(Magics, Configurable):
         )
 
         ALLOWED_DUPLICATES = []
-        DISALLOWED_ALIASES = {
-            "-t": "--table",
-            "-s": "--schema",
-            "-o": "--output",
-        }
 
         if line == "":
             raise exceptions.UsageError(VALID_COMMANDS_MSG)
@@ -83,7 +78,7 @@ class SqlCmdMagic(Magics, Configurable):
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
             check_duplicate_arguments(
-                "sqlcmd", split, ALLOWED_DUPLICATES, DISALLOWED_ALIASES
+                self.execute, "sqlcmd", split, ALLOWED_DUPLICATES
             )
 
             if command in AVAILABLE_SQLCMD_COMMANDS:

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -75,7 +75,8 @@ class SqlCmdMagic(Magics, Configurable):
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments(self.execute, "sqlcmd", split)
+            if others:
+                check_duplicate_arguments(self.execute, "sqlcmd", split)
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -76,7 +76,16 @@ class SqlCmdMagic(Magics, Configurable):
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
             if others:
-                check_duplicate_arguments(self.execute, "sqlcmd", split)
+                check_duplicate_arguments(
+                    self.execute,
+                    "sqlcmd",
+                    split,
+                    disallowed_aliases={
+                        "-t": "--table",
+                        "-s": "--schema",
+                        "-o": "--output",
+                    },
+                )
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -69,15 +69,15 @@ class SqlCmdMagic(Magics, Configurable):
             f"Valid commands are: {', '.join(AVAILABLE_SQLCMD_COMMANDS)}"
         )
 
-        ALLOWED_DUPLICATES = []
-
         if line == "":
             raise exceptions.UsageError(VALID_COMMANDS_MSG)
         else:
             # directly use shlex since SqlCmdMagic does not use magic_args from parse.py
             split = shlex.split(line, posix=False)
             command, others = split[0].strip(), split[1:]
-            check_duplicate_arguments(self.execute, "sqlcmd", split, ALLOWED_DUPLICATES)
+            check_duplicate_arguments(
+                self.execute, "sqlcmd", split, allowed_duplicates=[]
+            )
 
             if command in AVAILABLE_SQLCMD_COMMANDS:
                 if (

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -235,8 +235,6 @@ def without_sql_comment(parser, line):
     return " ".join(result)
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 def split_args_and_sql(line):
     """Separates line into args and sql query
 
@@ -281,16 +279,22 @@ def split_args_and_sql(line):
     return arg_line, sql_line
 
 
-def magic_args(magic_execute, line, cmd_from):
+def magic_args(magic_execute, line, cmd_from, allowed_duplicates=None):
     """
     Returns the parsed arguments from the line as parsed by magic_execute
     """
+    allowed_duplicates = allowed_duplicates or []
     line = without_sql_comment(parser=magic_execute.parser, line=line)
     arg_line, sql_line = split_args_and_sql(line)
 
     args = shlex.split(arg_line, posix=False)
     if len(args) > 1:
-        check_duplicate_arguments(args[1:], cmd_from)
+        check_duplicate_arguments(
+            magic_execute,
+            cmd_from,
+            args,
+            allowed_duplicates
+        )
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -9,6 +9,7 @@ import warnings
 from sqlalchemy.engine.url import URL
 
 from sql import exceptions
+from sql.util import check_duplicate_arguments
 
 # Keywords used to identify the beginning of SQL queries
 # in split_args_and_sql(). Should cover all cases but can
@@ -278,11 +279,16 @@ def split_args_and_sql(line):
     return arg_line, sql_line
 
 
-def magic_args(magic_execute, line):
+def magic_args(magic_execute, line, cmd_from):
+    """
+    Returns the parsed arguments from the line as parsed by magic_execute
+    """
     line = without_sql_comment(parser=magic_execute.parser, line=line)
     arg_line, sql_line = split_args_and_sql(line)
 
     args = shlex.split(arg_line, posix=False)
+    if len(args) > 1:
+        check_duplicate_arguments(args[1:], cmd_from)
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -235,6 +235,7 @@ def without_sql_comment(parser, line):
     return " ".join(result)
 
 
+<<<<<<< HEAD
 def split_args_and_sql(line):
     """Separates line into args and sql query
 
@@ -280,6 +281,9 @@ def split_args_and_sql(line):
 
 
 def magic_args(magic_execute, line, cmd_from):
+=======
+def magic_args(magic_execute, line, cmd_from, allowed_duplicates, disallowed_aliases):
+>>>>>>> 3353e01 (Modified code to contain the allowed duplicates and disallowed aliases within the Magic Class itself)
     """
     Returns the parsed arguments from the line as parsed by magic_execute
     """
@@ -288,12 +292,19 @@ def magic_args(magic_execute, line, cmd_from):
 
     args = shlex.split(arg_line, posix=False)
     if len(args) > 1:
+<<<<<<< HEAD
         check_duplicate_arguments(args[1:], cmd_from)
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:
         parsed.line = shlex.split(sql_line, posix=False)
     return parsed
+=======
+        check_duplicate_arguments(
+            cmd_from, args, allowed_duplicates, disallowed_aliases
+        )
+    return magic_execute.parser.parse_args(args)
+>>>>>>> 3353e01 (Modified code to contain the allowed duplicates and disallowed aliases within the Magic Class itself)
 
 
 def escape_string_literals_with_colon_prefix(query):

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -236,6 +236,7 @@ def without_sql_comment(parser, line):
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def split_args_and_sql(line):
     """Separates line into args and sql query
 
@@ -281,9 +282,6 @@ def split_args_and_sql(line):
 
 
 def magic_args(magic_execute, line, cmd_from):
-=======
-def magic_args(magic_execute, line, cmd_from, allowed_duplicates, disallowed_aliases):
->>>>>>> 3353e01 (Modified code to contain the allowed duplicates and disallowed aliases within the Magic Class itself)
     """
     Returns the parsed arguments from the line as parsed by magic_execute
     """
@@ -292,19 +290,12 @@ def magic_args(magic_execute, line, cmd_from, allowed_duplicates, disallowed_ali
 
     args = shlex.split(arg_line, posix=False)
     if len(args) > 1:
-<<<<<<< HEAD
         check_duplicate_arguments(args[1:], cmd_from)
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:
         parsed.line = shlex.split(sql_line, posix=False)
     return parsed
-=======
-        check_duplicate_arguments(
-            cmd_from, args, allowed_duplicates, disallowed_aliases
-        )
-    return magic_execute.parser.parse_args(args)
->>>>>>> 3353e01 (Modified code to contain the allowed duplicates and disallowed aliases within the Magic Class itself)
 
 
 def escape_string_literals_with_colon_prefix(query):

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -289,12 +289,7 @@ def magic_args(magic_execute, line, cmd_from, allowed_duplicates=None):
 
     args = shlex.split(arg_line, posix=False)
     if len(args) > 1:
-        check_duplicate_arguments(
-            magic_execute,
-            cmd_from,
-            args,
-            allowed_duplicates
-        )
+        check_duplicate_arguments(magic_execute, cmd_from, args, allowed_duplicates)
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -174,7 +174,7 @@ def check_duplicate_arguments(
         if len(dec_args) > 1:
             aliased_arguments[dec_args[0]] = dec_args[1]
         else:
-            if dec_args[0].startswith('--') or dec_args[0].startswith('-'):
+            if dec_args[0].startswith("--") or dec_args[0].startswith("-"):
                 unaliased_arguments.append(dec_args[0])
 
     if len(args) <= 1:

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -158,7 +158,7 @@ def show_deprecation_warning():
 
 
 def check_duplicate_arguments(
-    magic_execute, cmd_from, args, allowed_duplicates=[]
+    magic_execute, cmd_from, args, allowed_duplicates=[], disallowed_aliases={}
 ) -> bool:
     """
     Raises UsageError when duplicate arguments are passed to magics.
@@ -173,8 +173,11 @@ def check_duplicate_arguments(
     args
         The arguments passed to the magic command.
     allowed_duplicates
-        The duplicates that are allowed for the class which invoked this function.
-        Defaults to an empty list.
+        The duplicate arguments that are allowed for the class which invoked this
+        function. Defaults to an empty list.
+    disallowed_aliases
+        The aliases for the arguments that are not allowed to be used together
+        for the class that invokes this function. Defaults to an empty dict.
 
     Returns
     -------
@@ -194,6 +197,8 @@ def check_duplicate_arguments(
         else:
             if decorator_args[0].startswith("--") or decorator_args[0].startswith("-"):
                 unaliased_arguments.append(decorator_args[0])
+    if aliased_arguments == {}:
+        aliased_arguments = disallowed_aliases
 
     # Separate arguments from passed options
     args = [arg for arg in args if arg.startswith("--") or arg.startswith("-")]

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -124,7 +124,7 @@ def flatten(src, ltypes=(list, tuple)):
                 i -= 1
                 break
             else:
-                process_list[i : i + 1] = process_list[i]
+                process_list[i: i + 1] = process_list[i]
         i += 1
 
     # If input src data type is tuple, return tuple
@@ -155,6 +155,24 @@ def show_deprecation_warning():
         "raise an exception in the next major release so please remove it.",
         FutureWarning,
     )
+
+
+def check_duplicate_arguments(args, cmd_from):
+    """
+    Raises UsageError when duplicate arguments are passed to magics.
+    """
+
+    args = [arg for arg in args if "--" in arg]
+    print(args)
+    if len(args) != len(set(args)):
+        duplicate_args = set([arg for arg in args if args.count(arg) != 1])
+        print(duplicate_args)
+        raise exceptions.UsageError(
+            f"Duplicate arguments in %{cmd_from}. "
+            f"Please use only one of each of the following: "
+            f"{', '.join(duplicate_args)}"
+        )
+    return True
 
 
 def find_path_from_root(file_name):
@@ -269,7 +287,8 @@ def get_user_configs(file_path):
     while section_names:
         section_to_find, sections_from_user = section_names.pop(0), data.keys()
         if section_to_find not in sections_from_user:
-            close_match = difflib.get_close_matches(section_to_find, sections_from_user)
+            close_match = difflib.get_close_matches(
+                section_to_find, sections_from_user)
             if not close_match:
                 MESSAGE_PREFIX = (
                     f"Tip: You may define configurations in "
@@ -329,7 +348,8 @@ def validate_mutually_exclusive_args(arg_names, args):
     args : list
         args values
     """
-    specified_args = [arg_name for arg_name, arg in zip(arg_names, args) if arg]
+    specified_args = [arg_name for arg_name,
+                      arg in zip(arg_names, args) if arg]
     if len(specified_args) > 1:
         raise exceptions.ValueError(
             f"{pretty_print(specified_args)} are specified. "

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -182,11 +182,6 @@ def check_duplicate_arguments(
         When there are no duplicates, a True bool is returned.
     """
 
-    # Returns True if there are no duplicate arguments (1 or less arguments)
-    # Example: %sqlcmd tables
-    if len(args) <= 1:
-        return True
-
     aliased_arguments = {}
     unaliased_arguments = []
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -157,49 +157,15 @@ def show_deprecation_warning():
     )
 
 
-def check_duplicate_arguments(cmd_from, args) -> bool:
+def check_duplicate_arguments(
+    cmd_from, args, allowed_duplicates, disallowed_aliases
+) -> bool:
     """
     Raises UsageError when duplicate arguments are passed to magics.
     Returns true if no duplicates in arguments or aliases.
     """
     if len(args) <= 1:
         return True
-
-    allowed_duplicates = {
-        "sql": ["-w", "--with", "--append", "--interact"],
-        "sqlplot": ["-w", "--with"],
-        "sqlcmd": [],
-    }
-
-    disallowed_aliases = {
-        "sql": {
-            "-l": "--connections",
-            "-x": "--close",
-            "-c": "--creator",
-            "-s": "--section",
-            "-p": "--persist",
-            "-a": "--connection-arguments",
-            "-f": "--file",
-            "-n": "--no-index",
-            "-S": "--save",
-            "-A": "--alias",
-        },
-        "sqlplot": {
-            "-t": "--table",
-            "-s": "--schema",
-            "-c": "--column",
-            "-o": "--orient",
-            "-b": "--bins",
-            "-B": "--breaks",
-            "-W": "--binwidth",
-            "-S": "--show-numbers",
-        },
-        "sqlcmd": {
-            "-t": "--table",
-            "-s": "--schema",
-            "-o": "--output",
-        },
-    }
 
     args = [arg for arg in args if arg.startswith("--") or arg.startswith("-")]
 
@@ -215,17 +181,17 @@ def check_duplicate_arguments(cmd_from, args) -> bool:
     duplicate_args = []
     visited_args = set()
     for arg in args:
-        if arg not in allowed_duplicates[cmd_from]:
+        if arg not in allowed_duplicates:
             if arg not in visited_args:
                 visited_args.add(arg)
             else:
                 duplicate_args.append(arg)
 
     alias_pairs_present = [
-        (opt, disallowed_aliases[cmd_from][opt])
+        (opt, disallowed_aliases[opt])
         for opt in single_hyphen_opts
-        if opt in disallowed_aliases[cmd_from]
-        if disallowed_aliases[cmd_from][opt] in double_hyphen_opts
+        if opt in disallowed_aliases
+        if disallowed_aliases[opt] in double_hyphen_opts
     ]
 
     error_message = ""

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -161,8 +161,9 @@ def check_duplicate_arguments(args, cmd_from):
     """
     Raises UsageError when duplicate arguments are passed to magics.
     """
+    ALLOWED_DUPLICATES = ["--with", "--interact"]
 
-    args = [arg for arg in args if "--" in arg and arg != "--with"]
+    args = [arg for arg in args if "--" in arg and arg not in ALLOWED_DUPLICATES]
     if len(args) != len(set(args)):
         duplicate_args = set([arg for arg in args if args.count(arg) != 1])
         raise exceptions.UsageError(

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -162,7 +162,7 @@ def check_duplicate_arguments(args, cmd_from):
     Raises UsageError when duplicate arguments are passed to magics.
     """
 
-    args = [arg for arg in args if "--" in arg]
+    args = [arg for arg in args if "--" in arg and arg != "--with"]
     if len(args) != len(set(args)):
         duplicate_args = set([arg for arg in args if args.count(arg) != 1])
         raise exceptions.UsageError(

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -158,7 +158,7 @@ def show_deprecation_warning():
 
 
 def check_duplicate_arguments(
-    magic_execute, cmd_from, args, allowed_duplicates
+    magic_execute, cmd_from, args, allowed_duplicates=[]
 ) -> bool:
     """
     Raises UsageError when duplicate arguments are passed to magics.
@@ -174,6 +174,7 @@ def check_duplicate_arguments(
         The arguments passed to the magic command.
     allowed_duplicates
         The duplicates that are allowed for the class which invoked this function.
+        Defaults to an empty list.
 
     Returns
     -------

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -124,7 +124,7 @@ def flatten(src, ltypes=(list, tuple)):
                 i -= 1
                 break
             else:
-                process_list[i: i + 1] = process_list[i]
+                process_list[i : i + 1] = process_list[i]
         i += 1
 
     # If input src data type is tuple, return tuple
@@ -163,14 +163,12 @@ def check_duplicate_arguments(args, cmd_from):
     """
 
     args = [arg for arg in args if "--" in arg]
-    print(args)
     if len(args) != len(set(args)):
         duplicate_args = set([arg for arg in args if args.count(arg) != 1])
-        print(duplicate_args)
         raise exceptions.UsageError(
             f"Duplicate arguments in %{cmd_from}. "
             f"Please use only one of each of the following: "
-            f"{', '.join(duplicate_args)}"
+            f"{', '.join(sorted(duplicate_args))}"
         )
     return True
 
@@ -287,8 +285,7 @@ def get_user_configs(file_path):
     while section_names:
         section_to_find, sections_from_user = section_names.pop(0), data.keys()
         if section_to_find not in sections_from_user:
-            close_match = difflib.get_close_matches(
-                section_to_find, sections_from_user)
+            close_match = difflib.get_close_matches(section_to_find, sections_from_user)
             if not close_match:
                 MESSAGE_PREFIX = (
                     f"Tip: You may define configurations in "
@@ -348,8 +345,7 @@ def validate_mutually_exclusive_args(arg_names, args):
     args : list
         args values
     """
-    specified_args = [arg_name for arg_name,
-                      arg in zip(arg_names, args) if arg]
+    specified_args = [arg_name for arg_name, arg in zip(arg_names, args) if arg]
     if len(specified_args) > 1:
         raise exceptions.ValueError(
             f"{pretty_print(specified_args)} are specified. "

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -158,7 +158,7 @@ def show_deprecation_warning():
 
 
 def check_duplicate_arguments(
-    magic_execute, cmd_from, args, allowed_duplicates=[], disallowed_aliases={}
+    magic_execute, cmd_from, args, allowed_duplicates=None, disallowed_aliases=None
 ) -> bool:
     """
     Raises UsageError when duplicate arguments are passed to magics.
@@ -174,29 +174,35 @@ def check_duplicate_arguments(
         The arguments passed to the magic command.
     allowed_duplicates
         The duplicate arguments that are allowed for the class which invoked this
-        function. Defaults to an empty list.
+        function. Defaults to None.
     disallowed_aliases
         The aliases for the arguments that are not allowed to be used together
-        for the class that invokes this function. Defaults to an empty dict.
+        for the class that invokes this function. Defaults to None.
 
     Returns
     -------
     boolean
         When there are no duplicates, a True bool is returned.
     """
+    allowed_duplicates = allowed_duplicates or []
+    disallowed_aliases = disallowed_aliases or {}
 
     aliased_arguments = {}
     unaliased_arguments = []
 
     # Separates the aliased_arguments and unaliased_arguments.
     # Aliased arguments example: '-w' and '--with'
-    for decorator in magic_execute.decorators:
-        decorator_args = decorator.args
-        if len(decorator_args) > 1:
-            aliased_arguments[decorator_args[0]] = decorator_args[1]
-        else:
-            if decorator_args[0].startswith("--") or decorator_args[0].startswith("-"):
-                unaliased_arguments.append(decorator_args[0])
+    if cmd_from != "sqlcmd":
+        for decorator in magic_execute.decorators:
+            decorator_args = decorator.args
+            if len(decorator_args) > 1:
+                aliased_arguments[decorator_args[0]] = decorator_args[1]
+            else:
+                if decorator_args[0].startswith("--") or decorator_args[0].startswith(
+                    "-"
+                ):
+                    unaliased_arguments.append(decorator_args[0])
+
     if aliased_arguments == {}:
         aliased_arguments = disallowed_aliases
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -221,7 +221,7 @@ def check_duplicate_arguments(cmd_from, args) -> bool:
             else:
                 duplicate_args.append(arg)
 
-    either_or = [
+    alias_pairs_present = [
         (opt, disallowed_aliases[cmd_from][opt])
         for opt in single_hyphen_opts
         if opt in disallowed_aliases[cmd_from]
@@ -230,19 +230,25 @@ def check_duplicate_arguments(cmd_from, args) -> bool:
 
     error_message = ""
     if duplicate_args:
-        error_message += (
+        duplicates_error = (
             f"Duplicate arguments in %{cmd_from}. "
             "Please use only one of each of the following: "
             f"{', '.join(sorted(duplicate_args))}. "
         )
+    else:
+        duplicates_error = ""
 
-    if either_or:
-        arg_list = sorted([" or ".join(pair) for pair in either_or])
-        error_message += (
+    if alias_pairs_present:
+        arg_list = sorted([" or ".join(pair) for pair in alias_pairs_present])
+        alias_error = (
             f"Duplicate aliases for arguments in %{cmd_from}. "
             "Please use either one of "
             f"{', '.join(arg_list)}."
         )
+    else:
+        alias_error = ""
+
+    error_message = f"{duplicates_error}{alias_error}"
 
     if error_message:
         raise exceptions.UsageError(error_message)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -18,6 +18,37 @@ PATH_TO_TMP_ASSETS = PATH_TO_TESTS / "tmp"
 PATH_TO_TMP_ASSETS.mkdir(exist_ok=True)
 
 
+@pytest.fixture
+def check_duplicate_message_factory():
+    def _generate_error_message(cmd, args, aliases=None):
+        error_message = ""
+        duplicates = set([arg for arg in args if args.count(arg) != 1])
+
+        if duplicates:
+            error_message += (
+                f"Duplicate arguments in %{cmd}. "
+                "Please use only one of each of the following: "
+                f"{', '.join(sorted(duplicates))}."
+            )
+            if aliases:
+                error_message += " "
+
+        if aliases:
+            alias_list = []
+            for pair in sorted(aliases):
+                print(pair[0], pair[1])
+                alias_list.append(f"{f'-{pair[0]}'} or {f'--{pair[1]}'}")
+            error_message += (
+                f"Duplicate aliases for arguments in %{cmd}. "
+                "Please use either one of "
+                f"{', '.join(alias_list)}."
+            )
+
+        return error_message
+
+    return _generate_error_message
+
+
 @pytest.fixture(scope="function", autouse=True)
 def isolate_tests(monkeypatch):
     """

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -174,7 +174,8 @@ def test_parse_connect_shovel_over_newlines():
     ],
 )
 def test_connection_from_dsn_section(section, expected):
-    result = connection_str_from_dsn_section(section=section, config=DummyConfig)
+    result = connection_str_from_dsn_section(
+        section=section, config=DummyConfig)
     assert result == expected
 
 
@@ -204,7 +205,8 @@ def test_connection_from_dsn_section(section, expected):
     ],
 )
 def test_connection_string(input_, expected):
-    assert _connection_string(input_, "src/tests/test_dsn_config.ini") == expected
+    assert _connection_string(
+        input_, "src/tests/test_dsn_config.ini") == expected
 
 
 class Bunch:
@@ -300,7 +302,7 @@ def complete_with_defaults(mapping):
 
 
 @pytest.mark.parametrize(
-    "line, cmd_from, expected_error_message, setup",
+    "line, cmd_from, expected_error_message",
     [
         (
             "duckdb:// --alias test1 --alias test2",
@@ -309,7 +311,6 @@ def complete_with_defaults(mapping):
                 "Duplicate arguments in %sql. "
                 "Please use only one of each of the following: --alias"
             ),
-            None,
         ),
         (
             """histogram --table penguins.csv --column bill_length_mm
@@ -319,7 +320,6 @@ def complete_with_defaults(mapping):
                 "Duplicate arguments in %sqlplot. "
                 "Please use only one of each of the following: --column"
             ),
-            None,
         ),
         (
             """bar --table penguins.csv --column bill_length_mm
@@ -329,15 +329,12 @@ def complete_with_defaults(mapping):
                 "Duplicate arguments in %sqlplot. "
                 "Please use only one of each of the following: --show-numbers"
             ),
-            None,
         ),
     ],
 )
 def test_magic_args_raises_usageerror(
-    load_penguin, ip, line, cmd_from, expected_error_message, setup
+    load_penguin, ip, line, cmd_from, expected_error_message
 ):
-    if setup:
-        ip.run_cell(setup)
     sql_line = ip.magics_manager.lsmagic()["line"][cmd_from]
 
     with pytest.raises(UsageError) as excinfo:
@@ -366,7 +363,8 @@ def test_magic_args_does_not_raise_usageerror(ip, line, expected_out):
 @pytest.mark.parametrize(
     "query, expected_escaped, expected_found",
     [
-        ("SELECT * FROM table where x > :x", "SELECT * FROM table where x > :x", []),
+        ("SELECT * FROM table where x > :x",
+         "SELECT * FROM table where x > :x", []),
         (
             "SELECT * FROM table where x > ':x'",
             "SELECT * FROM table where x > '\\:x'",

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -312,7 +312,7 @@ Please use only one of each of the following: --alias"
         ),
     ],
 )
-def test_magic_args_raises_UsageError(ip, line, cmd_from, expected_error_message):
+def test_magic_args_raises_usageerror(ip, line, cmd_from, expected_error_message):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
     with pytest.raises(UsageError) as excinfo:

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -351,7 +351,7 @@ def test_magic_args_raises_usageerror(
         ),
     ],
 )
-def test_magic_args_does_not_raise_usageerror(ip, line, expected_out):
+def test_magic_args(ip, line, expected_out):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
     args = magic_args(sql_line, line, "sql")

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -302,33 +302,24 @@ def complete_with_defaults(mapping):
 @pytest.mark.parametrize(
     "line, expected_out, cmd_from, expected_error_message, raises",
     [
-        (
-            "some-argument",
-            {"line": ["some-argument"]},
-            None,
-            None,
-            False
-        ),
-        (
-            "a b c",
-            {"line": ["a", "b", "c"]},
-            None,
-            None,
-            False
-        ),
+        ("some-argument", {"line": ["some-argument"]}, None, None, False),
+        ("a b c", {"line": ["a", "b", "c"]}, None, None, False),
         (
             "a b c --file query.sql",
             {"line": ["a", "b", "c"], "file": "query.sql"},
             None,
             None,
-            False
+            False,
         ),
         (
             "duckdb:// --alias test1 --alias test2",
             None,
             "sql",
-            "Duplicate arguments in %sql. Please use only one of each of the following: --alias",
-            True
+            (
+                "Duplicate arguments in %sql. \
+Please use only one of each of the following: --alias"
+            ),
+            True,
         ),
     ],
 )

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -333,10 +333,51 @@ def complete_with_defaults(mapping):
 def test_magic_args_raises_usageerror(
     load_penguin, ip, line, cmd_from, expected_error_message
 ):
+    ALLOWED_DUPLICATES = {
+        "sql": ["-w", "--with", "--append", "--interact"],
+        "sqlplot": ["-w", "--with"],
+        "sqlcmd": [],
+    }
+
+    DISALLOWED_ALIASES = {
+        "sql": {
+            "-l": "--connections",
+            "-x": "--close",
+            "-c": "--creator",
+            "-s": "--section",
+            "-p": "--persist",
+            "-a": "--connection-arguments",
+            "-f": "--file",
+            "-n": "--no-index",
+            "-S": "--save",
+            "-A": "--alias",
+        },
+        "sqlplot": {
+            "-t": "--table",
+            "-s": "--schema",
+            "-c": "--column",
+            "-o": "--orient",
+            "-b": "--bins",
+            "-B": "--breaks",
+            "-W": "--binwidth",
+            "-S": "--show-numbers",
+        },
+        "sqlcmd": {
+            "-t": "--table",
+            "-s": "--schema",
+            "-o": "--output",
+        },
+    }
     sql_line = ip.magics_manager.lsmagic()["line"][cmd_from]
 
     with pytest.raises(UsageError) as excinfo:
-        magic_args(sql_line, line, cmd_from)
+        magic_args(
+            sql_line,
+            line,
+            cmd_from,
+            ALLOWED_DUPLICATES[cmd_from],
+            DISALLOWED_ALIASES[cmd_from],
+        )
     assert expected_error_message in str(excinfo.value)
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -359,7 +359,7 @@ def test_magic_args_raises_usageerror(
 def test_magic_args_does_not_raise_usageerror(ip, line, expected_out):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
-    args = magic_args(sql_line, line, "somewhere")
+    args = magic_args(sql_line, line, "sql")
     assert args.__dict__ == complete_with_defaults(expected_out)
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -174,8 +174,7 @@ def test_parse_connect_shovel_over_newlines():
     ],
 )
 def test_connection_from_dsn_section(section, expected):
-    result = connection_str_from_dsn_section(
-        section=section, config=DummyConfig)
+    result = connection_str_from_dsn_section(section=section, config=DummyConfig)
     assert result == expected
 
 
@@ -205,8 +204,7 @@ def test_connection_from_dsn_section(section, expected):
     ],
 )
 def test_connection_string(input_, expected):
-    assert _connection_string(
-        input_, "src/tests/test_dsn_config.ini") == expected
+    assert _connection_string(input_, "src/tests/test_dsn_config.ini") == expected
 
 
 class Bunch:
@@ -363,8 +361,7 @@ def test_magic_args_does_not_raise_usageerror(ip, line, expected_out):
 @pytest.mark.parametrize(
     "query, expected_escaped, expected_found",
     [
-        ("SELECT * FROM table where x > :x",
-         "SELECT * FROM table where x > :x", []),
+        ("SELECT * FROM table where x > :x", "SELECT * FROM table where x > :x", []),
         (
             "SELECT * FROM table where x > ':x'",
             "SELECT * FROM table where x > '\\:x'",

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -300,55 +300,337 @@ def complete_with_defaults(mapping):
 
 
 @pytest.mark.parametrize(
-    "line, cmd_from, expected_error_message",
+    "line, cmd_from, args, aliases",
     [
+        # FOR %sql
+        # for creator/c
+        (
+            "--creator creator1 --creator creator2",
+            "sql",
+            ["--creator", "--creator"],
+            [],
+        ),
+        (
+            "-c creator1 -c creator2",
+            "sql",
+            ["-c", "-c"],
+            [],
+        ),
+        (
+            "--creator creator1 -c creator2",
+            "sql",
+            ["--creator", "-c"],
+            [("c", "creator")],
+        ),
+        # for persist/p
+        (
+            "--persist my_data1 --persist my_data2",
+            "sql",
+            ["--persist", "--persist"],
+            [],
+        ),
+        (
+            "-p my_data1 -p my_data2",
+            "sql",
+            ["-p", "-p"],
+            [],
+        ),
+        (
+            "--persist my_data1 -p my_data2",
+            "sql",
+            ["--persist", "-p"],
+            [("p", "persist")],
+        ),
+        # for no-index/n
+        (
+            "--persist my_data3 --no-index --no-index",
+            "sql",
+            ["--persist", "--no-index", "--no-index"],
+            [],
+        ),
+        (
+            "--persist my_data3 -n -n",
+            "sql",
+            ["--persist", "-n", "-n"],
+            [],
+        ),
+        (
+            "--persist my_data3 --no-index -n",
+            "sql",
+            ["--persist", "--no-index", "-n"],
+            [("n", "no-index")],
+        ),
+        # for file/f
+        (
+            "--file my-query.sql --file my-query.sql",
+            "sql",
+            ["--file", "--file"],
+            [],
+        ),
+        (
+            "-f my-query.sql -f my-query.sql",
+            "sql",
+            ["-f", "-f"],
+            [],
+        ),
+        (
+            "--file my-query.sql -f my-query.sql",
+            "sql",
+            ["--file", "-f"],
+            [("f", "file")],
+        ),
+        # for alias/A
         (
             "duckdb:// --alias test1 --alias test2",
             "sql",
-            (
-                "Duplicate arguments in %sql. "
-                "Please use only one of each of the following: --alias"
-            ),
+            ["--alias", "--alias"],
+            [],
         ),
         (
-            """histogram --table penguins.csv --column bill_length_mm
---column body_mass_g""",
-            "sqlplot",
-            (
-                "Duplicate arguments in %sqlplot. "
-                "Please use only one of each of the following: --column"
-            ),
+            "duckdb:// -A test1 -A test2",
+            "sql",
+            ["-A", "-A"],
+            [],
         ),
         (
-            """bar --table penguins.csv --column bill_length_mm
---show-numbers --show-numbers""",
+            "duckdb:// --alias test1 -A test2",
+            "sql",
+            ["--alias", "-A"],
+            [("A", "alias")],
+        ),
+        # for connections/l
+        (
+            "--connections --connections",
+            "sql",
+            ["--connections", "--connections"],
+            [],
+        ),
+        (
+            "-l -l",
+            "sql",
+            ["-l", "-l"],
+            [],
+        ),
+        (
+            "--connections -l",
+            "sql",
+            ["--connections", "-l"],
+            [("l", "connections")],
+        ),
+        # for close/x
+        (
+            "--close db-two --close db-three",
+            "sql",
+            ["--close", "--close"],
+            [],
+        ),
+        (
+            "-x db-two -x db-three",
+            "sql",
+            ["-x", "-x"],
+            [],
+        ),
+        (
+            "--close db-two -x db-three",
+            "sql",
+            ["--close", "-x"],
+            [("x", "close")],
+        ),
+        # FOR %sqlplot
+        # for table/t
+        (
+            "histogram --table penguins --table penguins --column body_mass_g",
             "sqlplot",
-            (
-                "Duplicate arguments in %sqlplot. "
-                "Please use only one of each of the following: --show-numbers"
-            ),
+            ["--table", "--table", "--column"],
+            [],
+        ),
+        (
+            "histogram -t penguins -t penguins.csv --column body_mass_g",
+            "sqlplot",
+            ["-t", "-t", "--column"],
+            [],
+        ),
+        (
+            "histogram --table penguins -t penguins --column body_mass_g",
+            "sqlplot",
+            ["--table", "-t", "--column"],
+            [("t", "table")],
+        ),
+        # for column/c
+        (
+            "histogram --table penguins --column bill_length_mm penguins "
+            "--column body_mass_g",
+            "sqlplot",
+            ["--table", "--column", "--column"],
+            [],
+        ),
+        (
+            "histogram --table penguins -c bill_length_mm penguins -c body_mass_g",
+            "sqlplot",
+            ["--table", "-c", "-c"],
+            [],
+        ),
+        (
+            "histogram --table penguins --column bill_length_mm penguins "
+            "-c body_mass_g",
+            "sqlplot",
+            ["--table", "--column", "-c"],
+            [("c", "column")],
+        ),
+        # for bins/b
+        (
+            "histogram --table penguins --column body_mass_g --bins 30 --bins 40",
+            "sqlplot",
+            ["--table", "--column", "--bins", "--bins"],
+            [],
+        ),
+        (
+            "histogram --table penguins --column body_mass_g -b 30 -b 40",
+            "sqlplot",
+            ["--table", "--column", "-b", "-b"],
+            [],
+        ),
+        (
+            "histogram --table penguins --column body_mass_g --bins 30 -b 40",
+            "sqlplot",
+            ["--table", "--column", "--bins", "-b"],
+            [("b", "bins")],
+        ),
+        # for breaks/B
+        (
+            "histogram --table penguins.csv --column body_mass_g "
+            "--breaks 3200 4000 4800 --breaks 3200 4000 4800",
+            "sqlplot",
+            ["--table", "--column", "--breaks", "--breaks"],
+            [],
+        ),
+        (
+            "histogram --table penguins.csv --column body_mass_g "
+            "-B 3200 4000 4800 -B 3200 4000 4800",
+            "sqlplot",
+            ["--table", "--column", "-B", "-B"],
+            [],
+        ),
+        (
+            "histogram --table penguins.csv --column body_mass_g "
+            "--breaks 3200 4000 4800 -B 3200 4000 4800",
+            "sqlplot",
+            ["--table", "--column", "--breaks", "-B"],
+            [("B", "breaks")],
+        ),
+        # for binwidth/W
+        (
+            "histogram --table penguins.csv --column body_mass_g "
+            "--binwidth 150 --binwidth 150",
+            "sqlplot",
+            ["--table", "--column", "--binwidth", "--binwidth"],
+            [],
+        ),
+        (
+            "histogram --table penguins.csv --column body_mass_g -W 150 -W 150",
+            "sqlplot",
+            ["--table", "--column", "-W", "-W"],
+            [],
+        ),
+        (
+            "histogram --table penguins.csv --column body_mass_g --binwidth 150 -W 150",
+            "sqlplot",
+            ["--table", "--column", "--binwidth", "-W"],
+            [("W", "binwidth")],
+        ),
+        # for orient/o
+        (
+            "boxplot --table penguins --column body_mass_g --orient h --orient h",
+            "sqlplot",
+            ["--table", "--column", "--orient", "--orient"],
+            [],
+        ),
+        (
+            "boxplot --table penguins --column body_mass_g -o h -o h",
+            "sqlplot",
+            ["--table", "--column", "-o", "-o"],
+            [],
+        ),
+        (
+            "boxplot --table penguins --column body_mass_g --orient h -o h",
+            "sqlplot",
+            ["--table", "--column", "--orient", "-o"],
+            [("o", "orient")],
+        ),
+        # for show-numbers/S
+        (
+            "pie --table penguins.csv --column species --show-numbers --show-numbers",
+            "sqlplot",
+            ["--table", "--column", "--show-numbers", "--show-numbers"],
+            [],
+        ),
+        (
+            "pie --table penguins.csv --column species -S -S",
+            "sqlplot",
+            ["--table", "--column", "-S", "-S"],
+            [],
+        ),
+        (
+            "pie --table penguins.csv --column species --show-numbers -S",
+            "sqlplot",
+            ["--table", "--column", "--show-numbers", "-S"],
+            [("S", "show-numbers")],
+        ),
+        # FOR %sqlcmd
+        # for schema/s
+        (
+            "tables --schema s1 --schema s2",
+            "sqlcmd",
+            ["--schema", "--schema"],
+            [],
+        ),
+        (
+            "tables -s s1 -s s2",
+            "sqlcmd",
+            ["-s", "-s"],
+            [],
+        ),
+        (
+            "tables --schema s1 -s s2",
+            "sqlcmd",
+            ["--schema", "-s"],
+            [("s", "schema")],
+        ),
+        # for table/t
+        (
+            "columns --table penguins --table penguins",
+            "sqlcmd",
+            ["--table", "--table"],
+            [],
+        ),
+        (
+            "columns -t penguins -t penguins",
+            "sqlcmd",
+            ["-t", "-t"],
+            [],
+        ),
+        (
+            "columns --table penguins -t penguins",
+            "sqlcmd",
+            ["--table", "-t"],
+            [("t", "table")],
         ),
     ],
 )
 def test_magic_args_raises_usageerror(
-    load_penguin, ip, line, cmd_from, expected_error_message
+    check_duplicate_message_factory,
+    load_penguin,
+    ip_empty,
+    line,
+    cmd_from,
+    args,
+    aliases,
 ):
-    ALLOWED_DUPLICATES = {
-        "sql": ["-w", "--with", "--append", "--interact"],
-        "sqlplot": ["-w", "--with"],
-        "sqlcmd": [],
-    }
-
-    sql_line = ip.magics_manager.lsmagic()["line"][cmd_from]
-
     with pytest.raises(UsageError) as excinfo:
-        magic_args(
-            sql_line,
-            line,
-            cmd_from,
-            ALLOWED_DUPLICATES[cmd_from],
-        )
-    assert expected_error_message in str(excinfo.value)
+        ip_empty.run_cell(f"%{cmd_from} {line}")
+    assert check_duplicate_message_factory(cmd_from, args, aliases) in str(
+        excinfo.value
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -321,7 +321,7 @@ def test_magic_args_raises_UsageError(ip, line, cmd_from, expected_error_message
 
 
 @pytest.mark.parametrize(
-    "line, expected_out, cmd_from, expected_error_message, raises",
+    "line, expected_out",
     [
         ("some-argument", {"line": ["some-argument"]}),
         ("a b c", {"line": ["a", "b", "c"]}),

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -339,35 +339,6 @@ def test_magic_args_raises_usageerror(
         "sqlcmd": [],
     }
 
-    DISALLOWED_ALIASES = {
-        "sql": {
-            "-l": "--connections",
-            "-x": "--close",
-            "-c": "--creator",
-            "-s": "--section",
-            "-p": "--persist",
-            "-a": "--connection-arguments",
-            "-f": "--file",
-            "-n": "--no-index",
-            "-S": "--save",
-            "-A": "--alias",
-        },
-        "sqlplot": {
-            "-t": "--table",
-            "-s": "--schema",
-            "-c": "--column",
-            "-o": "--orient",
-            "-b": "--bins",
-            "-B": "--breaks",
-            "-W": "--binwidth",
-            "-S": "--show-numbers",
-        },
-        "sqlcmd": {
-            "-t": "--table",
-            "-s": "--schema",
-            "-o": "--output",
-        },
-    }
     sql_line = ip.magics_manager.lsmagic()["line"][cmd_from]
 
     with pytest.raises(UsageError) as excinfo:
@@ -376,7 +347,6 @@ def test_magic_args_raises_usageerror(
             line,
             cmd_from,
             ALLOWED_DUPLICATES[cmd_from],
-            DISALLOWED_ALIASES[cmd_from],
         )
     assert expected_error_message in str(excinfo.value)
 
@@ -395,7 +365,7 @@ def test_magic_args_raises_usageerror(
 def test_magic_args(ip, line, expected_out):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
-    args = magic_args(sql_line, line, "sql", [], {})
+    args = magic_args(sql_line, line, "sql", [])
     assert args.__dict__ == complete_with_defaults(expected_out)
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -395,7 +395,7 @@ def test_magic_args_raises_usageerror(
 def test_magic_args(ip, line, expected_out):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
-    args = magic_args(sql_line, line, "sql")
+    args = magic_args(sql_line, line, "sql", [], {})
     assert args.__dict__ == complete_with_defaults(expected_out)
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -306,8 +306,8 @@ def complete_with_defaults(mapping):
             "duckdb:// --alias test1 --alias test2",
             "sql",
             (
-                "Duplicate arguments in %sql. \
-Please use only one of each of the following: --alias"
+                "Duplicate arguments in %sql. "
+                "Please use only one of each of the following: --alias"
             ),
         ),
     ],
@@ -334,7 +334,7 @@ def test_magic_args_raises_usageerror(ip, line, cmd_from, expected_error_message
 def test_magic_args_does_not_raise_UsageError(ip, line, expected_out):
     sql_line = ip.magics_manager.lsmagic()["line"]["sql"]
 
-    args = magic_args(sql_line, line)
+    args = magic_args(sql_line, line, "somewhere")
     assert args.__dict__ == complete_with_defaults(expected_out)
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -312,7 +312,8 @@ def complete_with_defaults(mapping):
             None,
         ),
         (
-            "histogram --table penguins.csv --column bill_length_mm --column body_mass_g",
+            """histogram --table penguins.csv --column bill_length_mm
+--column body_mass_g""",
             "sqlplot",
             (
                 "Duplicate arguments in %sqlplot. "
@@ -321,7 +322,8 @@ def complete_with_defaults(mapping):
             None,
         ),
         (
-            "bar --table penguins.csv --column bill_length_mm --show-numbers --show-numbers",
+            """bar --table penguins.csv --column bill_length_mm
+--show-numbers --show-numbers""",
             "sqlplot",
             (
                 "Duplicate arguments in %sqlplot. "

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -18,7 +18,6 @@ from sql.parse import (
     ConnectionsFile,
 )
 
-
 default_connect_args = {"options": "-csearch_path=test"}
 
 PATH_TO_DSN_FILE = "src/tests/test_dsn_config.ini"

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -139,7 +139,7 @@ FROM data.csv
 """
     )
     out = ip.run_cell(
-        "%sqlplot histogram --table data.csv --column age --table data.csv"
+        "%sqlplot histogram --table data.csv --column age"
     )
     assert isinstance(out.result, matplotlib.axes._axes.Axes)
 
@@ -156,6 +156,6 @@ FROM data.csv
 """
     )
     out = ip.run_cell(
-        "%sqlplot histogram --table data.csv --column age --table data.csv"
+        "%sqlplot histogram --table data.csv --column age"
     )
     assert isinstance(out.result, matplotlib.axes._axes.Axes)

--- a/src/tests/test_plot.py
+++ b/src/tests/test_plot.py
@@ -138,9 +138,7 @@ SELECT *
 FROM data.csv
 """
     )
-    out = ip.run_cell(
-        "%sqlplot histogram --table data.csv --column age"
-    )
+    out = ip.run_cell("%sqlplot histogram --table data.csv --column age")
     assert isinstance(out.result, matplotlib.axes._axes.Axes)
 
 
@@ -155,7 +153,5 @@ SELECT *
 FROM data.csv
 """
     )
-    out = ip.run_cell(
-        "%sqlplot histogram --table data.csv --column age"
-    )
+    out = ip.run_cell("%sqlplot histogram --table data.csv --column age")
     assert isinstance(out.result, matplotlib.axes._axes.Axes)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -16,12 +16,14 @@ EXPECTED_STORE_SUGGESTIONS = (
         pytest.param(
             "a",
             "%sqlcmd columns --table {}",
-            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(
+                reason="this is not working yet, see #658"),
         ),
         pytest.param(
             "bbb",
             "%sqlcmd profile --table {}",
-            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(
+                reason="this is not working yet, see #658"),
         ),
         ("c_c", "%sqlplot histogram --table {} --column x"),
         ("d_d_d", "%sqlplot boxplot --table {} --column x"),
@@ -147,36 +149,39 @@ def test_is_sqlalchemy_error(string, substrings, expected):
 
 
 @pytest.mark.parametrize(
-    "args, cmd_from, raises, expected_error_message",
+    "args, cmd_from, expected_error_message",
     [
         (
             ["--table", "--table"],
             "sqlcmd",
-            True,
             "Duplicate arguments in %sqlcmd. \
 Please use only one of each of the following: --table",
         ),
         (
             ["--alias", "--alias"],
             "sql",
-            True,
             "Duplicate arguments in %sql. \
 Please use only one of each of the following: --alias",
         ),
         (
             ["--table", "--table", "--column", "--column"],
             "sqlplot",
-            True,
             "Duplicate arguments in %sqlplot. \
 Please use only one of each of the following: --column, --table",
         ),
-        (["--table", "--column"], "sqlplot", False, None),
     ],
 )
-def test_check_duplicate_arguments(args, cmd_from, raises, expected_error_message):
-    if raises:
-        with pytest.raises(UsageError) as excinfo:
-            util.check_duplicate_arguments(args, cmd_from)
-        assert expected_error_message in str(excinfo.value)
-    else:
-        assert util.check_duplicate_arguments(args, cmd_from)
+def test_check_duplicate_arguments_raises_UsageError(args, cmd_from, expected_error_message):
+    with pytest.raises(UsageError) as excinfo:
+        util.check_duplicate_arguments(args, cmd_from)
+    assert expected_error_message in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "args, cmd_from",
+    [
+        (["--table", "--column"], "sqlplot"),
+    ]
+)
+def test_check_duplicate_arguments_does_not_raise_UsageError(args, cmd_from):
+    assert util.check_duplicate_arguments(args, cmd_from)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -501,7 +501,6 @@ def test_check_duplicate_arguments_raises_usageerror(
 ):
     with pytest.raises(UsageError) as excinfo:
         util.check_duplicate_arguments(cmd_from, args)
-    print(str(excinfo.value))
     assert check_duplicate_message_factory(cmd_from, args, aliases) in str(
         excinfo.value
     )

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -16,14 +16,12 @@ EXPECTED_STORE_SUGGESTIONS = (
         pytest.param(
             "a",
             "%sqlcmd columns --table {}",
-            marks=pytest.mark.xfail(
-                reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
         ),
         pytest.param(
             "bbb",
             "%sqlcmd profile --table {}",
-            marks=pytest.mark.xfail(
-                reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
         ),
         ("c_c", "%sqlplot histogram --table {} --column x"),
         ("d_d_d", "%sqlplot boxplot --table {} --column x"),
@@ -171,7 +169,9 @@ Please use only one of each of the following: --column, --table",
         ),
     ],
 )
-def test_check_duplicate_arguments_raises_UsageError(args, cmd_from, expected_error_message):
+def test_check_duplicate_arguments_raises_UsageError(
+    args, cmd_from, expected_error_message
+):
     with pytest.raises(UsageError) as excinfo:
         util.check_duplicate_arguments(args, cmd_from)
     assert expected_error_message in str(excinfo.value)
@@ -181,7 +181,7 @@ def test_check_duplicate_arguments_raises_UsageError(args, cmd_from, expected_er
     "args, cmd_from",
     [
         (["--table", "--column"], "sqlplot"),
-    ]
+    ],
 )
 def test_check_duplicate_arguments_does_not_raise_UsageError(args, cmd_from):
     assert util.check_duplicate_arguments(args, cmd_from)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -10,6 +10,37 @@ EXPECTED_STORE_SUGGESTIONS = (
 )
 
 
+@pytest.fixture
+def check_duplicate_message_factory():
+    def _generate_error_message(cmd, args, aliases=None):
+        error_message = ""
+        duplicates = set([arg for arg in args if args.count(arg) != 1])
+
+        if duplicates:
+            error_message += (
+                f"Duplicate arguments in %{cmd}. "
+                "Please use only one of each of the following: "
+                f"{', '.join(sorted(duplicates))}."
+            )
+            if aliases:
+                error_message += " "
+
+        if aliases:
+            alias_list = []
+            for pair in sorted(aliases):
+                print(pair[0], pair[1])
+                alias_list.append(f"{f'-{pair[0]}'} or {f'--{pair[1]}'}")
+            error_message += (
+                f"Duplicate aliases for arguments in %{cmd}. "
+                "Please use either one of "
+                f"{', '.join(alias_list)}."
+            )
+
+        return error_message
+
+    return _generate_error_message
+
+
 @pytest.mark.parametrize(
     "store_table, query",
     [
@@ -147,41 +178,372 @@ def test_is_sqlalchemy_error(string, substrings, expected):
 
 
 @pytest.mark.parametrize(
-    "args, cmd_from, expected_error_message",
+    "cmd_from, args, aliases",
     [
+        # FOR SQL
+        #
+        # for creator/c
         (
-            ["--table", "--table"],
-            "sqlcmd",
-            "Duplicate arguments in %sqlcmd. \
-Please use only one of each of the following: --table",
-        ),
-        (
-            ["--alias", "--alias"],
             "sql",
-            "Duplicate arguments in %sql. \
-Please use only one of each of the following: --alias",
+            ["--creator", "--creator"],
+            [],
         ),
         (
-            ["--table", "--table", "--column", "--column"],
+            "sql",
+            ["-c", "-c"],
+            [],
+        ),
+        (
+            "sql",
+            ["--creator", "-c"],
+            [("c", "creator")],
+        ),
+        # for persist/p
+        (
+            "sql",
+            ["--persist", "--persist"],
+            [],
+        ),
+        (
+            "sql",
+            ["-p", "-p"],
+            [],
+        ),
+        (
+            "sql",
+            ["--persist", "-p"],
+            [("p", "persist")],
+        ),
+        # for no-index/n
+        (
+            "sql",
+            ["--persist", "--no-index", "--no-index"],
+            [],
+        ),
+        (
+            "sql",
+            ["--persist", "-n", "-n"],
+            [],
+        ),
+        (
+            "sql",
+            ["--persist", "--no-index", "-n"],
+            [("n", "no-index")],
+        ),
+        # for file/f
+        (
+            "sql",
+            ["--file", "--file"],
+            [],
+        ),
+        (
+            "sql",
+            ["-f", "-f"],
+            [],
+        ),
+        (
+            "sql",
+            ["--file", "-f"],
+            [("f", "file")],
+        ),
+        # for save/S
+        (
+            "sql",
+            ["--save", "--save"],
+            [],
+        ),
+        (
+            "sql",
+            ["-S", "-S"],
+            [],
+        ),
+        (
+            "sql",
+            ["--save", "-S"],
+            [("S", "save")],
+        ),
+        # for alias/A
+        (
+            "sql",
+            ["--alias", "--alias"],
+            [],
+        ),
+        (
+            "sql",
+            ["-A", "-A"],
+            [],
+        ),
+        (
+            "sql",
+            ["--alias", "-A"],
+            [("A", "alias")],
+        ),
+        # for connections/l
+        (
+            "sql",
+            ["--connections", "--connections"],
+            [],
+        ),
+        (
+            "sql",
+            ["-l", "-l"],
+            [],
+        ),
+        (
+            "sql",
+            ["--connections", "-l"],
+            [("l", "connections")],
+        ),
+        # for close/x
+        (
+            "sql",
+            ["--close", "--close"],
+            [],
+        ),
+        (
+            "sql",
+            ["-x", "-x"],
+            [],
+        ),
+        (
+            "sql",
+            ["--close", "-x"],
+            [("x", "close")],
+        ),
+        # for mixed
+        (
+            "sql",
+            ["--creator", "--creator", "-c", "--persist", "--file", "-f", "-c"],
+            [("c", "creator"), ("f", "file")],
+        ),
+        #
+        # FOR SQLPLOT
+        #
+        # for table/t
+        (
             "sqlplot",
-            "Duplicate arguments in %sqlplot. \
-Please use only one of each of the following: --column, --table",
+            ["--table", "--table", "--column"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["-t", "-t", "--column"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "-t", "--column"],
+            [("t", "table")],
+        ),
+        # for column/c
+        (
+            "sqlplot",
+            ["--table", "--column", "--column"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "-c", "-c"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-c"],
+            [("c", "column")],
+        ),
+        # for bins/b
+        (
+            "sqlplot",
+            ["--table", "--column", "--bins", "--bins"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-b", "-b"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "--bins", "-b"],
+            [("b", "bins")],
+        ),
+        # for breaks/B
+        (
+            "sqlplot",
+            ["--table", "--column", "--breaks", "--breaks"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-B", "-B"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "--breaks", "-B"],
+            [("B", "breaks")],
+        ),
+        # for binwidth/W
+        (
+            "sqlplot",
+            ["--table", "--column", "--binwidth", "--binwidth"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-W", "-W"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "--binwidth", "-W"],
+            [("W", "binwidth")],
+        ),
+        # for orient/o
+        (
+            "sqlplot",
+            ["--table", "--column", "--orient", "--orient"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-o", "-o"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "--orient", "-o"],
+            [("o", "orient")],
+        ),
+        # for show-numbers/S
+        (
+            "sqlplot",
+            ["--table", "--column", "--show-numbers", "--show-numbers"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "-S", "-S"],
+            [],
+        ),
+        (
+            "sqlplot",
+            ["--table", "--column", "--show-numbers", "-S"],
+            [("S", "show-numbers")],
+        ),
+        # for mixed
+        (
+            "sqlplot",
+            [
+                "--table",
+                "--column",
+                "--column",
+                "-w",
+                "--with",
+                "--show-numbers",
+                "--show-numbers",
+                "--binwidth",
+                "--orient",
+                "-o",
+                "--breaks",
+                "-B",
+            ],
+            [("o", "orient"), ("B", "breaks")],
+        ),
+        #
+        # FOR SQLCMD
+        #
+        # for schema/s
+        (
+            "sqlcmd",
+            ["--schema", "--schema"],
+            [],
+        ),
+        (
+            "sqlcmd",
+            ["-s", "-s"],
+            [],
+        ),
+        (
+            "sqlcmd",
+            ["--schema", "-s"],
+            [("s", "schema")],
+        ),
+        # for table/t
+        (
+            "sqlcmd",
+            ["--table", "--table"],
+            [],
+        ),
+        (
+            "sqlcmd",
+            ["-t", "-t"],
+            [],
+        ),
+        (
+            "sqlcmd",
+            ["--table", "-t"],
+            [("t", "table")],
+        ),
+        # for mixed
+        (
+            "sqlcmd",
+            ["--table", "-t", "-s", "-s", "--schema"],
+            [("t", "table"), ("s", "schema")],
         ),
     ],
 )
 def test_check_duplicate_arguments_raises_usageerror(
-    args, cmd_from, expected_error_message
+    check_duplicate_message_factory,
+    cmd_from,
+    args,
+    aliases,
 ):
     with pytest.raises(UsageError) as excinfo:
-        util.check_duplicate_arguments(args, cmd_from)
-    assert expected_error_message in str(excinfo.value)
+        util.check_duplicate_arguments(cmd_from, args)
+    print(str(excinfo.value))
+    assert check_duplicate_message_factory(cmd_from, args, aliases) in str(
+        excinfo.value
+    )
 
 
 @pytest.mark.parametrize(
-    "args, cmd_from",
+    "cmd_from, args",
     [
+        (["--creator"], "sql"),
+        (["-c"], "sql"),
+        (["--persist"], "sql"),
+        (["-p"], "sql"),
+        (["--persist", "--no-index"], "sql"),
+        (["--persist", "-n"], "sql"),
+        (["--file"], "sql"),
+        (["-f"], "sql"),
+        (["--save"], "sql"),
+        (["-S"], "sql"),
+        (["--alias"], "sql"),
+        (["-A"], "sql"),
+        (["--connections"], "sql"),
+        (["-l"], "sql"),
+        (["--close"], "sql"),
+        (["-x"], "sql"),
         (["--table", "--column"], "sqlplot"),
+        (["--table", "-c"], "sqlplot"),
+        (["-t", "--column"], "sqlplot"),
+        (["--table", "--column", "--breaks"], "sqlplot"),
+        (["--table", "--column", "-B"], "sqlplot"),
+        (["--table", "--column", "--bins"], "sqlplot"),
+        (["--table", "--column", "-b"], "sqlplot"),
+        (["--table", "--column", "--binwidth"], "sqlplot"),
+        (["--table", "--column", "-W"], "sqlplot"),
+        (["--table", "--column", "--orient"], "sqlplot"),
+        (["--table", "--column", "-o"], "sqlplot"),
+        (["--table", "--column", "--show-numbers"], "sqlplot"),
+        (["--table", "--column", "-S"], "sqlplot"),
+        (["--table"], "sqlcmd"),
+        (["-t"], "sqlcmd"),
+        (["--table", "--schema"], "sqlcmd"),
+        (["--table", "-s"], "sqlcmd"),
     ],
 )
-def test_check_duplicate_arguments_does_not_raise_usageerror(args, cmd_from):
-    assert util.check_duplicate_arguments(args, cmd_from)
+def test_check_duplicate_arguments_does_not_raise_usageerror(cmd_from, args):
+    assert util.check_duplicate_arguments(cmd_from, args)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -507,6 +507,35 @@ ALLOWED_DUPLICATES = {
             ],
             [("w", "with"), ("o", "orient"), ("B", "breaks")],
         ),
+        #
+        # FOR SQLCMD
+        #
+        # for schema/s
+        (
+            SqlCmdMagic.execute,
+            "sqlcmd",
+            ["--schema", "--schema"],
+            [],
+        ),
+        (
+            SqlCmdMagic.execute,
+            "sqlcmd",
+            ["-s", "-s"],
+            [],
+        ),
+        # for table/t
+        (
+            SqlCmdMagic.execute,
+            "sqlcmd",
+            ["--table", "--table"],
+            [],
+        ),
+        (
+            SqlCmdMagic.execute,
+            "sqlcmd",
+            ["-t", "-t"],
+            [],
+        ),
     ],
 )
 def test_check_duplicate_arguments_raises_usageerror(
@@ -557,6 +586,10 @@ def test_check_duplicate_arguments_raises_usageerror(
         (SqlPlotMagic.execute, ["--table", "--column", "-o"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "--show-numbers"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "-S"], "sqlplot"),
+        (SqlCmdMagic.execute, ["--table"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["-t"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["--table", "--schema"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["--table", "-s"], "sqlcmd"),
     ],
 )
 def test_check_duplicate_arguments_does_not_raise_usageerror(

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -16,14 +16,12 @@ EXPECTED_STORE_SUGGESTIONS = (
         pytest.param(
             "a",
             "%sqlcmd columns --table {}",
-            marks=pytest.mark.xfail(
-                reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
         ),
         pytest.param(
             "bbb",
             "%sqlcmd profile --table {}",
-            marks=pytest.mark.xfail(
-                reason="this is not working yet, see #658"),
+            marks=pytest.mark.xfail(reason="this is not working yet, see #658"),
         ),
         ("c_c", "%sqlplot histogram --table {} --column x"),
         ("d_d_d", "%sqlplot boxplot --table {} --column x"),
@@ -155,27 +153,25 @@ def test_is_sqlalchemy_error(string, substrings, expected):
             ["--table", "--table"],
             "sqlcmd",
             True,
-            "Duplicate arguments in %sqlcmd. Please use only one of each of the following: --table"
+            "Duplicate arguments in %sqlcmd. \
+Please use only one of each of the following: --table",
         ),
         (
             ["--alias", "--alias"],
             "sql",
             True,
-            "Duplicate arguments in %sql. Please use only one of each of the following: --alias"
+            "Duplicate arguments in %sql. \
+Please use only one of each of the following: --alias",
         ),
         (
             ["--table", "--table", "--column", "--column"],
             "sqlplot",
             True,
-            "Duplicate arguments in %sqlplot. Please use only one of each of the following: --table, --column"
+            "Duplicate arguments in %sqlplot. \
+Please use only one of each of the following: --column, --table",
         ),
-        (
-            ["--table", "--column"],
-            "sqlplot",
-            False,
-            None
-        ),
-    ]
+        (["--table", "--column"], "sqlplot", False, None),
+    ],
 )
 def test_check_duplicate_arguments(args, cmd_from, raises, expected_error_message):
     if raises:

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -169,7 +169,7 @@ Please use only one of each of the following: --column, --table",
         ),
     ],
 )
-def test_check_duplicate_arguments_raises_UsageError(
+def test_check_duplicate_arguments_raises_usageerror(
     args, cmd_from, expected_error_message
 ):
     with pytest.raises(UsageError) as excinfo:
@@ -183,5 +183,5 @@ def test_check_duplicate_arguments_raises_UsageError(
         (["--table", "--column"], "sqlplot"),
     ],
 )
-def test_check_duplicate_arguments_does_not_raise_UsageError(args, cmd_from):
+def test_check_duplicate_arguments_does_not_raise_usageerror(args, cmd_from):
     assert util.check_duplicate_arguments(args, cmd_from)

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -507,54 +507,6 @@ ALLOWED_DUPLICATES = {
             ],
             [("w", "with"), ("o", "orient"), ("B", "breaks")],
         ),
-        #
-        # FOR SQLCMD
-        #
-        # for schema/s
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["--schema", "--schema"],
-            [],
-        ),
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["-s", "-s"],
-            [],
-        ),
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["--schema", "-s"],
-            [("s", "schema")],
-        ),
-        # for table/t
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["--table", "--table"],
-            [],
-        ),
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["-t", "-t"],
-            [],
-        ),
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["--table", "-t"],
-            [("t", "table")],
-        ),
-        # for mixed
-        (
-            SqlCmdMagic.execute,
-            "sqlcmd",
-            ["--table", "-t", "-s", "-s", "--schema"],
-            [("t", "table"), ("s", "schema")],
-        ),
     ],
 )
 def test_check_duplicate_arguments_raises_usageerror(
@@ -599,21 +551,17 @@ def test_check_duplicate_arguments_raises_usageerror(
         (SqlPlotMagic.execute, ["--table", "--column", "-B"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "--bins"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "-b"], "sqlplot"),
-        (SqlPlotMagic.execute, ["--table",
-         "--column", "--binwidth"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "--binwidth"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "-W"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "--orient"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "-o"], "sqlplot"),
-        (SqlPlotMagic.execute, ["--table",
-         "--column", "--show-numbers"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "--show-numbers"], "sqlplot"),
         (SqlPlotMagic.execute, ["--table", "--column", "-S"], "sqlplot"),
-        (SqlCmdMagic.execute, ["--table"], "sqlcmd"),
-        (SqlCmdMagic.execute, ["-t"], "sqlcmd"),
-        (SqlCmdMagic.execute, ["--table", "--schema"], "sqlcmd"),
-        (SqlCmdMagic.execute, ["--table", "-s"], "sqlcmd"),
     ],
 )
-def test_check_duplicate_arguments_does_not_raise_usageerror(magic_execute, args, cmd_from):
+def test_check_duplicate_arguments_does_not_raise_usageerror(
+    magic_execute, args, cmd_from
+):
     assert util.check_duplicate_arguments(
         magic_execute, cmd_from, args, ALLOWED_DUPLICATES[cmd_from]
     )

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -3,6 +3,9 @@ from IPython.core.error import UsageError
 import pytest
 from sql import util
 import json
+from sql.magic import SqlMagic
+from sql.magic_cmd import SqlCmdMagic
+from sql.magic_plot import SqlPlotMagic
 
 ERROR_MESSAGE = "Table cannot be None"
 EXPECTED_STORE_SUGGESTIONS = (
@@ -183,172 +186,167 @@ ALLOWED_DUPLICATES = {
     "sqlcmd": [],
 }
 
-DISALLOWED_ALIASES = {
-    "sql": {
-        "-l": "--connections",
-        "-x": "--close",
-        "-c": "--creator",
-        "-s": "--section",
-        "-p": "--persist",
-        "-a": "--connection-arguments",
-        "-f": "--file",
-        "-n": "--no-index",
-        "-S": "--save",
-        "-A": "--alias",
-    },
-    "sqlplot": {
-        "-t": "--table",
-        "-s": "--schema",
-        "-c": "--column",
-        "-o": "--orient",
-        "-b": "--bins",
-        "-B": "--breaks",
-        "-W": "--binwidth",
-        "-S": "--show-numbers",
-    },
-    "sqlcmd": {
-        "-t": "--table",
-        "-s": "--schema",
-        "-o": "--output",
-    },
-}
-
 
 @pytest.mark.parametrize(
-    "cmd_from, args, aliases",
+    "magic_execute, cmd_from, args, aliases",
     [
         # FOR SQL
         #
         # for creator/c
         (
+            SqlMagic.execute,
             "sql",
             ["--creator", "--creator"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-c", "-c"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--creator", "-c"],
             [("c", "creator")],
         ),
         # for persist/p
         (
+            SqlMagic.execute,
             "sql",
             ["--persist", "--persist"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-p", "-p"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--persist", "-p"],
             [("p", "persist")],
         ),
         # for no-index/n
         (
+            SqlMagic.execute,
             "sql",
             ["--persist", "--no-index", "--no-index"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--persist", "-n", "-n"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--persist", "--no-index", "-n"],
             [("n", "no-index")],
         ),
         # for file/f
         (
+            SqlMagic.execute,
             "sql",
             ["--file", "--file"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-f", "-f"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--file", "-f"],
             [("f", "file")],
         ),
         # for save/S
         (
+            SqlMagic.execute,
             "sql",
             ["--save", "--save"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-S", "-S"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--save", "-S"],
             [("S", "save")],
         ),
         # for alias/A
         (
+            SqlMagic.execute,
             "sql",
             ["--alias", "--alias"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-A", "-A"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--alias", "-A"],
             [("A", "alias")],
         ),
         # for connections/l
         (
+            SqlMagic.execute,
             "sql",
             ["--connections", "--connections"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-l", "-l"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--connections", "-l"],
             [("l", "connections")],
         ),
         # for close/x
         (
+            SqlMagic.execute,
             "sql",
             ["--close", "--close"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["-x", "-x"],
             [],
         ),
         (
+            SqlMagic.execute,
             "sql",
             ["--close", "-x"],
             [("x", "close")],
         ),
         # for mixed
         (
+            SqlMagic.execute,
             "sql",
             ["--creator", "--creator", "-c", "--persist", "--file", "-f", "-c"],
             [("c", "creator"), ("f", "file")],
@@ -358,118 +356,140 @@ DISALLOWED_ALIASES = {
         #
         # for table/t
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--table", "--column"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["-t", "-t", "--column"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "-t", "--column"],
             [("t", "table")],
         ),
         # for column/c
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--column"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "-c", "-c"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-c"],
             [("c", "column")],
         ),
         # for bins/b
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--bins", "--bins"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-b", "-b"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--bins", "-b"],
             [("b", "bins")],
         ),
         # for breaks/B
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--breaks", "--breaks"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-B", "-B"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--breaks", "-B"],
             [("B", "breaks")],
         ),
         # for binwidth/W
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--binwidth", "--binwidth"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-W", "-W"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--binwidth", "-W"],
             [("W", "binwidth")],
         ),
         # for orient/o
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--orient", "--orient"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-o", "-o"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--orient", "-o"],
             [("o", "orient")],
         ),
         # for show-numbers/S
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--show-numbers", "--show-numbers"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "-S", "-S"],
             [],
         ),
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             ["--table", "--column", "--show-numbers", "-S"],
             [("S", "show-numbers")],
         ),
         # for mixed
         (
+            SqlPlotMagic.execute,
             "sqlplot",
             [
                 "--table",
@@ -485,45 +505,52 @@ DISALLOWED_ALIASES = {
                 "--breaks",
                 "-B",
             ],
-            [("o", "orient"), ("B", "breaks")],
+            [("w", "with"), ("o", "orient"), ("B", "breaks")],
         ),
         #
         # FOR SQLCMD
         #
         # for schema/s
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["--schema", "--schema"],
             [],
         ),
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["-s", "-s"],
             [],
         ),
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["--schema", "-s"],
             [("s", "schema")],
         ),
         # for table/t
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["--table", "--table"],
             [],
         ),
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["-t", "-t"],
             [],
         ),
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["--table", "-t"],
             [("t", "table")],
         ),
         # for mixed
         (
+            SqlCmdMagic.execute,
             "sqlcmd",
             ["--table", "-t", "-s", "-s", "--schema"],
             [("t", "table"), ("s", "schema")],
@@ -532,13 +559,14 @@ DISALLOWED_ALIASES = {
 )
 def test_check_duplicate_arguments_raises_usageerror(
     check_duplicate_message_factory,
+    magic_execute,
     cmd_from,
     args,
     aliases,
 ):
     with pytest.raises(UsageError) as excinfo:
         util.check_duplicate_arguments(
-            cmd_from, args, ALLOWED_DUPLICATES[cmd_from], DISALLOWED_ALIASES[cmd_from]
+            magic_execute, cmd_from, args, ALLOWED_DUPLICATES[cmd_from]
         )
     assert check_duplicate_message_factory(cmd_from, args, aliases) in str(
         excinfo.value
@@ -546,44 +574,46 @@ def test_check_duplicate_arguments_raises_usageerror(
 
 
 @pytest.mark.parametrize(
-    "args, cmd_from",
+    "magic_execute, args, cmd_from",
     [
-        (["--creator"], "sql"),
-        (["-c"], "sql"),
-        (["--persist"], "sql"),
-        (["-p"], "sql"),
-        (["--persist", "--no-index"], "sql"),
-        (["--persist", "-n"], "sql"),
-        (["--file"], "sql"),
-        (["-f"], "sql"),
-        (["--save"], "sql"),
-        (["-S"], "sql"),
-        (["--alias"], "sql"),
-        (["-A"], "sql"),
-        (["--connections"], "sql"),
-        (["-l"], "sql"),
-        (["--close"], "sql"),
-        (["-x"], "sql"),
-        (["--table", "--column"], "sqlplot"),
-        (["--table", "-c"], "sqlplot"),
-        (["-t", "--column"], "sqlplot"),
-        (["--table", "--column", "--breaks"], "sqlplot"),
-        (["--table", "--column", "-B"], "sqlplot"),
-        (["--table", "--column", "--bins"], "sqlplot"),
-        (["--table", "--column", "-b"], "sqlplot"),
-        (["--table", "--column", "--binwidth"], "sqlplot"),
-        (["--table", "--column", "-W"], "sqlplot"),
-        (["--table", "--column", "--orient"], "sqlplot"),
-        (["--table", "--column", "-o"], "sqlplot"),
-        (["--table", "--column", "--show-numbers"], "sqlplot"),
-        (["--table", "--column", "-S"], "sqlplot"),
-        (["--table"], "sqlcmd"),
-        (["-t"], "sqlcmd"),
-        (["--table", "--schema"], "sqlcmd"),
-        (["--table", "-s"], "sqlcmd"),
+        (SqlMagic.execute, ["--creator"], "sql"),
+        (SqlMagic.execute, ["-c"], "sql"),
+        (SqlMagic.execute, ["--persist"], "sql"),
+        (SqlMagic.execute, ["-p"], "sql"),
+        (SqlMagic.execute, ["--persist", "--no-index"], "sql"),
+        (SqlMagic.execute, ["--persist", "-n"], "sql"),
+        (SqlMagic.execute, ["--file"], "sql"),
+        (SqlMagic.execute, ["-f"], "sql"),
+        (SqlMagic.execute, ["--save"], "sql"),
+        (SqlMagic.execute, ["-S"], "sql"),
+        (SqlMagic.execute, ["--alias"], "sql"),
+        (SqlMagic.execute, ["-A"], "sql"),
+        (SqlMagic.execute, ["--connections"], "sql"),
+        (SqlMagic.execute, ["-l"], "sql"),
+        (SqlMagic.execute, ["--close"], "sql"),
+        (SqlMagic.execute, ["-x"], "sql"),
+        (SqlPlotMagic.execute, ["--table", "--column"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "-c"], "sqlplot"),
+        (SqlPlotMagic.execute, ["-t", "--column"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "--breaks"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "-B"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "--bins"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "-b"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table",
+         "--column", "--binwidth"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "-W"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "--orient"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "-o"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table",
+         "--column", "--show-numbers"], "sqlplot"),
+        (SqlPlotMagic.execute, ["--table", "--column", "-S"], "sqlplot"),
+        (SqlCmdMagic.execute, ["--table"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["-t"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["--table", "--schema"], "sqlcmd"),
+        (SqlCmdMagic.execute, ["--table", "-s"], "sqlcmd"),
     ],
 )
-def test_check_duplicate_arguments_does_not_raise_usageerror(args, cmd_from):
+def test_check_duplicate_arguments_does_not_raise_usageerror(magic_execute, args, cmd_from):
     assert util.check_duplicate_arguments(
-        cmd_from, args, ALLOWED_DUPLICATES[cmd_from], DISALLOWED_ALIASES[cmd_from]
+        magic_execute, cmd_from, args, ALLOWED_DUPLICATES[cmd_from]
     )

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -150,7 +150,7 @@ def test_is_sqlalchemy_error(string, substrings, expected):
 
 
 @pytest.mark.parametrize(
-    "cmd_from, args, aliases",
+    "args, aliases",
     [
         # for creator/c
         (


### PR DESCRIPTION
## Describe your changes

1. Created a guard `check_duplicate_arguments` in `src/sql/util.py`.
2. Used the guard to check for duplicates when parsing in `SQLCommand`, `SQLPlotCommand` and `SQLCmdMagic` classes.
3. Created tests for `check_duplicate_arguments`.
4. Added tests to `test_magic_args` for the improved implementation.
5. Implemented logic to prevent aliases of arguments being used with them unless forbidden.

## Issue number

Closes #806 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--908.org.readthedocs.build/en/908/

<!-- readthedocs-preview jupysql end -->