### PR TITLE
Fix 944: Fixed edge case of cli argument duplication for `%sqlcmd` magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [Fix] Fixed bug that returns empty results when exception is raised from DB driver
 * [Fix] Added guards to check and raise errors when arguments are entered twice in %sql, %sqlcmd and %sqlplot (#806)
 * [Fix] Fixed bug that returns snippet typo error message when another table is misspelled (#940)
+* [Fix] Fixed edge case where `%sqlcmd snippets` allowed use of multiple delete statements (#944)
 
 ## 0.10.3 (2023-11-06)
 

--- a/src/sql/magic_cmd.py
+++ b/src/sql/magic_cmd.py
@@ -84,6 +84,9 @@ class SqlCmdMagic(Magics, Configurable):
                         "-t": "--table",
                         "-s": "--schema",
                         "-o": "--output",
+                        "-d": "--delete",
+                        "-D": "--delete-force",
+                        "-A": "--delete-force-all",
                     },
                 )
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -266,7 +266,7 @@ def check_duplicate_arguments(
     else:
         duplicates_error = ""
 
-    if alias_pairs_present and not len(delete_arg_present) > 1:
+    if alias_pairs_present and len(delete_arg_present) <= 1:
         arg_list = [" or ".join(pair) for pair in sorted(alias_pairs_present)]
         alias_error = (
             f"Duplicate aliases for arguments in %{cmd_from}. "

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -20,7 +20,7 @@ PATH_TO_TMP_ASSETS.mkdir(exist_ok=True)
 
 @pytest.fixture
 def check_duplicate_message_factory():
-    def _generate_error_message(cmd, args, aliases=None):
+    def _generate_error_message(cmd, args, aliases=None, delete_present=False):
         error_message = ""
         duplicates = set([arg for arg in args if args.count(arg) != 1])
 
@@ -28,12 +28,10 @@ def check_duplicate_message_factory():
             error_message += (
                 f"Duplicate arguments in %{cmd}. "
                 "Please use only one of each of the following: "
-                f"{', '.join(sorted(duplicates))}."
+                f"{', '.join(sorted(duplicates))}. "
             )
-            if aliases:
-                error_message += " "
 
-        if aliases:
+        if aliases and not delete_present:
             alias_list = []
             for pair in sorted(aliases):
                 print(pair[0], pair[1])
@@ -41,8 +39,29 @@ def check_duplicate_message_factory():
             error_message += (
                 f"Duplicate aliases for arguments in %{cmd}. "
                 "Please use either one of "
-                f"{', '.join(alias_list)}."
+                f"{', '.join(alias_list)}. "
             )
+
+        if delete_present:
+            delete_arg_list = [
+                "-d",
+                "-D",
+                "-A",
+                "--delete",
+                "--delete-force",
+                "--delete-force-all",
+            ]
+            delete_args_present = set()
+            for arg in args:
+                if arg in delete_arg_list:
+                    delete_args_present.add(arg)
+
+            if len(delete_args_present) > 1:
+                delete_args_present = list(sorted(delete_args_present, reverse=True))
+                error_message += (
+                    "Please use only one of the following delete commands at a time: "
+                    f"{', '.join(delete_args_present)}. "
+                )
 
         return error_message
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -20,7 +20,7 @@ PATH_TO_TMP_ASSETS.mkdir(exist_ok=True)
 
 @pytest.fixture
 def check_duplicate_message_factory():
-    def _generate_error_message(cmd, args, aliases=None, delete_present=False):
+    def _generate_error_message(cmd, args, aliases=None, delete_option_used=False):
         error_message = ""
         duplicates = set([arg for arg in args if args.count(arg) != 1])
 
@@ -31,10 +31,9 @@ def check_duplicate_message_factory():
                 f"{', '.join(sorted(duplicates))}. "
             )
 
-        if aliases and not delete_present:
+        if aliases and not delete_option_used:
             alias_list = []
             for pair in sorted(aliases):
-                print(pair[0], pair[1])
                 alias_list.append(f"{f'-{pair[0]}'} or {f'--{pair[1]}'}")
             error_message += (
                 f"Duplicate aliases for arguments in %{cmd}. "
@@ -42,7 +41,7 @@ def check_duplicate_message_factory():
                 f"{', '.join(alias_list)}. "
             )
 
-        if delete_present:
+        if delete_option_used:
             delete_arg_list = [
                 "-d",
                 "-D",

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -426,104 +426,41 @@ DISALLOWED_ALIASES = {
     "args, aliases, delete_present",
     [
         # for schema/s
-        (
-            ["--schema", "--schema"],
-            [],
-            False
-        ),
-        (
-            ["-s", "-s"],
-            [],
-            False
-        ),
-        (
-            ["--schema", "-s"],
-            [("s", "schema")],
-            False
-        ),
+        (["--schema", "--schema"], [], False),
+        (["-s", "-s"], [], False),
+        (["--schema", "-s"], [("s", "schema")], False),
         # for table/t
-        (
-            ["--table", "--table"],
-            [],
-            False
-        ),
-        (
-            ["-t", "-t"],
-            [],
-            False
-        ),
-        (
-            ["--table", "-t"],
-            [("t", "table")],
-            False
-        ),
+        (["--table", "--table"], [], False),
+        (["-t", "-t"], [], False),
+        (["--table", "-t"], [("t", "table")], False),
         # for delete/d
-        (
-            ["--delete", "--delete"],
-            [],
-            True
-        ),
-        (
-            ["-d", "-d"],
-            [],
-            True
-        ),
-        (
-            ["--delete", "-d"],
-            [("d", "delete")],
-            True
-        ),
+        (["--delete", "--delete"], [], True),
+        (["-d", "-d"], [], True),
+        (["--delete", "-d"], [("d", "delete")], True),
         # for delete-force/D
-        (
-            ["--delete-force", "--delete-force"],
-            [],
-            True
-        ),
-        (
-            ["-D", "-D"],
-            [],
-            True
-        ),
-        (
-            ["--delete-force", "-D"],
-            [("D", "delete-force")],
-            True
-        ),
+        (["--delete-force", "--delete-force"], [], True),
+        (["-D", "-D"], [], True),
+        (["--delete-force", "-D"], [("D", "delete-force")], True),
         # for delete-force-all/A
-        (
-            ["--delete-force-all", "--delete-force-all"],
-            [],
-            True
-        ),
-        (
-            ["-A", "-A"],
-            [],
-            True
-        ),
-        (
-            ["--delete-force-all", "-A"],
-            [("A", "delete-force-all")],
-            True
-        ),
+        (["--delete-force-all", "--delete-force-all"], [], True),
+        (["-A", "-A"], [], True),
+        (["--delete-force-all", "-A"], [("A", "delete-force-all")], True),
         # for mixed delete
         (
             ["-d", "-D", "-A", "--delete", "--delete-force", "--delete-force-all"],
             [("d", "delete"), ("D", "delete-force"), ("A", "delete-force-all")],
-            True
+            True,
         ),
         # for mixed
         (
             ["--table", "-t", "-s", "-s", "--schema"],
             [("t", "table"), ("s", "schema")],
-            False
+            False,
         ),
     ],
 )
 def test_check_duplicate_arguments_raises_usageerror_for_sqlcmd(
-    check_duplicate_message_factory,
-    args,
-    aliases,
-    delete_present
+    check_duplicate_message_factory, args, aliases, delete_present
 ):
     with pytest.raises(UsageError) as excinfo:
         util.check_duplicate_arguments(
@@ -533,9 +470,9 @@ def test_check_duplicate_arguments_raises_usageerror_for_sqlcmd(
             [],
             DISALLOWED_ALIASES["sqlcmd"],
         )
-    assert check_duplicate_message_factory("sqlcmd", args, aliases, delete_present) in str(
-        excinfo.value
-    )
+    assert check_duplicate_message_factory(
+        "sqlcmd", args, aliases, delete_present
+    ) in str(excinfo.value)
 
 
 ALLOWED_DUPLICATES = {

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -415,43 +415,107 @@ DISALLOWED_ALIASES = {
         "-t": "--table",
         "-s": "--schema",
         "-o": "--output",
+        "-d": "--delete",
+        "-D": "--delete-force",
+        "-A": "--delete-force-all",
     },
 }
 
 
 @pytest.mark.parametrize(
-    "args, aliases",
+    "args, aliases, delete_present",
     [
         # for schema/s
         (
             ["--schema", "--schema"],
             [],
+            False
         ),
         (
             ["-s", "-s"],
             [],
+            False
         ),
         (
             ["--schema", "-s"],
             [("s", "schema")],
+            False
         ),
         # for table/t
         (
             ["--table", "--table"],
             [],
+            False
         ),
         (
             ["-t", "-t"],
             [],
+            False
         ),
         (
             ["--table", "-t"],
             [("t", "table")],
+            False
+        ),
+        # for delete/d
+        (
+            ["--delete", "--delete"],
+            [],
+            True
+        ),
+        (
+            ["-d", "-d"],
+            [],
+            True
+        ),
+        (
+            ["--delete", "-d"],
+            [("d", "delete")],
+            True
+        ),
+        # for delete-force/D
+        (
+            ["--delete-force", "--delete-force"],
+            [],
+            True
+        ),
+        (
+            ["-D", "-D"],
+            [],
+            True
+        ),
+        (
+            ["--delete-force", "-D"],
+            [("D", "delete-force")],
+            True
+        ),
+        # for delete-force-all/A
+        (
+            ["--delete-force-all", "--delete-force-all"],
+            [],
+            True
+        ),
+        (
+            ["-A", "-A"],
+            [],
+            True
+        ),
+        (
+            ["--delete-force-all", "-A"],
+            [("A", "delete-force-all")],
+            True
+        ),
+        # for mixed delete
+        (
+            ["-d", "-D", "-A", "--delete", "--delete-force", "--delete-force-all"],
+            [("d", "delete"), ("D", "delete-force"), ("A", "delete-force-all")],
+            True
         ),
         # for mixed
         (
             ["--table", "-t", "-s", "-s", "--schema"],
             [("t", "table"), ("s", "schema")],
+            False
         ),
     ],
 )
@@ -459,6 +523,7 @@ def test_check_duplicate_arguments_raises_usageerror_for_sqlcmd(
     check_duplicate_message_factory,
     args,
     aliases,
+    delete_present
 ):
     with pytest.raises(UsageError) as excinfo:
         util.check_duplicate_arguments(
@@ -468,7 +533,7 @@ def test_check_duplicate_arguments_raises_usageerror_for_sqlcmd(
             [],
             DISALLOWED_ALIASES["sqlcmd"],
         )
-    assert check_duplicate_message_factory("sqlcmd", args, aliases) in str(
+    assert check_duplicate_message_factory("sqlcmd", args, aliases, delete_present) in str(
         excinfo.value
     )
 


### PR DESCRIPTION
## Describe your changes
1. Added logic to disable use of more than one delete commands in `%sqlcmd snippets`. No longer allows any combination of `-d`, `--delete`, `-D`, `--delete-force`, `-A` and `--delete-force-all` for the %sqlcmd snippets magic.
2. Added test to reflect changes in the `check_duplicate_arguments` function.

## Issue number

Closes #944 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--946.org.readthedocs.build/en/946/

<!-- readthedocs-preview jupysql end -->