### PR TITLE
Refactor close-matching when reading toml config

### DIFF
--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -417,8 +417,8 @@ def get_user_configs(primary_path, alternate_path):
                     similar_key_list = find_close_match("SqlMagic", keys)
                     if similar_key_list:
                         raise exceptions.ConfigurationError(
-                            f"[tool.jupysql.{similar_key_list[0]}] is an invalid section "
-                            f"name in {file_path}. "
+                            f"[tool.jupysql.{similar_key_list[0]}] is an "
+                            f"invalid section name in {file_path}. "
                             f"Did you mean [tool.jupysql.SqlMagic]?"
                         )
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -561,7 +561,6 @@ def enclose_table_with_double_quotations(table, conn):
 
     return _table
 
-
 def is_rendering_required(line):
     """Function to check possibility of line
     text containing expandable arguments"""

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -415,13 +415,6 @@ autocommit = true
         ),
         (
             """
-[tool.jupySql.SqlMagic]
-autocommit = true
-""",
-            "'jupySql' is an invalid section name in {path}. Did you mean 'jupysql'?",
-        ),
-        (
-            """
 [tool.jupysql.SqlMagic]
 autocommit = True
 """,

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -415,6 +415,13 @@ autocommit = true
         ),
         (
             """
+[tool.jupysql.SQLMagics]
+autocommit = true
+""",
+            "[tool.jupysql.SQLMagics] is an invalid section name in {path}. Did you mean [tool.jupysql.SqlMagic]?",
+        ),
+        (
+            """
 [tool.jupysql.SqlMagic]
 autocommit = True
 """,
@@ -575,6 +582,13 @@ autopandas=True
 """,
             [
                 "[tool.jupysql.SqlMagic] present in {pyproject_path} but empty.",
+            ],
+        ),
+        (
+            "[tool.JupySQL.SqlMagic]",
+            "",
+            [
+                "Hint: We found 'tool.JupySQL' in {pyproject_path}. Did you mean 'tool.jupysql'?",
             ],
         ),
     ],

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -418,7 +418,8 @@ autocommit = true
 [tool.jupysql.SQLMagics]
 autocommit = true
 """,
-            "[tool.jupysql.SQLMagics] is an invalid section name in {path}. Did you mean [tool.jupysql.SqlMagic]?",
+            "[tool.jupysql.SQLMagics] is an invalid section name in {path}. "
+            "Did you mean [tool.jupysql.SqlMagic]?",
         ),
         (
             """
@@ -588,7 +589,8 @@ autopandas=True
             "[tool.JupySQL.SqlMagic]",
             "",
             [
-                "Hint: We found 'tool.JupySQL' in {pyproject_path}. Did you mean 'tool.jupysql'?",
+                "Hint: We found 'tool.JupySQL' in {pyproject_path}. "
+                "Did you mean 'tool.jupysql'?",
             ],
         ),
     ],


### PR DESCRIPTION
## Describe your changes

This PR refactors `sql.util.get_user_configs()` to more specifically target only the config section `[tool.jupysql.SqlMagic]`.

When searching for "jupysql", a hint (instead of an error) will be displayed only if there is exact case-insensitive match (such as "jupySql"). We are making this stricter, because we cannot anticipate the naming of other tools in the general `tool` namespace.

A `close_match` is still used for "SqlMagic", so we detect things like "SqlMagic**s**". If found, such things will continue to throw an error with a hint, because we are now in the `jupysql` namespace.

Because the logic differs slightly at each level, I revised the structure to be a direct linear derival of the key we need, rather than the more generic toml loop search implementation. This enhances readability over the alternative of adding if/else logic within the loop to vary the logic as we go deeper down the tree.

## Issue number

Closes #975
Closes #969 -- this is fixed by the `return None, None` at the end. Although not original target of this PR, it wasn't possible to just leave this broken

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--976.org.readthedocs.build/en/976/

<!-- readthedocs-preview jupysql end -->