### PR TITLE
Remove sqlalchemy upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.12dev
 
+* [Feature] Remove sqlalchemy upper bound ([#1020](https://github.com/ploomber/jupysql/pull/1020))
+
 ## 0.10.11 (2024-07-03)
 
 * [Fix] Fix error when connections.ini contains a `query` value as dictionary ([#1015](https://github.com/ploomber/jupysql/issues/1015))

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ install_requires = [
     "prettytable",
     # IPython dropped support for Python 3.8
     "ipython<=8.12.0; python_version <= '3.8'",
-    # sqlalchemy 2.0.29 breaking the CI: https://github.com/ploomber/jupysql/issues/1001
-    "sqlalchemy<2.0.29",
+    "sqlalchemy",
     "sqlparse",
     "ipython-genutils>=0.1.0",
     "jinja2",


### PR DESCRIPTION
## Describe your changes
Remove sqlalchemy upper bound as the issue that documented the reason (#1001) seems to have been closed. 

## Issue number

Closes #1001

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--1020.org.readthedocs.build/en/1020/

<!-- readthedocs-preview jupysql end -->