### PR TITLE
958 Unrecognized Argument on negative number queries

### DIFF
--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -290,7 +290,7 @@ def magic_args(magic_execute, line, cmd_from, allowed_duplicates=None):
 
     if len(args) > 1:
         check_duplicate_arguments(magic_execute, cmd_from, args, allowed_duplicates)
-    
+
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -259,9 +259,8 @@ def split_args_and_sql(line):
     """
     arg_line, sql_line = line, ""
 
-    # Only separate when json arrow operators used
-    # Otherwise, behavior is unchanged
-    if not any(op in line for op in ["->", "-->"]):
+    # Only separate when sql commands are used
+    if not any(cmd in line for cmd in SQL_COMMANDS):
         return arg_line, sql_line
 
     # Identify beginning of sql query using keywords
@@ -288,12 +287,15 @@ def magic_args(magic_execute, line, cmd_from, allowed_duplicates=None):
     arg_line, sql_line = split_args_and_sql(line)
 
     args = shlex.split(arg_line, posix=False)
+
     if len(args) > 1:
         check_duplicate_arguments(magic_execute, cmd_from, args, allowed_duplicates)
+    
     parsed = magic_execute.parser.parse_args(args)
 
     if sql_line:
         parsed.line = shlex.split(sql_line, posix=False)
+
     return parsed
 
 

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -259,8 +259,12 @@ def split_args_and_sql(line):
     """
     arg_line, sql_line = line, ""
 
+    # Filenames may include sql keywords, so we omit them
+    check = re.sub(r"('.*')", "", line)
+    check = re.sub(r'(".*")', "", check)
+
     # Only separate when sql commands are used
-    if not any(cmd in line for cmd in SQL_COMMANDS):
+    if not any(cmd in check for cmd in SQL_COMMANDS):
         return arg_line, sql_line
 
     # Identify beginning of sql query using keywords

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -259,12 +259,22 @@ def split_args_and_sql(line):
     """
     arg_line, sql_line = line, ""
 
-    # Filenames may include sql keywords, so we omit them
-    check = re.sub(r"('.*')", "", line)
-    check = re.sub(r'(".*")', "", check)
+    # When queries include filenames, they may include SQL keywords
+    #   ex. 'penguins_selected'.csv contains "select"
+    # In these cases, splitting the query leads to parsing errors.
+    # So we ignore any filenames by removing text between double quotes ""
+    # and single quotes '' below.
+    # Note: This won't affect the query because we are only modifying the
+    # text we use to check for SQL commands. Any splitting is done
+    # on the original line which includes filenames.
+    line_no_filenames = re.sub(r"('.*')", "", line)  # 'file.csv' --> ''
+    line_no_filenames = re.sub(r'(".*")', "", line_no_filenames)  # "file.csv" --> ""
 
-    # Only separate when sql commands are used
-    if not any(cmd in check for cmd in SQL_COMMANDS):
+    # Now that filenames are removed, check the line for any SQL commands
+    # If any SQL commands are found in the line, we split the line into args and sql.
+    #   Note: lines without SQL commands will not be split
+    #       ex. %sql duckdb:// or %sqlplot boxplot --table data.csv
+    if not any(cmd in line_no_filenames for cmd in SQL_COMMANDS):
         return arg_line, sql_line
 
     # Identify beginning of sql query using keywords

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2597,3 +2597,19 @@ SELECT * FROM penguins.csv;"""
     # Test error and message
     assert error_type == excinfo.value.error_type
     assert error_message in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "%sql select 5 * -2",
+        "%sql select 5 * - 2",
+        "%sql select 5 * -2;",
+        "%sql select -5 * 2;",
+        "%sql select 5 * -2 ;",
+        "%sql select 5 * - 2;",
+    ]
+)
+def test_negative_operations_query(ip, query):
+    result = ip.run_cell(query).result
+    assert list(result.dict().values())[-1][0] == -10

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2608,7 +2608,7 @@ SELECT * FROM penguins.csv;"""
         "%sql select -5 * 2;",
         "%sql select 5 * -2 ;",
         "%sql select 5 * - 2;",
-    ]
+    ],
 )
 def test_negative_operations_query(ip, query):
     result = ip.run_cell(query).result

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2608,34 +2608,13 @@ SELECT * FROM penguins.csv;"""
         ("%sql select -5 * 2;", (-10,)),
         ("%sql select 5 * -2 ;", (-10,)),
         ("%sql select 5 * - 2;", (-10,)),
-        (
-            "%sql select x * -2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select x *-2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select x * - 2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select x *- 2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select -x * 2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select - x * 2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
-        (
-            "%sql select - x* 2 from number_table",
-            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
-        ),
+        ("%sql select x * -2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select x *-2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select x * - 2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select x *- 2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select -x * 2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select - x * 2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
+        ("%sql select - x* 2 from number_table", (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)),
     ],
 )
 def test_negative_operations_query(ip, query, expected):

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -2600,16 +2600,44 @@ SELECT * FROM penguins.csv;"""
 
 
 @pytest.mark.parametrize(
-    "query",
+    "query, expected",
     [
-        "%sql select 5 * -2",
-        "%sql select 5 * - 2",
-        "%sql select 5 * -2;",
-        "%sql select -5 * 2;",
-        "%sql select 5 * -2 ;",
-        "%sql select 5 * - 2;",
+        ("%sql select 5 * -2", (-10,)),
+        ("%sql select 5 * - 2", (-10,)),
+        ("%sql select 5 * -2;", (-10,)),
+        ("%sql select -5 * 2;", (-10,)),
+        ("%sql select 5 * -2 ;", (-10,)),
+        ("%sql select 5 * - 2;", (-10,)),
+        (
+            "%sql select x * -2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select x *-2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select x * - 2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select x *- 2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select -x * 2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select - x * 2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
+        (
+            "%sql select - x* 2 from number_table",
+            (-8, 10, -4, 0, 10, 4, 4, 8, -4, -8)
+        ),
     ],
 )
-def test_negative_operations_query(ip, query):
+def test_negative_operations_query(ip, query, expected):
     result = ip.run_cell(query).result
-    assert list(result.dict().values())[-1][0] == -10
+    assert list(result.dict().values())[-1] == expected

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -845,8 +845,8 @@ def test_escape_string_slicing_notation(query, expected_escaped, expected_found)
         ),
         (
             "select * from authors",
-            "select * from authors",
             "",
+            "select * from authors",
         ),
         (
             "select '[1,2,3]'::json -> 1",


### PR DESCRIPTION
## Describe your changes
- In `parse.py`, changed `split_args_and_sql()` to run anytime a SQL command is found, rather than only when JSON arrow operators are used
- This avoids corner cases where `-` is used to indicate a negative number in `SELECT` queries
- Added some spaces to `magic_args` to improve readability
- Added tests to verify correctness
- Added no-changelog label since this is a corner case of the other PR #918 

## Issue number

Closes #958 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--964.org.readthedocs.build/en/964/

<!-- readthedocs-preview jupysql end -->