### PR TITLE
Fixed typo in docs/integration/clickhouse

### DIFF
--- a/doc/integrations/clickhouse.ipynb
+++ b/doc/integrations/clickhouse.ipynb
@@ -249,7 +249,7 @@
    "source": [
     "Now, we'll load 1.4 million rows into our table.\n",
     "\n",
-    "If you're using the Docker container, you can execute the followig in a terminal to start a bash session:\n",
+    "If you're using the Docker container, you can execute the following in a terminal to start a bash session:\n",
     "\n",
     "```sh\n",
     "docker exec -it clickhouse bash\n",


### PR DESCRIPTION
## Describe your changes
Typo fix: followig -> following

## Issue number

Closes #909 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)


<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--916.org.readthedocs.build/en/916/

<!-- readthedocs-preview jupysql end -->