### PR TITLE
919 DuckDB Native uncaught CatalogException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * [Fix] Fixed bug that showed wrong error when querying snippet with invalid function (#902)
 * [Fix] Disabled CTE generation when snippets are detected in a non-SELECT type query. (#651, #652)
 * [Fix] Fix empty result in certain duckdb `SELECT` and `SUMMARIZE` queries with leading comments (#892)
-* [Fix] Fixed bug that allowed uncaught CatalogException with invalid queries in DuckDB native (#919)
 
 ## 0.10.2 (2023-09-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [Fix] Fixed bug that showed wrong error when querying snippet with invalid function (#902)
 * [Fix] Disabled CTE generation when snippets are detected in a non-SELECT type query. (#651, #652)
 * [Fix] Fix empty result in certain duckdb `SELECT` and `SUMMARIZE` queries with leading comments (#892)
+* [Fix] Fixed bug that allowed uncaught CatalogException with invalid queries in DuckDB native (#919)
 
 ## 0.10.2 (2023-09-22)
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -396,6 +396,7 @@ def is_non_sqlalchemy_error(error):
     """Function to check if error is a specific non-SQLAlchemy error"""
     specific_db_errors = [
         "duckdb.CatalogException",
+        "Catalog Error",
         "Parser Error",
         "pyodbc.ProgrammingError",
     ]

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -1310,104 +1310,102 @@ SELECT * FROM {__TABLE_NAME__};
             ],
             "RuntimeError",
         ),
-        # (
-        #     "ip_with_MSSQL",
-        #     "mysnippet",
-        #     [
-        #         "not_a_function' is not a recognized built-in function name",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # pytest.param(
-        #     "ip_with_MSSQL",
-        #     "mysnip",
-        #     [
-        #         "If using snippets, you may pass the --with argument explicitly.",
-        #     ],
-        #     "RuntimeError",
-        #     marks=pytest.mark.xfail(
-        #         reason="MSSQL prioritizes function error over table error"
-        #     ),
-        # ),
-        # (
-        #     "ip_with_Snowflake",
-        #     "mysnippet",
-        #     [
-        #         "FUNCTION not_a_function does not exist",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_Snowflake",
-        #     "mysnip",
-        #     [
-        #         "If using snippets, you may pass the --with argument explicitly.",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_oracle",
-        #     "mysnippet",
-        #     [
-        #         '"NOT_A_FUNCTION": invalid identifier',
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_oracle",
-        #     "mysnip",
-        #     [
-        #         "table or view does not exist",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_clickhouse",
-        #     "mysnippet",
-        #     [
-        #         "FUNCTION not_a_function does not exist",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_clickhouse",
-        #     "mysnip",
-        #     [
-        #         "If using snippets, you may pass the --with argument explicitly.",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_redshift",
-        #     "mysnippet",
-        #     [
-        #         "FUNCTION not_a_function does not exist",
-        #     ],
-        #     "RuntimeError",
-        # ),
-        # (
-        #     "ip_with_redshift",
-        #     "mysnip",
-        #     [
-        #         "If using snippets, you may pass the --with argument explicitly.",
-        #     ],
-        #     "RuntimeError",
-        # ),
+        (
+            "ip_with_MSSQL",
+            "mysnippet",
+            [
+                "not_a_function' is not a recognized built-in function name",
+            ],
+            "RuntimeError",
+        ),
         pytest.param(
+            "ip_with_MSSQL",
+            "mysnip",
+            [
+                "If using snippets, you may pass the --with argument explicitly.",
+            ],
+            "RuntimeError",
+            marks=pytest.mark.xfail(
+                reason="MSSQL prioritizes function error over table error"
+            ),
+        ),
+        (
+            "ip_with_Snowflake",
+            "mysnippet",
+            [
+                "FUNCTION not_a_function does not exist",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_Snowflake",
+            "mysnip",
+            [
+                "If using snippets, you may pass the --with argument explicitly.",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_oracle",
+            "mysnippet",
+            [
+                '"NOT_A_FUNCTION": invalid identifier',
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_oracle",
+            "mysnip",
+            [
+                "table or view does not exist",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_clickhouse",
+            "mysnippet",
+            [
+                "FUNCTION not_a_function does not exist",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_clickhouse",
+            "mysnip",
+            [
+                "If using snippets, you may pass the --with argument explicitly.",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_redshift",
+            "mysnippet",
+            [
+                "FUNCTION not_a_function does not exist",
+            ],
+            "RuntimeError",
+        ),
+        (
+            "ip_with_redshift",
+            "mysnip",
+            [
+                "If using snippets, you may pass the --with argument explicitly.",
+            ],
+            "RuntimeError",
+        ),
+        (
             "ip_with_duckDB_native",
             "mysnippet",
             [
                 "Scalar Function with name not_a_function does not exist!",
             ],
             "RuntimeError",
-            marks=pytest.mark.xfail(reason="Issue with catching Catalog Exception"),
         ),
-        pytest.param(
+        (
             "ip_with_duckDB_native",
             "mysnip",
-            ["There is no table with name 'mysnip'"],
+            ["Table with name mysnip does not exist!"],
             "RuntimeError",
-            marks=pytest.mark.xfail(reason="Issue with catching Catalog Exception"),
         ),
     ],
     ids=[
@@ -1417,16 +1415,16 @@ SELECT * FROM {__TABLE_NAME__};
         "with-typo-mySQL",
         "no-typo-mariaDB",
         "with-typo-mariaDB",
-        # "no-typo-MSSQL",
-        # "with-typo-MSSQL",
-        # "no-typo-Snowflake",
-        # "with-typo-Snowflake",
-        # "no-typo-oracle",
-        # "with-typo-oracle",
-        # "no-typo-clickhouse",
-        # "with-typo-clickhouse",
-        # "no-typo-redshift",
-        # "with-typo-redshift",
+        "no-typo-MSSQL",
+        "with-typo-MSSQL",
+        "no-typo-Snowflake",
+        "with-typo-Snowflake",
+        "no-typo-oracle",
+        "with-typo-oracle",
+        "no-typo-clickhouse",
+        "with-typo-clickhouse",
+        "no-typo-redshift",
+        "with-typo-redshift",
         "no-typo-duckDB-native",
         "with-typo-duckDB-native",
     ],

--- a/src/tests/integration/test_generic_db_operations.py
+++ b/src/tests/integration/test_generic_db_operations.py
@@ -1310,89 +1310,89 @@ SELECT * FROM {__TABLE_NAME__};
             ],
             "RuntimeError",
         ),
-        (
-            "ip_with_MSSQL",
-            "mysnippet",
-            [
-                "not_a_function' is not a recognized built-in function name",
-            ],
-            "RuntimeError",
-        ),
-        pytest.param(
-            "ip_with_MSSQL",
-            "mysnip",
-            [
-                "If using snippets, you may pass the --with argument explicitly.",
-            ],
-            "RuntimeError",
-            marks=pytest.mark.xfail(
-                reason="MSSQL prioritizes function error over table error"
-            ),
-        ),
-        (
-            "ip_with_Snowflake",
-            "mysnippet",
-            [
-                "FUNCTION not_a_function does not exist",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_Snowflake",
-            "mysnip",
-            [
-                "If using snippets, you may pass the --with argument explicitly.",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_oracle",
-            "mysnippet",
-            [
-                '"NOT_A_FUNCTION": invalid identifier',
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_oracle",
-            "mysnip",
-            [
-                "table or view does not exist",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_clickhouse",
-            "mysnippet",
-            [
-                "FUNCTION not_a_function does not exist",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_clickhouse",
-            "mysnip",
-            [
-                "If using snippets, you may pass the --with argument explicitly.",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_redshift",
-            "mysnippet",
-            [
-                "FUNCTION not_a_function does not exist",
-            ],
-            "RuntimeError",
-        ),
-        (
-            "ip_with_redshift",
-            "mysnip",
-            [
-                "If using snippets, you may pass the --with argument explicitly.",
-            ],
-            "RuntimeError",
-        ),
+        # (
+        #     "ip_with_MSSQL",
+        #     "mysnippet",
+        #     [
+        #         "not_a_function' is not a recognized built-in function name",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # pytest.param(
+        #     "ip_with_MSSQL",
+        #     "mysnip",
+        #     [
+        #         "If using snippets, you may pass the --with argument explicitly.",
+        #     ],
+        #     "RuntimeError",
+        #     marks=pytest.mark.xfail(
+        #         reason="MSSQL prioritizes function error over table error"
+        #     ),
+        # ),
+        # (
+        #     "ip_with_Snowflake",
+        #     "mysnippet",
+        #     [
+        #         "FUNCTION not_a_function does not exist",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_Snowflake",
+        #     "mysnip",
+        #     [
+        #         "If using snippets, you may pass the --with argument explicitly.",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_oracle",
+        #     "mysnippet",
+        #     [
+        #         '"NOT_A_FUNCTION": invalid identifier',
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_oracle",
+        #     "mysnip",
+        #     [
+        #         "table or view does not exist",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_clickhouse",
+        #     "mysnippet",
+        #     [
+        #         "FUNCTION not_a_function does not exist",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_clickhouse",
+        #     "mysnip",
+        #     [
+        #         "If using snippets, you may pass the --with argument explicitly.",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_redshift",
+        #     "mysnippet",
+        #     [
+        #         "FUNCTION not_a_function does not exist",
+        #     ],
+        #     "RuntimeError",
+        # ),
+        # (
+        #     "ip_with_redshift",
+        #     "mysnip",
+        #     [
+        #         "If using snippets, you may pass the --with argument explicitly.",
+        #     ],
+        #     "RuntimeError",
+        # ),
         pytest.param(
             "ip_with_duckDB_native",
             "mysnippet",
@@ -1417,16 +1417,16 @@ SELECT * FROM {__TABLE_NAME__};
         "with-typo-mySQL",
         "no-typo-mariaDB",
         "with-typo-mariaDB",
-        "no-typo-MSSQL",
-        "with-typo-MSSQL",
-        "no-typo-Snowflake",
-        "with-typo-Snowflake",
-        "no-typo-oracle",
-        "with-typo-oracle",
-        "no-typo-clickhouse",
-        "with-typo-clickhouse",
-        "no-typo-redshift",
-        "with-typo-redshift",
+        # "no-typo-MSSQL",
+        # "with-typo-MSSQL",
+        # "no-typo-Snowflake",
+        # "with-typo-Snowflake",
+        # "no-typo-oracle",
+        # "with-typo-oracle",
+        # "no-typo-clickhouse",
+        # "with-typo-clickhouse",
+        # "no-typo-redshift",
+        # "with-typo-redshift",
         "no-typo-duckDB-native",
         "with-typo-duckDB-native",
     ],

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2129,7 +2129,7 @@ def test_comments_in_duckdb_select_summarize(ip_empty, cell, expected_output):
 def test_query_snippet_invalid_function_error_message(
     ip, setup, save_snippet, query_with_error, error_msgs, error_type
 ):
-    # Set up snippet
+    # Set up snippet.
     ip.run_cell(setup)
     ip.run_cell(save_snippet)
 


### PR DESCRIPTION
## Describe your changes
- When running integration tests for https://github.com/ploomber/jupysql/pull/912 I noticed that querying a snippet using an invalid function or invalid snippet name on a DuckDB native connection results in an uncaught CatalogException.
- Edited `util.py` to catch the phrase "Catalog Error" as a specific non-SQLAlchemy error
- Removed xfail from duckdb_native test cases in `test_generic_db_operations.py`::test_query_snippet_invalid_function_error_message

## Issue number

Closes #919 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--920.org.readthedocs.build/en/920/

<!-- readthedocs-preview jupysql end -->