### PR TITLE
[Fix 954]: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.8dev
 
+* [Fix] Fixed bug where the `%sql` line magic would not parse properly due to expectations from shlex(#954)
+
 ## 0.10.7 (2023-12-23)
 
 * [Feature] Add Spark Connection as a dialect for Jupysql ([#965](https://github.com/ploomber/jupysql/issues/965)) (by [@gilandose](https://github.com/gilandose))

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -229,8 +229,7 @@ def without_sql_comment(parser, line):
 
     args = _option_strings_from_parser(parser)
     result = itertools.takewhile(
-        lambda word: (not word.startswith("--")) or (word in args),
-        line.split()
+        lambda word: (not word.startswith("--")) or (word in args), line.split()
     )
     return " ".join(result)
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -232,11 +232,10 @@ def without_sql_comment(parser, line):
     temp_line = pattern.sub(lambda x: x.group().replace(" ", ""), line)
     spaces_removed = len(line) - len(temp_line)
     result = itertools.takewhile(
-        lambda word: (not word.startswith("--")) or (word in args),
-        temp_line.split()
+        lambda word: (not word.startswith("--")) or (word in args), temp_line.split()
     )
     result = " ".join(result)
-    result = line[:len(result) + spaces_removed]
+    result = line[: len(result) + spaces_removed]
     return result
 
 
@@ -279,7 +278,9 @@ def split_args_and_sql(line):
     # If any SQL commands are found in the line, we split the line into args and sql.
     #   Note: lines without SQL commands will not be split
     #       ex. %sql duckdb:// or %sqlplot boxplot --table data.csv
-    if any(cmd in line_no_filenames for cmd in SQL_COMMANDS) or any(cmd.upper() in line_no_filenames for cmd in SQL_COMMANDS):
+    if any(cmd in line_no_filenames for cmd in SQL_COMMANDS) or any(
+        cmd.upper() in line_no_filenames for cmd in SQL_COMMANDS
+    ):
         # Identify beginning of sql query using keywords
         split_idx = -1
         for token in line.split():

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -230,7 +230,7 @@ def without_sql_comment(parser, line):
     args = _option_strings_from_parser(parser)
     result = itertools.takewhile(
         lambda word: (not word.startswith("--")) or (word in args),
-        shlex.split(line, posix=False),
+        line.split()
     )
     return " ".join(result)
 
@@ -300,8 +300,7 @@ def magic_args(magic_execute, line, cmd_from, allowed_duplicates=None):
     line = without_sql_comment(parser=magic_execute.parser, line=line)
     arg_line, sql_line = split_args_and_sql(line)
 
-    args = shlex.split(arg_line, posix=False)
-
+    args = arg_line.split()
     if len(args) > 1:
         check_duplicate_arguments(magic_execute, cmd_from, args, allowed_duplicates)
 

--- a/src/tests/test_column_guesser.py
+++ b/src/tests/test_column_guesser.py
@@ -12,7 +12,8 @@ class SqlEnv(object):
         self.connectstr = connectstr
 
     def query(self, txt):
-        return ip.run_line_magic("sql", "%s %s" % (self.connectstr, txt))
+        ip.run_line_magic("sql", self.connectstr)
+        return ip.run_line_magic("sql", "%s" % txt)
 
 
 sql_env = SqlEnv("sqlite://")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2466,9 +2466,6 @@ def test_query_comment_after_semicolon(ip, query, expected):
     assert list(result.dict().values())[-1][0] == expected
 
 
-error_message_link = "https://jupysql.ploomber.io/en/latest/compose.html#with-argument"
-
-
 @pytest.mark.parametrize(
     "query, error_type, error_message",
     [
@@ -2477,32 +2474,33 @@ error_message_link = "https://jupysql.ploomber.io/en/latest/compose.html#with-ar
 SELECT * FROM snip;
 SELECT * from temp;""",
             "TableNotFoundError",
-            f"""If using snippets, you may pass the --with argument explicitly.
-For more details please refer: {error_message_link}
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 There is no table with name 'snip'.
 Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+(duckdb.duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM snip;
                       ^
-[SQL: SELECT * FROM snip;]
-""",
+[SQL: SELECT * FROM snip;]""",
         ),
         (
             """%%sql
 SELECT * FROM snippet;
 SELECT * from tem;""",
             "RuntimeError",
-            f"""If using snippets, you may pass the --with argument explicitly.
-For more details please refer: {error_message_link}
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 
 Original error message from DB driver:
-(duckdb.CatalogException) Catalog Error: Table with name tem does not exist!
+(duckdb.duckdb.CatalogException) Catalog Error: Table with name tem does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * from tem;
                       ^
@@ -2513,15 +2511,16 @@ LINE 1: SELECT * from tem;
 SELECT * FROM snip;
 SELECT * from tem;""",
             "TableNotFoundError",
-            f"""If using snippets, you may pass the --with argument explicitly.
-For more details please refer: {error_message_link}
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 There is no table with name 'snip'.
 Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+(duckdb.duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM snip;
                       ^
@@ -2532,17 +2531,17 @@ LINE 1: SELECT * FROM snip;
 SELECT * FROM s;
 SELECT * from temp;""",
             "RuntimeError",
-            f"""If using snippets, you may pass the --with argument explicitly.
-For more details please refer: {error_message_link}
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 
 Original error message from DB driver:
-(duckdb.CatalogException) Catalog Error: Table with name s does not exist!
+(duckdb.duckdb.CatalogException) Catalog Error: Table with name s does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM s;
                       ^
-[SQL: SELECT * FROM s;]
-""",
+[SQL: SELECT * FROM s;]""",
         ),
         (
             """%%sql
@@ -2550,12 +2549,13 @@ DROP TABLE temp;
 SELECT * FROM snippet;
 SELECT * from temp;""",
             "RuntimeError",
-            f"""If using snippets, you may pass the --with argument explicitly.
-For more details please refer: {error_message_link}
+            """If using snippets, you may pass the --with argument explicitly.
+For more details please refer: \
+https://jupysql.ploomber.io/en/latest/compose.html#with-argument
 
 
 Original error message from DB driver:
-(duckdb.CatalogException) Catalog Error: Table with name snippet does not exist!
+(duckdb.duckdb.CatalogException) Catalog Error: Table with name snippet does not exist!
 Did you mean "pg_type"?
 LINE 1: SELECT * FROM snippet;
                       ^
@@ -2595,7 +2595,6 @@ SELECT * FROM penguins.csv;"""
         ip_empty.run_cell(query)
 
     # Test error and message
-    print(excinfo.value)
     assert error_type == excinfo.value.error_type
     assert error_message in str(excinfo.value)
 

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2466,6 +2466,9 @@ def test_query_comment_after_semicolon(ip, query, expected):
     assert list(result.dict().values())[-1][0] == expected
 
 
+error_message_link = "https://jupysql.ploomber.io/en/latest/compose.html#with-argument"
+
+
 @pytest.mark.parametrize(
     "query, error_type, error_message",
     [
@@ -2474,33 +2477,32 @@ def test_query_comment_after_semicolon(ip, query, expected):
 SELECT * FROM snip;
 SELECT * from temp;""",
             "TableNotFoundError",
-            """If using snippets, you may pass the --with argument explicitly.
-For more details please refer: \
-https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+            f"""If using snippets, you may pass the --with argument explicitly.
+For more details please refer: {error_message_link}
 
 There is no table with name 'snip'.
 Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(duckdb.duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM snip;
                       ^
-[SQL: SELECT * FROM snip;]""",
+[SQL: SELECT * FROM snip;]
+""",
         ),
         (
             """%%sql
 SELECT * FROM snippet;
 SELECT * from tem;""",
             "RuntimeError",
-            """If using snippets, you may pass the --with argument explicitly.
-For more details please refer: \
-https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+            f"""If using snippets, you may pass the --with argument explicitly.
+For more details please refer: {error_message_link}
 
 
 Original error message from DB driver:
-(duckdb.duckdb.CatalogException) Catalog Error: Table with name tem does not exist!
+(duckdb.CatalogException) Catalog Error: Table with name tem does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * from tem;
                       ^
@@ -2511,16 +2513,15 @@ LINE 1: SELECT * from tem;
 SELECT * FROM snip;
 SELECT * from tem;""",
             "TableNotFoundError",
-            """If using snippets, you may pass the --with argument explicitly.
-For more details please refer: \
-https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+            f"""If using snippets, you may pass the --with argument explicitly.
+For more details please refer: {error_message_link}
 
 There is no table with name 'snip'.
 Did you mean: 'snippet'
 
 
 Original error message from DB driver:
-(duckdb.duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
+(duckdb.CatalogException) Catalog Error: Table with name snip does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM snip;
                       ^
@@ -2531,17 +2532,17 @@ LINE 1: SELECT * FROM snip;
 SELECT * FROM s;
 SELECT * from temp;""",
             "RuntimeError",
-            """If using snippets, you may pass the --with argument explicitly.
-For more details please refer: \
-https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+            f"""If using snippets, you may pass the --with argument explicitly.
+For more details please refer: {error_message_link}
 
 
 Original error message from DB driver:
-(duckdb.duckdb.CatalogException) Catalog Error: Table with name s does not exist!
+(duckdb.CatalogException) Catalog Error: Table with name s does not exist!
 Did you mean "temp"?
 LINE 1: SELECT * FROM s;
                       ^
-[SQL: SELECT * FROM s;]""",
+[SQL: SELECT * FROM s;]
+""",
         ),
         (
             """%%sql
@@ -2549,13 +2550,12 @@ DROP TABLE temp;
 SELECT * FROM snippet;
 SELECT * from temp;""",
             "RuntimeError",
-            """If using snippets, you may pass the --with argument explicitly.
-For more details please refer: \
-https://jupysql.ploomber.io/en/latest/compose.html#with-argument
+            f"""If using snippets, you may pass the --with argument explicitly.
+For more details please refer: {error_message_link}
 
 
 Original error message from DB driver:
-(duckdb.duckdb.CatalogException) Catalog Error: Table with name snippet does not exist!
+(duckdb.CatalogException) Catalog Error: Table with name snippet does not exist!
 Did you mean "pg_type"?
 LINE 1: SELECT * FROM snippet;
                       ^
@@ -2595,6 +2595,7 @@ SELECT * FROM penguins.csv;"""
         ip_empty.run_cell(query)
 
     # Test error and message
+    print(excinfo.value)
     assert error_type == excinfo.value.error_type
     assert error_message in str(excinfo.value)
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -777,8 +777,8 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
             "ell",
         ),
         (
-            "select 'hello'[:-1]",
-            "hell",
+            "select 'hello'[:-2]",
+            "hel",
         ),
     ],
 )

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -777,8 +777,8 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
             "ell",
         ),
         (
-            "select 'hello'[:-2]",
-            "hel",
+            "select 'hello'[:-3]",
+            "he",
         ),
     ],
 )

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -772,7 +772,7 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
         ),
         (
             "select 'hello'[:-2]",
-            "hell",
+            "hel",
         ),
     ],
 )
@@ -897,6 +897,11 @@ where name = (names ->> 'Brenda')",
             "-p --save snippet -N ",
             "insert into authors values('[100]'::json->0)",
         ),
+        (
+            "--save snippet SELECT TRIM(' padded ')",
+            "--save snippet ",
+            "SELECT TRIM(' padded ')",
+        ),
     ],
     ids=[
         "no-query",
@@ -910,6 +915,7 @@ where name = (names ->> 'Brenda')",
         "update",
         "delete",
         "insert",
+        "select-uppercase",
     ],
 )
 def test_split_args_and_sql(line, expected_args, expected_sql):

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -263,6 +263,12 @@ def test_without_sql_comment_dashes_in_string():
     assert without_sql_comment(parser=parser_stub, line=line) == expected
 
 
+def test_without_sql_comment_dashes_in_string_with_spaces():
+    line = "SELECT ' --very --confusing ' FROM author -- uff da"
+    expected = "SELECT ' --very --confusing ' FROM author"
+    assert without_sql_comment(parser=parser_stub, line=line) == expected
+
+
 def test_without_sql_comment_with_arg_and_leading_comment():
     line = "--file moo.txt --persist --comment, not arg"
     expected = "--file moo.txt --persist"

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -777,8 +777,8 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
             "ell",
         ),
         (
-            "select 'hello'[:-2]",
-            "hel",
+            "select 'hello'[:-1]",
+            "hell",
         ),
     ],
 )

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -777,8 +777,8 @@ def test_connections_file_get_default_connection_url(tmp_empty, content, expecte
             "ell",
         ),
         (
-            "select 'hello'[:-3]",
-            "he",
+            "select 'hello'[:-2]",
+            "hell",
         ),
     ],
 )


### PR DESCRIPTION
## Describe your changes
1. Modified `split_args_and_sql` to account for uppercase SQL commands.
2. Modified `split_args_and_sql` to check for variable assignments and add it to `sql_line` instead of `arg_line`.
3. Modified `without_sql_comment` to improve handling for cases in which queries include a `--` within quotes with spaces. Example : `SELECT TRIM (' --padded ')`.
4. Added tests for the modifications.

## Issue number

Closes #954

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
:books: Documentation preview :books:: https://jupysql--955.org.readthedocs.build/en/955/

<!-- readthedocs-preview jupysql end -->