### PR TITLE
Fix buggy __init__ method

### DIFF
--- a/src/sql/ggplot/facet_wrap.py
+++ b/src/sql/ggplot/facet_wrap.py
@@ -6,8 +6,6 @@ from sql.util import enclose_table_with_double_quotations
 
 
 class facet:
-    def __init__():
-        pass
 
     def get_facet_values(self, table, column, with_):
         conn = sql.connection.ConnectionManager.current


### PR DESCRIPTION
## Describe your changes

It's a silly little thing that I noticed when looking at something else.  The `facet` class in `ggplot/facet_wrap.py` was missing the `self` argument in its `__init__` method.  This wasn't an issue, since this class is never used directly.  Only its subclass, `facet_wrap` is used, which has its own functional `__init__` method, which doesn't call the superclass method.  Since the method supposed to do anything, I just removed it.

I'm not sure why flake8 or black didn't raise a fuss about this.

## Issue number

Closes #X

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--999.org.readthedocs.build/en/999/

<!-- readthedocs-preview jupysql end -->