### PR TITLE
940 Confusing error message when table does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.10.4dev
 * [Fix] Fix bug causing empty result on SQL with trailing semicolon and comment (#907)
-
 * [Fix] Fixed bug that returns empty results when exception is raised from DB driver
+* [Fix] Fixed bug that returns snippet typo error message when another table is misspelled (#940)
 
 ## 0.10.3 (2023-11-06)
 

--- a/src/sql/error_handler.py
+++ b/src/sql/error_handler.py
@@ -29,6 +29,11 @@ def _snippet_typo_error_message(query):
             suggestions = util.find_close_match(table, get_all_keys())
             err_message = f"There is no table with name {table!r}."
             if len(suggestions) > 0:
+                # If snippet is found in suggestions, this snippet
+                # must not be misspelled (a different table name is)
+                # so we don't show this message.
+                if table in suggestions:
+                    continue
                 suggestions_message = util.get_suggestions_message(suggestions)
                 return f"{err_message}{suggestions_message}"
     return ""

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2449,8 +2449,7 @@ Did you mean: 'snippet'
 
 Original error message from DB driver:
 (sqlite3.OperationalError) no such table: snip
-[SQL: SELECT * FROM snip;]
-(Background on this error at: https://sqlalche.me/e/20/e3q8)""",
+[SQL: SELECT * FROM snip;]""",
         ),
         (
             """%%sql
@@ -2464,8 +2463,7 @@ https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 Original error message from DB driver:
 (sqlite3.OperationalError) no such table: tem
-[SQL: SELECT * from tem;]
-(Background on this error at: https://sqlalche.me/e/20/e3q8)""",
+[SQL: SELECT * from tem;]""",
         ),
         (
             """%%sql
@@ -2482,8 +2480,7 @@ Did you mean: 'snippet'
 
 Original error message from DB driver:
 (sqlite3.OperationalError) no such table: snip
-[SQL: SELECT * FROM snip;]
-(Background on this error at: https://sqlalche.me/e/20/e3q8)""",
+[SQL: SELECT * FROM snip;]""",
         ),
         (
             """%%sql
@@ -2497,8 +2494,7 @@ https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 Original error message from DB driver:
 (sqlite3.OperationalError) no such table: s
-[SQL: SELECT * FROM s;]
-(Background on this error at: https://sqlalche.me/e/20/e3q8)""",
+[SQL: SELECT * FROM s;]""",
         ),
     ],
     ids=["snippet-typo", "table-typo", "both-typo", "snippet-typo-no-suggestion"],

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2508,8 +2508,32 @@ LINE 1: SELECT * FROM s;
                       ^
 [SQL: SELECT * FROM s;]""",
         ),
+        (
+            """%%sql
+DROP TABLE temp;
+SELECT * FROM snippet;
+SELECT * from temp;""",
+            "RuntimeError",
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+
+
+Original error message from DB driver:
+(duckdb.CatalogException) Catalog Error: Table with name snippet does not exist!
+Did you mean "pg_type"?
+LINE 1: SELECT * FROM snippet;
+                      ^
+[SQL: SELECT * FROM snippet;]""",
+        ),
     ],
-    ids=["snippet-typo", "table-typo", "both-typo", "snippet-typo-no-suggestion"],
+    ids=[
+        "snippet-typo",
+        "table-typo",
+        "both-typo",
+        "snippet-typo-no-suggestion",
+        "no-typo-drop-table",
+    ],
 )
 def test_table_does_not_exist_with_snippet_error(
     ip_empty, query, error_type, error_message

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2448,7 +2448,10 @@ Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(sqlite3.OperationalError) no such table: snip
+(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+Did you mean "temp"?
+LINE 1: SELECT * FROM snip;
+                      ^
 [SQL: SELECT * FROM snip;]""",
         ),
         (
@@ -2462,7 +2465,10 @@ https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 
 Original error message from DB driver:
-(sqlite3.OperationalError) no such table: tem
+(duckdb.CatalogException) Catalog Error: Table with name tem does not exist!
+Did you mean "temp"?
+LINE 1: SELECT * from tem;
+                      ^
 [SQL: SELECT * from tem;]""",
         ),
         (
@@ -2479,7 +2485,10 @@ Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(sqlite3.OperationalError) no such table: snip
+(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+Did you mean "temp"?
+LINE 1: SELECT * FROM snip;
+                      ^
 [SQL: SELECT * FROM snip;]""",
         ),
         (
@@ -2493,29 +2502,38 @@ https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 
 Original error message from DB driver:
-(sqlite3.OperationalError) no such table: s
+(duckdb.CatalogException) Catalog Error: Table with name s does not exist!
+Did you mean "temp"?
+LINE 1: SELECT * FROM s;
+                      ^
 [SQL: SELECT * FROM s;]""",
         ),
     ],
     ids=["snippet-typo", "table-typo", "both-typo", "snippet-typo-no-suggestion"],
 )
-def test_table_does_not_exist_with_snippet_error(ip, query, error_type, error_message):
+def test_table_does_not_exist_with_snippet_error(
+    ip_empty, query, error_type, error_message
+):
+    ip_empty.run_cell(
+        """%load_ext sql
+%sql duckdb://"""
+    )
     # Create temp table
-    ip.run_cell(
+    ip_empty.run_cell(
         """%%sql
 CREATE TABLE temp AS
-SELECT * FROM author"""
+SELECT * FROM penguins.csv"""
     )
 
     # Create snippet
-    ip.run_cell(
+    ip_empty.run_cell(
         """%%sql --save snippet
-SELECT * FROM website;"""
+SELECT * FROM penguins.csv;"""
     )
 
     # Run query
     with pytest.raises(Exception) as excinfo:
-        ip.run_cell(query)
+        ip_empty.run_cell(query)
 
     # Test error and message
     assert error_type == excinfo.value.error_type


### PR DESCRIPTION
## Describe your changes
- Edited `_snippet_typo_error_message` in `error_handler.py` to check if the snippet is spelled correctly before returning the snippet typo error message. Previously, it assumed the would show the error message even if the snippet were spelled correctly. 
- The bug described in #940 occurred because any table misspelling, when included in a query that also uses snippets, was treated as a snippet misspelling automatically. JupySQL still checks for snippet misspellings first, but now if the snippet is spelled correctly, it doesn't return any snippet error message and instead returns the correct "Table __ Not Found" error message.
## Issue number

Closes #940 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--942.org.readthedocs.build/en/942/

<!-- readthedocs-preview jupysql end -->