### PR TITLE
[Fix 911] Search for config in ~/.jupysql/config if pyproject.toml does not have a SqlMagic section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.10.5dev
+* [Fix] Look into ~/.jupysql/config for config if pyproject.toml does not have a SqlMagic section (#911)
 
 ## 0.10.4 (2023-11-28)
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -696,57 +696,64 @@ def get_query_type(command: str):
 def set_configs(ip, file_path):
     """Set user defined SqlMagic configuration settings"""
     sql = ip.find_cell_magic("sql").__self__
-    user_configs = util.get_user_configs(file_path)
+    success, user_configs = util.get_user_configs(file_path)
     default_configs = util.get_default_configs(sql)
     table_rows = []
-    for config, value in user_configs.items():
-        if config in default_configs.keys():
-            default_type = type(default_configs[config])
-            if isinstance(value, default_type):
-                setattr(sql, config, value)
-                table_rows.append([config, value])
-            else:
-                display.message(
-                    f"'{value}' is an invalid value for '{config}'. "
-                    f"Please use {default_type.__name__} value instead."
-                )
-        else:
-            util.find_close_match_config(config, default_configs.keys())
 
-    return table_rows
+    if success:
+        for config, value in user_configs.items():
+            if config in default_configs.keys():
+                default_type = type(default_configs[config])
+                if isinstance(value, default_type):
+                    setattr(sql, config, value)
+                    table_rows.append([config, value])
+                else:
+                    display.message(
+                        f"'{value}' is an invalid value for '{config}'. "
+                        f"Please use {default_type.__name__} value instead."
+                    )
+            else:
+                util.find_close_match_config(config, default_configs.keys())
+
+    return (success, table_rows)
 
 
 def load_SqlMagic_configs(ip):
     """Loads saved SqlMagic configs in pyproject.toml or ~/.jupysql/config"""
-    file_path = util.find_path_from_root("pyproject.toml")
-    if not file_path:
-        alternate_path = Path("~/.jupysql/config").expanduser()
-        if alternate_path.exists():
-            file_path = str(alternate_path)
-    if file_path:
-        try:
-            table_rows = set_configs(ip, file_path)
-        except Exception as e:
-            if type(e).__name__ == "TomlDecodeError":
-                display.message_warning(
-                    f"Could not load configuration file at {file_path} "
-                    "(default configuration will be used).\nPlease "
-                    f"check that it is valid TOML: {e}"
-                )
-                return
-            if type(e).__name__ == "ModuleNotFoundError":
-                display.message(
-                    "The 'toml' package isn't installed. To load settings from "
-                    "pyproject.toml or ~/.jupysql/config, install with: "
-                    "pip install toml"
-                )
-                return
-            else:
-                raise
 
-        if table_rows:
-            display.message("Settings changed:")
-            display.table(["Config", "value"], table_rows)
+    file_path = util.find_path_from_root("pyproject.toml")
+    alternate_path = Path("~/.jupysql/config").expanduser()
+    if not alternate_path.exists():
+        alternate_path = None
+
+    table_rows = []
+    success = False
+    try:
+        if file_path:
+            success, table_rows = set_configs(ip, file_path)
+        if not success and alternate_path is not None:
+            success, table_rows = set_configs(ip, alternate_path)
+    except Exception as e:
+        if type(e).__name__ == "TomlDecodeError":
+            display.message_warning(
+                f"Could not load configuration file at {file_path} "
+                "(default configuration will be used).\nPlease "
+                f"check that it is valid TOML: {e}"
+            )
+            return
+        if type(e).__name__ == "ModuleNotFoundError":
+            display.message(
+                "The 'toml' package isn't installed. To load settings from "
+                "pyproject.toml or ~/.jupysql/config, install with: "
+                "pip install toml"
+            )
+            return
+        else:
+            raise
+
+    if table_rows:
+        display.message("Settings changed:")
+        display.table(["Config", "value"], table_rows)
 
 
 def load_ipython_extension(ip):

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -736,8 +736,9 @@ def load_SqlMagic_configs(ip):
     except Exception as e:
         if type(e).__name__ == "TomlDecodeError":
             display.message_warning(
-                f"Could not load configuration file at {file_path} "
-                "(default configuration will be used).\nPlease "
+                f"Could not load configuration file at {file_path}"
+                f"{(' or ' + str(alternate_path)) if alternate_path else ''}"
+                " (default configuration will be used).\nPlease "
                 f"check that it is valid TOML: {e}"
             )
             return

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 
 import sqlparse
+import os
 
 try:
     from ipywidgets import interact
@@ -728,7 +729,7 @@ def set_configs(ip, file_path, alternate_path):
 def load_SqlMagic_configs(ip):
     """Loads saved SqlMagic configs in pyproject.toml or ~/.jupysql/config"""
 
-    file_path = util.find_path_from_root("pyproject.toml")
+    file_path = Path(os.getcwd()).joinpath("pyproject.toml")
     alternate_path = Path("~/.jupysql/config").expanduser()
 
     table_rows = []

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -700,7 +700,6 @@ def set_configs(ip, file_path, alternate_path):
     default_configs = util.get_default_configs(sql)
     table_rows = []
 
-    success = False
     if user_configs:
         for config, value in user_configs.items():
             if config in default_configs.keys():
@@ -708,7 +707,6 @@ def set_configs(ip, file_path, alternate_path):
                 if isinstance(value, default_type):
                     setattr(sql, config, value)
                     table_rows.append([config, value])
-                    success = True
                 else:
                     display.message(
                         f"'{value}' is an invalid value for '{config}'. "
@@ -716,11 +714,6 @@ def set_configs(ip, file_path, alternate_path):
                     )
             else:
                 util.find_close_match_config(config, default_configs.keys())
-        if success:
-            if loaded_from is not None:
-                display.message(f"Loading configurations from {loaded_from}.")
-            else:
-                display.message("Loading default configurations.")
 
     return table_rows
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -3,7 +3,6 @@ import re
 from pathlib import Path
 
 import sqlparse
-import os
 
 try:
     from ipywidgets import interact
@@ -729,7 +728,7 @@ def set_configs(ip, file_path, alternate_path):
 def load_SqlMagic_configs(ip):
     """Loads saved SqlMagic configs in pyproject.toml or ~/.jupysql/config"""
 
-    file_path = Path(os.getcwd()).joinpath("pyproject.toml")
+    file_path = util.find_path_from_root("pyproject.toml")
     alternate_path = Path("~/.jupysql/config").expanduser()
 
     table_rows = []

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -696,10 +696,11 @@ def get_query_type(command: str):
 def set_configs(ip, file_path, alternate_path):
     """Set user defined SqlMagic configuration settings"""
     sql = ip.find_cell_magic("sql").__self__
-    user_configs = util.get_user_configs(file_path, alternate_path)
+    user_configs, loaded_from = util.get_user_configs(file_path, alternate_path)
     default_configs = util.get_default_configs(sql)
     table_rows = []
 
+    success = False
     if user_configs:
         for config, value in user_configs.items():
             if config in default_configs.keys():
@@ -707,6 +708,7 @@ def set_configs(ip, file_path, alternate_path):
                 if isinstance(value, default_type):
                     setattr(sql, config, value)
                     table_rows.append([config, value])
+                    success = True
                 else:
                     display.message(
                         f"'{value}' is an invalid value for '{config}'. "
@@ -714,6 +716,11 @@ def set_configs(ip, file_path, alternate_path):
                     )
             else:
                 util.find_close_match_config(config, default_configs.keys())
+        if success:
+            if loaded_from is not None:
+                display.message(f"Loading configurations from {loaded_from}.")
+            else:
+                display.message("Loading default configurations.")
 
     return table_rows
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -717,7 +717,10 @@ def set_configs(ip, file_path, alternate_path):
             else:
                 util.find_close_match_config(config, default_configs.keys())
         if success:
-            display.message(f"Loading configurations from {loaded_from}")
+            if loaded_from is not None:
+                display.message(f"Loading configurations from {loaded_from}.")
+            else:
+                display.message("Loading default configurations.")
 
     return table_rows
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -696,7 +696,7 @@ def get_query_type(command: str):
 def set_configs(ip, file_path, alternate_path):
     """Set user defined SqlMagic configuration settings"""
     sql = ip.find_cell_magic("sql").__self__
-    user_configs, loaded_from = util.get_user_configs(file_path, alternate_path)
+    user_configs = util.get_user_configs(file_path, alternate_path)
     default_configs = util.get_default_configs(sql)
     table_rows = []
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -693,14 +693,14 @@ def get_query_type(command: str):
     return query_type
 
 
-def set_configs(ip, file_path):
+def set_configs(ip, file_path=None, alternate_path=None, display_message=False):
     """Set user defined SqlMagic configuration settings"""
     sql = ip.find_cell_magic("sql").__self__
-    success, user_configs = util.get_user_configs(file_path)
+    user_configs = util.get_user_configs(file_path, alternate_path, display_message)
     default_configs = util.get_default_configs(sql)
     table_rows = []
 
-    if success:
+    if user_configs:
         for config, value in user_configs.items():
             if config in default_configs.keys():
                 default_type = type(default_configs[config])
@@ -715,7 +715,7 @@ def set_configs(ip, file_path):
             else:
                 util.find_close_match_config(config, default_configs.keys())
 
-    return (success, table_rows)
+    return table_rows
 
 
 def load_SqlMagic_configs(ip):
@@ -727,12 +727,8 @@ def load_SqlMagic_configs(ip):
         alternate_path = None
 
     table_rows = []
-    success = False
     try:
-        if file_path:
-            success, table_rows = set_configs(ip, file_path)
-        if not success and alternate_path is not None:
-            success, table_rows = set_configs(ip, alternate_path)
+        table_rows = set_configs(ip, file_path, alternate_path)
     except Exception as e:
         if type(e).__name__ == "TomlDecodeError":
             display.message_warning(

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -399,7 +399,6 @@ def get_user_configs(primary_path, alternate_path):
 
         # Look for SqlMagic section in toml file
         while section_names:
-
             section_found = False
             section_to_find, sections_from_user = section_names.pop(0), data.keys()
 
@@ -411,9 +410,9 @@ def get_user_configs(primary_path, alternate_path):
                 if not close_match:
                     if display_tip:
                         display.message(
-                                f"Tip: You may define configurations in {primary_path}"
-                                f" or {alternate_path}. "
-                                )
+                            f"Tip: You may define configurations in {primary_path}"
+                            f" or {alternate_path}. "
+                        )
                         tip_displayed = True
                     break
                 else:
@@ -432,15 +431,15 @@ def get_user_configs(primary_path, alternate_path):
 
         if section_to_find == "SqlMagic" and section_found:
             display.message(
-                    f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
-                    )
+                f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
+            )
             display_tip = False
 
         if (tip_displayed or not display_tip) and not configuration_docs_displayed:
             display.message_html(
-                    f"Please review our <a href='{CONFIGURATION_DOCS_STR}'>"
-                    "configuration guideline</a>."
-                    )
+                f"Please review our <a href='{CONFIGURATION_DOCS_STR}'>"
+                "configuration guideline</a>."
+            )
             configuration_docs_displayed = True
 
         status = ""
@@ -449,9 +448,7 @@ def get_user_configs(primary_path, alternate_path):
         elif file_path == alternate_path:
             status = "Did not find user configurations in pyproject.toml"
 
-            display.message(
-                f"{status}."
-            )
+            display.message(f"{status}.")
 
     return data, None
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -436,7 +436,7 @@ def get_user_configs(primary_path, alternate_path):
             )
             configuration_docs_displayed = True
 
-        if not data and not section_found and file_path:
+        if not data and not section_found and file_path and file_path.exists():
             display.message(f"Did not find user configurations in {file_path}.")
         elif section_found and data:
             return data, file_path

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -388,7 +388,6 @@ def get_user_configs(primary_path, alternate_path):
     # Look for user configurations in pyproject.toml and ~/.jupysql/config
     # in that particular order
     for file_path in [primary_path, alternate_path]:
-
         section_to_find = None
         section_found = False
         if file_path is not None:

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -379,6 +379,8 @@ def get_user_configs(file_path):
     """
     data = load_toml(file_path)
     section_names = ["tool", "jupysql", "SqlMagic"]
+    section_to_find = ""
+
     while section_names:
         section_to_find, sections_from_user = section_names.pop(0), data.keys()
         if section_to_find not in sections_from_user:
@@ -392,7 +394,7 @@ def get_user_configs(file_path):
                     f"{MESSAGE_PREFIX}<a href='{CONFIGURATION_DOCS_STR}'>"
                     "configuration guideline</a>."
                 )
-                return {}
+                return (False, {})
             else:
                 raise exceptions.ConfigurationError(
                     f"{pretty_print(close_match)} is an invalid section "
@@ -412,7 +414,7 @@ def get_user_configs(file_path):
             )
     else:
         display.message(f"Loading configurations from {file_path}")
-    return data
+    return (True, data)
 
 
 def get_default_configs(sql):

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -378,6 +378,8 @@ def get_user_configs(primary_path, alternate_path):
     -------
     dict
         saved configuration settings
+    Path
+        the path of the file used to get user configurations
     """
     data = None
     display_tip = True  # Set to true if tip is to be displayed
@@ -438,9 +440,9 @@ def get_user_configs(primary_path, alternate_path):
         elif not data and not section_found:
             display.message(f"Did not find user configurations in {file_path}.")
         elif section_found and data:
-            return data
+            return data, file_path
 
-    return data
+    return data, None
 
 
 def get_default_configs(sql):

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -390,7 +390,7 @@ def get_user_configs(primary_path, alternate_path):
     for file_path in [primary_path, alternate_path]:
         section_to_find = None
         section_found = False
-        if file_path is not None:
+        if file_path and file_path.exists():
             data = load_toml(file_path)
             section_names = ["tool", "jupysql", "SqlMagic"]
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -393,7 +393,7 @@ def get_user_configs(primary_path, alternate_path):
             if primary_path:
                 STATUS = "Did not find user configurations in pyproject.toml"
             display.message(
-                f"{STATUS}. " f"Looking for user configurations in {alternate_path}"
+                f"{STATUS}. " f"Looking for user configurations in {alternate_path}."
             )
 
         data = load_toml(file_path)
@@ -425,17 +425,23 @@ def get_user_configs(primary_path, alternate_path):
             section_found = True
             data = data[section_to_find]
 
-        if section_to_find == "SqlMagic" and section_found and not data:
-            display.message(
-                f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
-            )
-            disable_tip = True
+        if not data:
+            if section_to_find == "SqlMagic" and section_found:
+                display.message(
+                    f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
+                )
+                disable_tip = True
 
-        if tip_displayed or disable_tip:
-            display.message_html(
-                f"Please review our <a href='{CONFIGURATION_DOCS_STR}'>"
-                "configuration guideline</a>."
-            )
+            elif file_path == alternate_path:
+                display.message(
+                    f"Did not find user configurations in {alternate_path}."
+                )
+
+            if tip_displayed or disable_tip:
+                display.message_html(
+                    f"Please review our <a href='{CONFIGURATION_DOCS_STR}'>"
+                    "configuration guideline</a>."
+                )
         elif data:
             return data, file_path
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -378,6 +378,8 @@ def get_user_configs(primary_path, alternate_path):
     -------
     dict
         saved configuration settings
+    Path
+        the path of the file used to get user configurations
     """
     data = None
     tip_displayed = False

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -387,7 +387,8 @@ def get_user_configs(primary_path, alternate_path):
 
     # Look for user configurations in pyproject.toml and ~/.jupysql/config
     # in that particular order
-    for file_path in [primary_path, alternate_path]:
+    path_list = [primary_path, alternate_path]
+    for file_path in path_list:
         section_to_find = None
         section_found = False
         if file_path and file_path.exists():
@@ -422,7 +423,7 @@ def get_user_configs(primary_path, alternate_path):
                 section_found = True
                 data = data[section_to_find]
 
-        if section_to_find == "SqlMagic" and section_found:
+        if section_to_find == "SqlMagic" and section_found and not data:
             display.message(
                 f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
             )
@@ -435,9 +436,7 @@ def get_user_configs(primary_path, alternate_path):
             )
             configuration_docs_displayed = True
 
-        if file_path is None:
-            display.message(f"Did not find {file_path}.")
-        elif not data and not section_found:
+        if not data and not section_found and file_path:
             display.message(f"Did not find user configurations in {file_path}.")
         elif section_found and data:
             return data, file_path

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -374,6 +374,8 @@ def get_user_configs(file_path):
 
     Returns
     -------
+    boolean
+        A boolean representing if the user configurations were set successfully.
     dict
         saved configuration settings
     """

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -398,7 +398,7 @@ def get_user_configs(primary_path, alternate_path):
 
         data = load_toml(file_path)
         section_names = ["tool", "jupysql", "SqlMagic"]
-        section_to_find = ""
+        section_to_find = None
         section_found = False
 
         while section_names:

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -422,10 +422,6 @@ def get_user_configs(primary_path, alternate_path):
                 section_found = True
                 data = data[section_to_find]
 
-        # If SqlMagic section has user configs
-        if data:
-            return data, file_path
-
         if section_to_find == "SqlMagic" and section_found:
             display.message(
                 f"[tool.jupysql.SqlMagic] present in {file_path} but empty. "
@@ -439,13 +435,12 @@ def get_user_configs(primary_path, alternate_path):
             )
             configuration_docs_displayed = True
 
-        status = ""
-        if primary_path is None:
-            status = "Did not find pyproject.toml"
-        elif file_path == alternate_path:
-            status = "Did not find user configurations in pyproject.toml"
-
-        display.message(f"{status}{'.' if status else ''}")
+        if file_path is None:
+            display.message(f"Did not find {file_path}.")
+        elif not data and not section_found:
+            display.message(f"Did not find user configurations in {file_path}.")
+        elif section_found and data:
+            return data, file_path
 
     return data, None
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -378,8 +378,6 @@ def get_user_configs(primary_path, alternate_path):
     -------
     dict
         saved configuration settings
-    Path
-        the path of the file used to get user configurations
     """
     data = None
     display_tip = True  # Set to true if tip is to be displayed
@@ -440,9 +438,9 @@ def get_user_configs(primary_path, alternate_path):
         elif not data and not section_found:
             display.message(f"Did not find user configurations in {file_path}.")
         elif section_found and data:
-            return data, file_path
+            return data
 
-    return data, None
+    return data
 
 
 def get_default_configs(sql):

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -384,9 +384,6 @@ github = "ploomber/jupysql"
 def test_load_toml_user_configurations_not_specified(
     tmp_empty, ip_no_magics, capsys, file_content
 ):
-    home_toml = Path("~/.jupysql/config").expanduser()
-    if home_toml.exists():
-        os.remove(home_toml)
     Path("pyproject.toml").write_text(file_content)
     os.mkdir("sub")
     os.chdir("sub")

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -518,7 +518,8 @@ autocommit = true
             "",
             "",
             [
-                "Tip: You may define configurations in {pyproject_path} or {config_path}.",
+                """Tip: You may define configurations in {pyproject_path}
+or {config_path}.""",
                 "Did not find user configurations in {pyproject_path}.",
                 "Did not find user configurations in {config_path}.",
             ],
@@ -527,7 +528,8 @@ autocommit = true
             "",
             "[tool.jupysql.SqlMagic]",
             [
-                "Tip: You may define configurations in {pyproject_path} or {config_path}.",
+                """Tip: You may define configurations in {pyproject_path}
+or {config_path}.""",
                 "Did not find user configurations in {pyproject_path}.",
                 "[tool.jupysql.SqlMagic] present in {config_path} but empty.",
             ],
@@ -540,7 +542,8 @@ feedback=True
 autopandas=True
 """,
             [
-                "Tip: You may define configurations in {pyproject_path} or {config_path}.",
+                """Tip: You may define configurations in {pyproject_path}
+or {config_path}.""",
                 "Did not find user configurations in {pyproject_path}.",
             ],
         ),

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -585,8 +585,13 @@ def test_user_config_load_sequence_and_messages(
     config_content,
     expected_messages,
 ):
-    Path("pyproject.toml").write_text(pyproject_content)
-    Path("~/.jupysql/config").expanduser().write_text(config_content)
+    toml_path = Path("pyproject.toml")
+    toml_path.touch(exist_ok=True)
+    toml_path.write_text(pyproject_content)
+
+    config_path = Path("~/.jupysql/config").expanduser()
+    config_path.touch(exist_ok=True)
+    config_path.write_text(config_content)
 
     toml_path = str(Path(os.getcwd()).joinpath("pyproject.toml"))
     config_path = str(Path("~/.jupysql/config").expanduser())
@@ -603,7 +608,7 @@ def test_user_config_load_sequence_and_messages(
 
     for message in expected_messages:
         expected_message = message.format(
-            pyproject_path=toml_path, config_path=config_path
+            pyproject_path=str(toml_path), config_path=str(config_path)
         )
         assert expected_message in out
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -343,24 +343,28 @@ def test_loading_toml_display_configuration_docs_link(
     tmp_empty, capsys, ip_no_magics, file_content, expected_message, monkeypatch
 ):
     Path("pyproject.toml").write_text(file_content)
-    toml_path = str(Path(os.getcwd()).joinpath("pyproject.toml"))
-    config_path = str(Path("~/.jupysql/config").expanduser())
+    toml_path = Path(os.getcwd()).joinpath("pyproject.toml")
+    config_path = Path("~/.jupysql/config").expanduser()
 
     os.mkdir("sub")
     os.chdir("sub")
+
     mock = Mock()
     monkeypatch.setattr(display, "message_html", mock)
     load_ipython_extension(ip_no_magics)
     out, _ = capsys.readouterr()
+
     param = (
         f"Please review our "
         f"<a href='{CONFIGURATION_DOCS_STR}'>configuration guideline</a>."
     )
+
     expected_message = expected_message.format(
-        primary_path=toml_path, alt_path=config_path
+        primary_path=str(toml_path), alt_path=str(config_path)
     )
-    mock.assert_called_once_with(param)
+
     assert expected_message in out
+    mock.assert_called_once_with(param)
 
 
 @pytest.mark.parametrize(
@@ -518,8 +522,10 @@ autocommit = true
             "",
             "",
             [
-                """Tip: You may define configurations in {pyproject_path}
-or {config_path}.""",
+                (
+                    "Tip: You may define configurations in "
+                    "{pyproject_path} or {config_path}."
+                ),
                 "Did not find user configurations in {pyproject_path}.",
                 "Did not find user configurations in {config_path}.",
             ],
@@ -528,8 +534,10 @@ or {config_path}.""",
             "",
             "[tool.jupysql.SqlMagic]",
             [
-                """Tip: You may define configurations in {pyproject_path}
-or {config_path}.""",
+                (
+                    "Tip: You may define configurations in "
+                    "{pyproject_path} or {config_path}."
+                ),
                 "Did not find user configurations in {pyproject_path}.",
                 "[tool.jupysql.SqlMagic] present in {config_path} but empty.",
             ],
@@ -542,8 +550,10 @@ feedback=True
 autopandas=True
 """,
             [
-                """Tip: You may define configurations in {pyproject_path}
-or {config_path}.""",
+                (
+                    "Tip: You may define configurations in "
+                    "{pyproject_path} or {config_path}."
+                ),
                 "Did not find user configurations in {pyproject_path}.",
             ],
         ),
@@ -589,6 +599,7 @@ def test_user_config_load_sequence_and_messages(
     toml_path.touch(exist_ok=True)
     toml_path.write_text(pyproject_content)
 
+    Path("~/.jupysql").expanduser().mkdir(parents=True, exist_ok=True)
     config_path = Path("~/.jupysql/config").expanduser()
     config_path.touch(exist_ok=True)
     config_path.write_text(config_content)

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2244,7 +2244,6 @@ INSERT INTO languages VALUES ('Python', 1), ('Java', 0), ('OCaml', 2)"""
         ip_empty.run_cell(sql_query)
 
     out, _ = capsys.readouterr()
-    print(out)
     assert expected_result in out
 
 


### PR DESCRIPTION
## Describe your changes
1. Modified `util.get_user_config` to return a boolean representing the successful setting of user defined configurations. Returns `True` if successful and `False` if not.
2. `magic.set_configs` now looks at the success state and behaves the same as it did only if successful config was set. If there was a failure in setting configurations, it skips tasks and returns the table rows as well as the success state.
3. The `magic.load_SqlMagic_configs` function now first looks for the user configurations in the following order:
- First in `pyproject.toml` in the project root directory
- Second in `~/.jupysql/config` if no `pyproject.toml` present
- In case `pyproject.toml` is present but is missing the SqlMagic section, the user configurations are searched for in the `~/.jupysql/config`.
4. Added tests for ensuring behavior.

## Issue number

Closes #911 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--935.org.readthedocs.build/en/935/

<!-- readthedocs-preview jupysql end -->