### PR TITLE
Try to import tomllib for Python 3.11 or greater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.11dev
 
+  [Fix] Fall back to TOML parsing package in the standard library for Python 3.11 or greater
+
 ## 0.10.10 (2024-02-07)
 
 * [Feature] Adds `ploomber-extension` as a dependency

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -10,6 +10,7 @@ from ploomber_core.dependencies import requires
 import ast
 from os.path import isfile
 import re
+import sys
 
 from jinja2 import Template
 
@@ -17,7 +18,10 @@ from jinja2 import Template
 try:
     import toml
 except ModuleNotFoundError:
-    toml = None
+    if sys.version_info >= (3, 11):
+        import tomllib as toml
+    else:
+        toml = None
 
 SINGLE_QUOTE = "'"
 DOUBLE_QUOTE = '"'


### PR DESCRIPTION
## Describe your changes
As of Python 3.11, the standard library includes a library for reading TOML files. This allows for new enough versions of Python to fall back on the stdlib version if toml is not installed.

## Issue number

Closes #X

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--1004.org.readthedocs.build/en/1004/

<!-- readthedocs-preview jupysql end -->