### PR TITLE
1011 Running sql using sparkconnect should not print full stack trace

### DIFF
--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -12,7 +12,7 @@ from sql import exceptions
 
 def handle_spark_dataframe(dataframe, should_cache=False):
     """Execute a ResultSet sqlaproxy using pysark module."""
-    if not DataFrame and not CDataFrame:
+    if not DataFrame and not CDataFrame and not AnalysisException:
         raise exceptions.MissingPackageError("pysark not installed")
 
     try:

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -1,9 +1,11 @@
 try:
     from pyspark.sql import DataFrame
     from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
+    from pyspark.sql.utils import AnalysisException
 except ModuleNotFoundError:
     DataFrame = None
     CDataFrame = None
+    AnalysisException = None
 
 from sql import exceptions
 
@@ -13,8 +15,13 @@ def handle_spark_dataframe(dataframe, should_cache=False):
     if not DataFrame and not CDataFrame:
         raise exceptions.MissingPackageError("pysark not installed")
 
-    return SparkResultProxy(dataframe, dataframe.columns, should_cache)
-
+    try:
+        return SparkResultProxy(dataframe, dataframe.columns, should_cache)
+    except AnalysisException as e:
+        print(e)
+    except Exception as e:
+        print(e)
+        raise (e)  
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from


### PR DESCRIPTION
## Describe your changes
1. Added try catch on handle_spark_dataframe. When pyspark.sql.utils.AnalysisException occurs, it shows only the spark error and not the full stack trace

## Issue number

Closes #[1011](https://github.com/ploomber/jupysql/issues/1011)

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)

