### PR TITLE
[Fix 879] Fixed queries with leading parentheses not showing expected control flow behavior (used to break `is_cte` logic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.10.5dev
+* [Fix] Fix queries with leading parentheses not showing expected control flow behavior (used to break `is_cte` logic) (#879)
 
 ## 0.10.4 (2023-11-28)
 
@@ -32,8 +33,6 @@
 * [Fix] Fix empty result in certain duckdb `SELECT` and `SUMMARIZE` queries with leading comments (#892)
 * [Fix] Fix incorrect conversion to Pandas/Polars dataframe for PIVOT statement results and InvalidInputException in PIVOT subqueries (#917)
 * [Doc] Added `run_statements` to the Python API docs (#922)
-* [Fix] Fix queries with leading parentheses not showing expected control flow behavior (used to break `is_cte` logic) (#879)
->>>>>>> a833bb3 (added to changelog)
 
 ## 0.10.2 (2023-09-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@
 * [Fix] Fix empty result in certain duckdb `SELECT` and `SUMMARIZE` queries with leading comments ([#892](https://github.com/ploomber/jupysql/issues/892))
 * [Fix] Fix incorrect conversion to Pandas/Polars dataframe for PIVOT statement results and InvalidInputException in PIVOT subqueries ([#917](https://github.com/ploomber/jupysql/issues/917))
 * [Doc] Added `run_statements` to the Python API docs ([#922](https://github.com/ploomber/jupysql/issues/922))
+* [Feature] Allow user-level config using ~/.jupysql/config (#880)
+* [Fix] Remove force deleted snippets from dependent snippet's `with` (#717)
+* [Fix] Comments added in SQL query to be stripped before saved as snippet (#886)
+* [Fix] Fixed bug passing :NUMBER while string slicing in query (#901)
+* [Fix] Fixed bug that showed wrong error when querying snippet with invalid function (#902)
+* [Fix] Disabled CTE generation when snippets are detected in a non-SELECT type query. (#651, #652)
+* [Fix] Fix empty result in certain duckdb `SELECT` and `SUMMARIZE` queries with leading comments (#892)
+* [Fix] Fix incorrect conversion to Pandas/Polars dataframe for PIVOT statement results and InvalidInputException in PIVOT subqueries (#917)
+* [Doc] Added `run_statements` to the Python API docs (#922)
+* [Fix] Fix queries with leading parentheses not showing expected control flow behavior (used to break `is_cte` logic) (#879)
+>>>>>>> a833bb3 (added to changelog)
 
 ## 0.10.2 (2023-09-22)
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -139,17 +139,17 @@ class SQLCommand:
 
         Example
         -------
-            (WITH my_penguins AS (
-                SELECT * FROM penguins.csv
-            )
-            SELECT * FROM my_penguins)
+        >>> strip_excess_parentheses(\"\"\"(WITH my_penguins AS (
+        ...    SELECT * FROM penguins.csv
+        ...)
+        ...SELECT * FROM my_penguins)\"\"\")
+        WITH my_penguins AS (
+            SELECT * FROM penguins.csv
+        )
+        SELECT * FROM my_penguins
 
-            becomes
-
-            WITH my_penguins AS (
-                SELECT * FROM penguins.csv
-            )
-            SELECT * FROM my_penguins
+        The method takes in a string and removes any excess
+        leading and lagging parentheses.
         """
         rendered_sql_command = rendered_sql_command.strip()
 

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -137,18 +137,19 @@ class SQLCommand:
         """
         Removes any leading parentheses from the sql_command_string
 
-        Examples::
-            (WITH my_penguins as (
-                select * from penguins.csv
+        Example
+        -------
+            (WITH my_penguins AS (
+                SELECT * FROM penguins.csv
             )
-            select * from my_penguins)
+            SELECT * FROM my_penguins)
 
             becomes
 
-            WITH my_penguins as (
-                select * from penguins.csv
+            WITH my_penguins AS (
+                SELECT * FROM penguins.csv
             )
-            select * from my_penguins
+            SELECT * FROM my_penguins
         """
         rendered_sql_command = rendered_sql_command.strip()
 
@@ -160,8 +161,13 @@ class SQLCommand:
                         parentheses_string.append(letter)
                 parentheses_string = "".join(parentheses_string)
 
-                if is_valid_parentheses(parentheses_string) and len(parentheses_string) >= 2:
-                    if len(parentheses_string) == 2 or is_valid_parentheses(parentheses_string[1:-1]):
+                if (
+                    is_valid_parentheses(parentheses_string)
+                    and len(parentheses_string) >= 2
+                ):
+                    if len(parentheses_string) == 2 or is_valid_parentheses(
+                        parentheses_string[1:-1]
+                    ):
                         rendered_sql_command = rendered_sql_command[1:-1]
 
                 return rendered_sql_command

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -135,7 +135,19 @@ class SQLCommand:
 
     def strip_excess_parentheses(self, rendered_sql_command):
         """
-        Removes any leading parentheses from the sql_command_string
+        Removes any leading parentheses from the sql_command_string.
+
+        Note
+        ----
+        The function removes the first and last character only if they are
+        parentheses and the remaining opening parentheses have a corresponding
+        valiod closing parentheses.
+
+        This does not work on queries that have a opening parentheses as their
+        first character but do not have the corresponding closing parentheses
+        as their last character (eg. (subquery) UNION (subquery)). It also
+        assumes that the user uses only a singular wrapping parentheses on the
+        entire query and not more than that.
 
         Example
         -------

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -130,13 +130,14 @@ class SQLCommand:
 
     def _var_expand(self, sql, user_ns):
         template_render = Template(sql).render(user_ns)
-        template_render = self.remove_leading_parentheses(template_render)
+        template_render = self.strip_excess_parentheses(template_render)
         return template_render
 
-    def remove_leading_parentheses(self, rendered_sql_command):
+    def strip_excess_parentheses(self, rendered_sql_command):
         """
         Removes any leading parentheses from the sql_command_string
-        Example:
+
+        Examples::
             (WITH my_penguins as (
                 select * from penguins.csv
             )
@@ -150,23 +151,20 @@ class SQLCommand:
             select * from my_penguins
         """
         rendered_sql_command = rendered_sql_command.strip()
-        count = 0
 
         if len(rendered_sql_command) > 1:
             if "(" == rendered_sql_command[0] and ")" == rendered_sql_command[-1]:
-                parentheses_string = ""
+                parentheses_string = []
                 for letter in rendered_sql_command:
-                    if letter in ["(", ")"]:
-                        parentheses_string += letter
+                    if letter == "(" or letter == ")":
+                        parentheses_string.append(letter)
+                parentheses_string = "".join(parentheses_string)
 
-                while is_valid_parentheses(parentheses_string):
-                    if len(parentheses_string) >= 2:
-                        parentheses_string = parentheses_string[1:-2]
-                        count += 1
-                    else:
-                        break
+                if is_valid_parentheses(parentheses_string) and len(parentheses_string) >= 2:
+                    if len(parentheses_string) == 2 or is_valid_parentheses(parentheses_string[1:-1]):
+                        rendered_sql_command = rendered_sql_command[1:-1]
 
-                return rendered_sql_command[count:-(count)]
+                return rendered_sql_command
         return rendered_sql_command
 
     def __repr__(self) -> str:

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -7,6 +7,7 @@ from sql import parse, exceptions
 from sql.store import store
 from sql.connection import ConnectionManager, is_pep249_compliant
 from sql.util import validate_nonidentifier_connection
+from sql.parse import is_valid_parentheses
 
 
 class SQLPlotCommand:
@@ -128,7 +129,45 @@ class SQLCommand:
         return self.parsed["return_result_var"]
 
     def _var_expand(self, sql, user_ns):
-        return Template(sql).render(user_ns)
+        template_render = Template(sql).render(user_ns)
+        template_render = self.remove_leading_parentheses(template_render)
+        return template_render
+
+    def remove_leading_parentheses(self, rendered_sql_command):
+        """
+        Removes any leading parentheses from the sql_command_string
+        Example:
+            (WITH my_penguins as (
+                select * from penguins.csv
+            )
+            select * from my_penguins)
+
+            becomes
+
+            WITH my_penguins as (
+                select * from penguins.csv
+            )
+            select * from my_penguins
+        """
+        rendered_sql_command = rendered_sql_command.strip()
+        count = 0
+
+        if len(rendered_sql_command) > 1:
+            if "(" == rendered_sql_command[0] and ")" == rendered_sql_command[-1]:
+                parentheses_string = ""
+                for letter in rendered_sql_command:
+                    if letter in ["(", ")"]:
+                        parentheses_string += letter
+
+                while is_valid_parentheses(parentheses_string):
+                    if len(parentheses_string) >= 2:
+                        parentheses_string = parentheses_string[1:-2]
+                        count += 1
+                    else:
+                        break
+
+                return rendered_sql_command[count:-(count)]
+        return rendered_sql_command
 
     def __repr__(self) -> str:
         return (

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -365,7 +365,7 @@ def find_named_parameters(input_string):
 
 
 def is_valid_parentheses(input_string: str) -> bool:
-    if len(input_string) < 2:
+    if len(input_string) < 2 or len(input_string) % 2 != 0:
         return False
 
     open_parentheses = "("

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -362,3 +362,26 @@ def find_named_parameters(input_string):
     matches = re.findall(variable_pattern, input_string)
 
     return matches
+
+
+def is_valid_parentheses(input_string: str) -> bool:
+    if len(input_string) < 2:
+        return False
+
+    open_parentheses = "("
+
+    stack = []
+
+    for parentheses in input_string:
+        if parentheses == open_parentheses:
+            stack.append(parentheses)
+        else:
+            if len(stack) > 0:
+                stack.pop()
+            else:
+                return False
+
+    if len(stack) > 0:
+        return False
+
+    return True

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -374,6 +374,7 @@ def is_valid_parentheses(input_string: str) -> bool:
     ----------
     input_string: str
         A string of parentheses (should include only '(' and ')')
+
     Returns
     -------
     bool:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -365,6 +365,20 @@ def find_named_parameters(input_string):
 
 
 def is_valid_parentheses(input_string: str) -> bool:
+    """
+    Finds if the input_string is a valid parentheses. A valid parentheses can
+    be defined as a string where every opening parentheses has a corresponding
+    closing parentheses.
+
+    Parameters
+    ----------
+    input_string: str
+        A string of parentheses (should include only '(' and ')')
+    Returns
+    -------
+    bool:
+        True if the string is a valid parentheses, False otherwise
+    """
     if len(input_string) < 2 or len(input_string) % 2 != 0:
         return False
 

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -48,10 +48,12 @@ class SQLStore(MutableMapping):
             matches = difflib.get_close_matches(key, self._data)
             error = f'"{key}" is not a valid snippet identifier.'
             if matches:
-                raise exceptions.UsageError(error + f' Did you mean "{matches[0]}"?')
+                raise exceptions.UsageError(
+                    error + f' Did you mean "{matches[0]}"?')
             else:
                 valid = ", ".join(f'"{key}"' for key in self._data.keys())
-                raise exceptions.UsageError(error + f" Valid identifiers are {valid}.")
+                raise exceptions.UsageError(
+                    error + f" Valid identifiers are {valid}.")
         return self._data[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -120,13 +122,15 @@ class SQLQuery:
         ` (backtick)
         """
         with_clause_template = Template(
-            """WITH{% for name in with_ %} {{name}} AS ({{rts(saved[name]._query)}})\
-{{ "," if not loop.last }}{% endfor %}{{query}}"""
+            """WITH{% for name in with_ %} {{name}} AS (\
+{{'\n\t' + rts(saved[name]._query) + '\n'}}\
+){{ "," if not loop.last }}{% endfor %}{{'\n' + query}}"""
         )
 
         with_clause_template_backtick = Template(
-            """WITH{% for name in with_ %} `{{name}}` AS ({{rts(saved[name]._query)}})\
-{{ "," if not loop.last }}{% endfor %}{{query}}"""
+            """WITH{% for name in with_ %} `{{name}}` AS (\
+{{'\n\t' + rts(saved[name]._query) + '\n'}}\
+){{ "," if not loop.last }}{% endfor %}{{'\n' + query}}"""
         )
         is_use_backtick = (
             sql.connection.ConnectionManager.current.is_use_backtick_template()
@@ -166,7 +170,8 @@ def _get_dependencies(store, keys):
 def _get_dependencies_for_key(store, key):
     """Retrieve dependencies for a single key"""
     deps = store[key]._with_
-    deps_of_deps = _flatten([_get_dependencies_for_key(store, dep) for dep in deps])
+    deps_of_deps = _flatten(
+        [_get_dependencies_for_key(store, dep) for dep in deps])
     return deps_of_deps + deps
 
 

--- a/src/sql/store.py
+++ b/src/sql/store.py
@@ -48,12 +48,10 @@ class SQLStore(MutableMapping):
             matches = difflib.get_close_matches(key, self._data)
             error = f'"{key}" is not a valid snippet identifier.'
             if matches:
-                raise exceptions.UsageError(
-                    error + f' Did you mean "{matches[0]}"?')
+                raise exceptions.UsageError(error + f' Did you mean "{matches[0]}"?')
             else:
                 valid = ", ".join(f'"{key}"' for key in self._data.keys())
-                raise exceptions.UsageError(
-                    error + f" Valid identifiers are {valid}.")
+                raise exceptions.UsageError(error + f" Valid identifiers are {valid}.")
         return self._data[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -170,8 +168,7 @@ def _get_dependencies(store, keys):
 def _get_dependencies_for_key(store, key):
     """Retrieve dependencies for a single key"""
     deps = store[key]._with_
-    deps_of_deps = _flatten(
-        [_get_dependencies_for_key(store, dep) for dep in deps])
+    deps_of_deps = _flatten([_get_dependencies_for_key(store, dep) for dep in deps])
     return deps_of_deps + deps
 
 

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -245,7 +245,7 @@ def test_with_contains_dash_show_warning_message(ip, sql_magic, capsys):
     assert "Using hyphens (-) in save argument isn't allowed" in str(error.value)
 
 
-def test_remove_leading_parentheses(ip, sql_magic):
+def test_strip_excess_parentheses(ip, sql_magic):
     cmd = SQLCommand(
         sql_magic,
         ip.user_ns,

--- a/src/tests/test_command.py
+++ b/src/tests/test_command.py
@@ -111,11 +111,11 @@ def test_parsed_sql_when_using_with(ip, sql_magic):
     )
 
     sql = (
-        "WITH `author_one` AS (\n\n        SELECT * FROM author LIMIT "
+        "WITH `author_one` AS (\n\tSELECT * FROM author LIMIT "
         "1\n)\nSELECT * FROM author_one"
     )
 
-    sql_original = "\nSELECT * FROM author_one"
+    sql_original = "SELECT * FROM author_one"
 
     assert cmd.parsed == {
         "connection": "",
@@ -138,13 +138,13 @@ def test_parsed_sql_when_using_file(ip, sql_magic, tmp_empty):
         "connection": "",
         "result_var": None,
         "return_result_var": False,
-        "sql": "SELECT * FROM author\n",
-        "sql_original": "SELECT * FROM author\n",
+        "sql": "SELECT * FROM author",
+        "sql_original": "SELECT * FROM author",
     }
 
     assert cmd.connection == ""
-    assert cmd.sql == "SELECT * FROM author\n"
-    assert cmd.sql_original == "SELECT * FROM author\n"
+    assert cmd.sql == "SELECT * FROM author"
+    assert cmd.sql_original == "SELECT * FROM author"
 
 
 def test_args(ip, sql_magic):
@@ -192,7 +192,7 @@ def test_parse_sql_when_passing_engine(ip, sql_magic, tmp_empty, line):
 
     cmd = SQLCommand(sql_magic, ip.user_ns, line, cell="SELECT * FROM author")
 
-    sql_expected = "\nSELECT * FROM author"
+    sql_expected = "SELECT * FROM author"
 
     assert cmd.parsed == {
         "connection": engine,
@@ -217,7 +217,7 @@ def test_variable_substitution_double_curly_cell_magic(ip, sql_magic):
         cell="GRANT CONNECT ON DATABASE postgres TO {{username}};",
     )
 
-    assert cmd.parsed["sql"] == "\nGRANT CONNECT ON DATABASE postgres TO some-user;"
+    assert cmd.parsed["sql"] == "GRANT CONNECT ON DATABASE postgres TO some-user;"
 
 
 def test_variable_substitution_double_curly_line_magic(ip, sql_magic):
@@ -243,3 +243,17 @@ def test_with_contains_dash_show_warning_message(ip, sql_magic, capsys):
 
     assert error.value.error_type == "UsageError"
     assert "Using hyphens (-) in save argument isn't allowed" in str(error.value)
+
+
+def test_remove_leading_parentheses(ip, sql_magic):
+    cmd = SQLCommand(
+        sql_magic,
+        ip.user_ns,
+        line="(WITH langs as (select * from languages) select * from langs)",
+        cell="",
+    )
+
+    assert (
+        cmd.parsed["sql"]
+        == "WITH langs as (select * from languages) select * from langs"
+    )

--- a/src/tests/test_magic_cte.py
+++ b/src/tests/test_magic_cte.py
@@ -30,9 +30,9 @@ SELECT * FROM positive_y;
 
     assert cell_execution.success
     assert cell_final_query.result == (
-        "WITH `positive_x` AS (\nSELECT * "
-        "FROM number_table WHERE x > 0), `positive_y` AS (\nSELECT * "
-        "FROM number_table WHERE y > 0)\nSELECT * FROM positive_x\n"
+        "WITH `positive_x` AS (\n\tSELECT * "
+        "FROM number_table WHERE x > 0\n), `positive_y` AS (\n\tSELECT * "
+        "FROM number_table WHERE y > 0\n)\nSELECT * FROM positive_x\n"
         "UNION\nSELECT * FROM positive_y;"
     )
 
@@ -52,8 +52,8 @@ def test_infer_dependencies(ip, capsys):
     out, _ = capsys.readouterr()
     result = ip.run_cell("%sqlcmd snippets final").result
     expected = (
-        "WITH `author_sub` AS (\nSELECT last_name FROM author "
-        "WHERE year_of_death > 1900)\nSELECT last_name FROM author_sub;"
+        "WITH `author_sub` AS (\n\tSELECT last_name FROM author "
+        "WHERE year_of_death > 1900\n)\nSELECT last_name FROM author_sub;"
     )
 
     assert result == expected
@@ -199,8 +199,8 @@ SELECT * FROM positive_x
     )
     cell_final_query = ip.run_cell("%sqlcmd snippets final").result
     assert (
-        cell_final_query == "WITH `positive_x` AS (\nSELECT * FROM number_table WHERE "
-        "x > 0)\nSELECT * FROM positive_x"
+        cell_final_query == "WITH `positive_x` AS (\n\tSELECT * FROM number_table WHERE"
+        " x > 0\n)\nSELECT * FROM positive_x"
     )
 
 
@@ -218,8 +218,8 @@ SELECT * FROM positive_x
     )
     cell_final_query = ip.run_cell("%sqlcmd snippets final").result
     assert (
-        cell_final_query == "WITH `positive_x` AS (\nSELECT * FROM "
-        "number_table\nWHERE x > 0)\nSELECT * FROM positive_x"
+        cell_final_query == "WITH `positive_x` AS (\n\tSELECT * FROM "
+        "number_table\nWHERE x > 0\n)\nSELECT * FROM positive_x"
     )
 
 
@@ -251,8 +251,8 @@ WHERE positive_x.x = positive_x_another.x
     cell_final_query = ip.run_cell("%sqlcmd snippets final").result
     assert (
         cell_final_query
-        == "WITH `positive_x` AS (\n\nSELECT * FROM number_table WHERE x > 0), "
-        "`positive_x_another` AS (\n\nSELECT * FROM number_table WHERE x > 0)\n"
+        == "WITH `positive_x` AS (\n\tSELECT * FROM number_table WHERE x > 0\n), "
+        "`positive_x_another` AS (\n\tSELECT * FROM number_table WHERE x > 0\n)\n"
         "SELECT * FROM positive_x, positive_x_another\nWHERE "
         "positive_x.x = positive_x_another.x"
     )
@@ -276,8 +276,8 @@ SELECT * FROM positive_x
     )
     cell_final_query = ip.run_cell("%sqlcmd snippets final").result
     assert (
-        cell_final_query == "WITH `positive_x` AS (\n\nSELECT * FROM number_table\n\n"
-        "WHERE x > 0)\nSELECT * FROM positive_x"
+        cell_final_query == "WITH `positive_x` AS (\n\tSELECT * FROM number_table\n\n"
+        "WHERE x > 0\n)\nSELECT * FROM positive_x"
     )
 
 
@@ -300,6 +300,6 @@ SELECT * FROM positive_x
     )
     cell_final_query = ip.run_cell("%sqlcmd snippets final").result
     assert (
-        cell_final_query == "WITH `positive_x` AS (\n\nSELECT * FROM number_table\n\n"
-        "WHERE x > 0)\nSELECT * FROM positive_x"
+        cell_final_query == "WITH `positive_x` AS (\n\tSELECT * FROM number_table\n\n"
+        "WHERE x > 0\n)\nSELECT * FROM positive_x"
     )

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -8,6 +8,7 @@ from IPython.core.error import UsageError
 from sql.parse import (
     connection_str_from_dsn_section,
     parse,
+    is_valid_parentheses,
     without_sql_comment,
     split_args_and_sql,
     magic_args,
@@ -916,3 +917,17 @@ def test_split_args_and_sql(line, expected_args, expected_sql):
     args_line, sql_line = split_args_and_sql(line)
     assert args_line == expected_args
     assert sql_line == expected_sql
+
+
+@pytest.mark.parametrize(
+    "input_string, expected",
+    [
+        ("((()))", True),
+        ("()()()", True),
+        ("(()", False),
+        ("(", False),
+        ("(()())", True),
+    ],
+)
+def test_is_valid_parentheses(input_string: str, expected: bool):
+    assert is_valid_parentheses(input_string) == expected

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -110,8 +110,7 @@ def test_key():
     sql_store = store.SQLStore()
 
     with pytest.raises(UsageError) as excinfo:
-        sql_store.store(
-            "first", "SELECT * FROM first WHERE x > 20", with_=["first"])
+        sql_store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
     assert "cannot appear in with_ argument" in str(excinfo.value)
 
@@ -159,8 +158,7 @@ def test_serial(with_, is_dialect_support_backtick, monkeypatch):
 
     sql_store = store.SQLStore()
     sql_store.store("first", "SELECT * FROM a WHERE x > 10")
-    sql_store.store(
-        "second", "SELECT * FROM first WHERE x > 20", with_=["first"])
+    sql_store.store("second", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
     sql_store.store(
         "third", "SELECT * FROM second WHERE x > 30", with_=["second", "first"]
@@ -211,16 +209,14 @@ def test_branch_root(is_dialect_support_backtick, monkeypatch):
 
     sql_store = store.SQLStore()
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store(
-        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
 
     sql_store.store("first_b", "SELECT * FROM b WHERE y > 10")
 
-    result = sql_store.render("SELECT * FROM third",
-                              with_=["third_a", "first_b"])
+    result = sql_store.render("SELECT * FROM third", with_=["third_a", "first_b"])
     assert (
         str(result)
         == "WITH {0}first_a{0} AS (\
@@ -268,16 +264,14 @@ def test_branch_root_reverse_final_with(is_dialect_support_backtick, monkeypatch
     sql_store = store.SQLStore()
 
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store(
-        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
 
     sql_store.store("first_b", "SELECT * FROM b WHERE y > 10")
 
-    result = sql_store.render("SELECT * FROM third",
-                              with_=["first_b", "third_a"])
+    result = sql_store.render("SELECT * FROM third", with_=["first_b", "third_a"])
     assert (
         str(result)
         == "WITH {0}first_a{0} AS (\
@@ -323,8 +317,7 @@ def test_branch(is_dialect_support_backtick, monkeypatch):
     sql_store = store.SQLStore()
 
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store(
-        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
@@ -333,8 +326,7 @@ def test_branch(is_dialect_support_backtick, monkeypatch):
         "first_b", "SELECT * FROM second_a WHERE y > 10", with_=["second_a"]
     )
 
-    result = sql_store.render("SELECT * FROM third",
-                              with_=["first_b", "third_a"])
+    result = sql_store.render("SELECT * FROM third", with_=["first_b", "third_a"])
     assert (
         str(result)
         == "WITH {0}first_a{0} AS (\
@@ -374,5 +366,4 @@ def test_del_saved_key(ip_snippets):
 def test_del_saved_key_error(ip_snippets):
     with pytest.raises(UsageError) as excinfo:
         store.del_saved_key("non_existent_key")
-    assert "No such saved snippet found : non_existent_key" in str(
-        excinfo.value)
+    assert "No such saved snippet found : non_existent_key" in str(excinfo.value)

--- a/src/tests/test_store.py
+++ b/src/tests/test_store.py
@@ -110,7 +110,8 @@ def test_key():
     sql_store = store.SQLStore()
 
     with pytest.raises(UsageError) as excinfo:
-        sql_store.store("first", "SELECT * FROM first WHERE x > 20", with_=["first"])
+        sql_store.store(
+            "first", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
     assert "cannot appear in with_ argument" in str(excinfo.value)
 
@@ -158,7 +159,8 @@ def test_serial(with_, is_dialect_support_backtick, monkeypatch):
 
     sql_store = store.SQLStore()
     sql_store.store("first", "SELECT * FROM a WHERE x > 10")
-    sql_store.store("second", "SELECT * FROM first WHERE x > 20", with_=["first"])
+    sql_store.store(
+        "second", "SELECT * FROM first WHERE x > 20", with_=["first"])
 
     sql_store.store(
         "third", "SELECT * FROM second WHERE x > 30", with_=["second", "first"]
@@ -168,9 +170,14 @@ def test_serial(with_, is_dialect_support_backtick, monkeypatch):
 
     assert (
         str(result)
-        == "WITH {0}first{0} AS (SELECT * FROM a WHERE x > 10), \
-{0}second{0} AS (SELECT * FROM first WHERE x > 20), \
-{0}third{0} AS (SELECT * FROM second WHERE x > 30)SELECT * FROM third".format(
+        == "WITH {0}first{0} AS (\
+\n\tSELECT * FROM a WHERE x > 10\
+\n), {0}second{0} AS (\
+\n\tSELECT * FROM first WHERE x > 20\
+\n), {0}third{0} AS (\
+\n\tSELECT * FROM second WHERE x > 30\
+\n)\
+\nSELECT * FROM third".format(
             identifier
         )
     )
@@ -204,20 +211,28 @@ def test_branch_root(is_dialect_support_backtick, monkeypatch):
 
     sql_store = store.SQLStore()
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store(
+        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
 
     sql_store.store("first_b", "SELECT * FROM b WHERE y > 10")
 
-    result = sql_store.render("SELECT * FROM third", with_=["third_a", "first_b"])
+    result = sql_store.render("SELECT * FROM third",
+                              with_=["third_a", "first_b"])
     assert (
         str(result)
-        == "WITH {0}first_a{0} AS (SELECT * FROM a WHERE x > 10), \
-{0}second_a{0} AS (SELECT * FROM first_a WHERE x > 20), \
-{0}third_a{0} AS (SELECT * FROM second_a WHERE x > 30), \
-{0}first_b{0} AS (SELECT * FROM b WHERE y > 10)SELECT * FROM third".format(
+        == "WITH {0}first_a{0} AS (\
+\n\tSELECT * FROM a WHERE x > 10\
+\n), {0}second_a{0} AS (\
+\n\tSELECT * FROM first_a WHERE x > 20\
+\n), {0}third_a{0} AS (\
+\n\tSELECT * FROM second_a WHERE x > 30\
+\n), {0}first_b{0} AS (\
+\n\tSELECT * FROM b WHERE y > 10\
+\n)\
+\nSELECT * FROM third".format(
             identifier
         )
     )
@@ -253,20 +268,28 @@ def test_branch_root_reverse_final_with(is_dialect_support_backtick, monkeypatch
     sql_store = store.SQLStore()
 
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store(
+        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
 
     sql_store.store("first_b", "SELECT * FROM b WHERE y > 10")
 
-    result = sql_store.render("SELECT * FROM third", with_=["first_b", "third_a"])
+    result = sql_store.render("SELECT * FROM third",
+                              with_=["first_b", "third_a"])
     assert (
         str(result)
-        == "WITH {0}first_a{0} AS (SELECT * FROM a WHERE x > 10), \
-{0}second_a{0} AS (SELECT * FROM first_a WHERE x > 20), \
-{0}first_b{0} AS (SELECT * FROM b WHERE y > 10), \
-{0}third_a{0} AS (SELECT * FROM second_a WHERE x > 30)SELECT * FROM third".format(
+        == "WITH {0}first_a{0} AS (\
+\n\tSELECT * FROM a WHERE x > 10\
+\n), {0}second_a{0} AS (\
+\n\tSELECT * FROM first_a WHERE x > 20\
+\n), {0}first_b{0} AS (\
+\n\tSELECT * FROM b WHERE y > 10\
+\n), {0}third_a{0} AS (\
+\n\tSELECT * FROM second_a WHERE x > 30\
+\n)\
+\nSELECT * FROM third".format(
             identifier
         )
     )
@@ -300,7 +323,8 @@ def test_branch(is_dialect_support_backtick, monkeypatch):
     sql_store = store.SQLStore()
 
     sql_store.store("first_a", "SELECT * FROM a WHERE x > 10")
-    sql_store.store("second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
+    sql_store.store(
+        "second_a", "SELECT * FROM first_a WHERE x > 20", with_=["first_a"])
     sql_store.store(
         "third_a", "SELECT * FROM second_a WHERE x > 30", with_=["second_a"]
     )
@@ -309,13 +333,20 @@ def test_branch(is_dialect_support_backtick, monkeypatch):
         "first_b", "SELECT * FROM second_a WHERE y > 10", with_=["second_a"]
     )
 
-    result = sql_store.render("SELECT * FROM third", with_=["first_b", "third_a"])
+    result = sql_store.render("SELECT * FROM third",
+                              with_=["first_b", "third_a"])
     assert (
         str(result)
-        == "WITH {0}first_a{0} AS (SELECT * FROM a WHERE x > 10), \
-{0}second_a{0} AS (SELECT * FROM first_a WHERE x > 20), \
-{0}first_b{0} AS (SELECT * FROM second_a WHERE y > 10), \
-{0}third_a{0} AS (SELECT * FROM second_a WHERE x > 30)SELECT * FROM third".format(
+        == "WITH {0}first_a{0} AS (\
+\n\tSELECT * FROM a WHERE x > 10\
+\n), {0}second_a{0} AS (\
+\n\tSELECT * FROM first_a WHERE x > 20\
+\n), {0}first_b{0} AS (\
+\n\tSELECT * FROM second_a WHERE y > 10\
+\n), {0}third_a{0} AS (\
+\n\tSELECT * FROM second_a WHERE x > 30\
+\n)\
+\nSELECT * FROM third".format(
             identifier
         )
     )
@@ -343,4 +374,5 @@ def test_del_saved_key(ip_snippets):
 def test_del_saved_key_error(ip_snippets):
     with pytest.raises(UsageError) as excinfo:
         store.del_saved_key("non_existent_key")
-    assert "No such saved snippet found : non_existent_key" in str(excinfo.value)
+    assert "No such saved snippet found : non_existent_key" in str(
+        excinfo.value)


### PR DESCRIPTION
## Describe your changes
1. Created flow to remove leading parentheses when rendering sql.
2. Created a new method `is_valid_parentheses` to be used as a helper function in rendering sql used in conjunction with `remove_leading_parentheses`.
3. Improved sql presentation after rendering using templates.

Fixed both the issues mentioned [here](https://github.com/ploomber/jupysql/issues/879#issuecomment-1754313194) by by removing all leading parentheses in the sql query itself instead of using dialect specific parentheses handling. I opted to implement removal of leading parentheses as I could not find any distinguishing use / effect of the parentheses in the different dialects.

## Issue number

Closes #879

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--934.org.readthedocs.build/en/934/

<!-- readthedocs-preview jupysql end -->