### PR TITLE
901 jupysql + duckdb breaks if passing `:NUMBER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Fix] Remove force deleted snippets from dependent snippet's `with` (#717)
 * [Fix] Comments added in SQL query to be stripped before saved as snippet (#886)
+* [Fix] Fixed bug passing :NUMBER while string slicing in query (#901)
 
 ## 0.10.2 (2023-09-22)
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -254,7 +254,7 @@ def escape_string_literals_with_colon_prefix(query):
 
 def escape_string_slicing_notation(query):
     """
-    Given a query, replaces all occurences of 'example'[x:y] with 'example'[x\:y].
+    Given a query, replaces all occurrences of 'example'[x:y] with 'example'[x\:y].
     Escaping the colon using \ ensures correct string slicing behavior rather
     than being interpreted as a bind parameter.
 
@@ -281,7 +281,7 @@ def find_named_parameters(input_string):
     identifier_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
 
     # Define the regular expression pattern for matching :variable format
-    variable_pattern = r'(?<!["\']\[)\:(' + identifier_pattern + ")"
+    variable_pattern = r'(?<!["\'])\:(' + identifier_pattern + ")"
 
     # Use findall to extract all matches of :variable from the input string
     matches = re.findall(variable_pattern, input_string)

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -238,9 +238,15 @@ def escape_string_literals_with_colon_prefix(query):
     # Define the regular expression pattern for matching ':variable' format
     single_quoted_variable_pattern = r"(?<!\\)':(" + identifier_pattern + r")(?<!\\)\'"
 
+    # Define the regular expression pattern for matching [x:y]
+    index_variable_pattern = r'(?<!\\):(' + r"\b[a-zA-Z0-9_]*\b" + r')(?<!\\)\]'
+
     # Replace ":variable" and ':variable' with "\:variable"
     query_quoted = re.sub(double_quoted_variable_pattern, r'"\\:\1"', query)
     query_quoted = re.sub(single_quoted_variable_pattern, r"'\\:\1'", query_quoted)
+
+    # Replace [x:y] with [x\:y]
+    query_quoted = re.sub(index_variable_pattern, r"\\:\1]", query_quoted)
 
     double_found = re.findall(double_quoted_variable_pattern, query)
     single_found = re.findall(single_quoted_variable_pattern, query)
@@ -253,7 +259,7 @@ def find_named_parameters(input_string):
     identifier_pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
 
     # Define the regular expression pattern for matching :variable format
-    variable_pattern = r'(?<!["\'])\:(' + identifier_pattern + ")"
+    variable_pattern = r'(?<!["\']\[)\:(' + identifier_pattern + ")"
 
     # Use findall to extract all matches of :variable from the input string
     matches = re.findall(variable_pattern, input_string)

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -246,7 +246,7 @@ def escape_string_literals_with_colon_prefix(query):
     double_found = re.findall(double_quoted_variable_pattern, query)
     single_found = re.findall(single_quoted_variable_pattern, query)
 
-    # Escape occurences of : for string slicing
+    # Escape occurrences of : for string slicing
     query_quoted, _ = escape_string_slicing_notation(query_quoted)
 
     return query_quoted, double_found + single_found

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -428,6 +428,37 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
 
 
 @pytest.mark.parametrize(
+    "query_jupysql, expected_duckdb",
+    [
+        (
+            "select 'hello'[:2]",
+            "he",
+        ),
+        (
+            "select 'hello'[2:]",
+            "ello",
+        ),
+        (
+            "select 'hello'[2:4]",
+            "ell",
+        ),
+        (
+            "select 'hello'[:-1]",
+            "hell",
+        ),
+    ],
+)
+def test_slicing_jupysql_matches_duckdb_expected(
+    ip_empty, query_jupysql, expected_duckdb
+):
+    ip_empty.run_cell("%load_ext sql")
+    ip_empty.run_cell("%sql duckdb://")
+    raw_result = ip_empty.run_line_magic("sql", query_jupysql)
+    result_jupysql = list(raw_result.dict().values())[0][0]
+    assert result_jupysql == expected_duckdb
+
+
+@pytest.mark.parametrize(
     "query, expected_escaped, expected_found",
     [
         (

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -472,6 +472,5 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
 )
 def test_escape_string_slicing_notation(query, expected_escaped, expected_found):
     escaped, found = escape_string_slicing_notation(query)
-    print(escaped, found)
     assert escaped == expected_escaped
     assert found == expected_found


### PR DESCRIPTION
## Describe your changes
- Fixed bug where jupysql + duckdb breaks when passing :NUMBER in string slicing notation
- Added function `escape_string_slicing_notation(query)` which escapes occurrences of :NUMBER 
e.g. 'hello'[:2] --> 'hello'[\:2]

## Issue number

Closes #901 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--910.org.readthedocs.build/en/910/

<!-- readthedocs-preview jupysql end -->