### PR TITLE
1011 Disable full stack trace when using spark connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.10.11dev
 
-* [Feature] Disable full stackt race when using spark connect ([#1011](https://github.com/ploomber/jupysql/issues/1011)) (by [@b1ackout](https://github.com/b1ackout))
+* [Feature] Disable full stack trace when using spark connect ([#1011](https://github.com/ploomber/jupysql/issues/1011)) (by [@b1ackout](https://github.com/b1ackout))
 
 ## 0.10.10 (2024-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.13dev
 
+* [Feature] Disable full stack trace when using spark connect ([#1011](https://github.com/ploomber/jupysql/issues/1011)) (by [@b1ackout](https://github.com/b1ackout))
+
 ## 0.10.12 (2024-07-12)
 
 * [Feature] Remove sqlalchemy upper bound ([#1020](https://github.com/ploomber/jupysql/pull/1020))
@@ -9,8 +11,6 @@
 ## 0.10.11 (2024-07-03)
 
 * [Fix] Fix error when connections.ini contains a `query` value as dictionary ([#1015](https://github.com/ploomber/jupysql/issues/1015))
-
-* [Feature] Disable full stack trace when using spark connect ([#1011](https://github.com/ploomber/jupysql/issues/1011)) (by [@b1ackout](https://github.com/b1ackout))
 
 ## 0.10.10 (2024-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.11dev
 
+* [Feature] Disable full stackt race when using spark connect ([#1011](https://github.com/ploomber/jupysql/issues/1011)) (by [@b1ackout](https://github.com/b1ackout))
+
 ## 0.10.10 (2024-02-07)
 
 * [Feature] Adds `ploomber-extension` as a dependency

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -1,36 +1,26 @@
-try:
-    from pyspark.sql import DataFrame
-    from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
-    from pyspark.sql.utils import AnalysisException
-except ModuleNotFoundError:
-    DataFrame = None
-    CDataFrame = None
-    AnalysisException = None
+# try:
+from pyspark.sql import DataFrame
+from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
+# except ModuleNotFoundError:
+#     DataFrame = None
+#     CDataFrame = None
 
 from sql import exceptions
 
 
 def handle_spark_dataframe(dataframe, should_cache=False):
     """Execute a ResultSet sqlaproxy using pysark module."""
-    if not DataFrame and not CDataFrame and not AnalysisException:
+    if not DataFrame and not CDataFrame:
         raise exceptions.MissingPackageError("pysark not installed")
 
-    try:
-        return SparkResultProxy(dataframe, dataframe.columns, should_cache)
-    except AnalysisException as e:
-        print(e)
-    except Exception as e:
-        print(e)
-        raise (e)
+    return SparkResultProxy(dataframe, dataframe.columns, should_cache)
 
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from
     SqlAlchemy.
     """
-
     dataframe = None
-
     def __init__(self, dataframe, headers, should_cache):
         self.dataframe = dataframe
         self.fetchall = dataframe.collect
@@ -40,21 +30,14 @@ class SparkResultProxy(object):
         self.returns_rows = True
         if should_cache:
             self.dataframe.cache()
-
     def fetchmany(self, size):
         return self.dataframe.take(size)
-
     def fetchone(self):
         return self.dataframe.head()
-
     def close(self):
         self.dataframe.unpersist()
-
-
 class SparkCursor(object):
     """Class to extend to give SqlAlchemy Cursor like behaviour"""
-
     description = None
-
     def __init__(self, headers) -> None:
         self.description = headers

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -12,7 +12,7 @@ from sql import exceptions
 
 def handle_spark_dataframe(dataframe, should_cache=False):
     """Execute a ResultSet sqlaproxy using pysark module."""
-    if not DataFrame and not CDataFrame:
+    if not DataFrame and not CDataFrame and not AnalysisException:
         raise exceptions.MissingPackageError("pysark not installed")
 
     try:

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -1,26 +1,27 @@
-# try:
-from pyspark.sql import DataFrame
-from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
-# except ModuleNotFoundError:
-#     DataFrame = None
-#     CDataFrame = None
+try:
+    from pyspark.sql import DataFrame
+    from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
+except ModuleNotFoundError:
+    DataFrame = None
+    CDataFrame = None
 
 from sql import exceptions
 
 
 def handle_spark_dataframe(dataframe, should_cache=False):
-    """Execute a ResultSet sqlaproxy using pyspark module."""
+    """Execute a ResultSet sqlaproxy using pysark module."""
     if not DataFrame and not CDataFrame:
-        raise exceptions.MissingPackageError("pyspark not installed")
+        raise exceptions.MissingPackageError("pysark not installed")
 
     return SparkResultProxy(dataframe, dataframe.columns, should_cache)
-
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from
     SqlAlchemy.
     """
+
     dataframe = None
+
     def __init__(self, dataframe, headers, should_cache):
         self.dataframe = dataframe
         self.fetchall = dataframe.collect
@@ -30,14 +31,21 @@ class SparkResultProxy(object):
         self.returns_rows = True
         if should_cache:
             self.dataframe.cache()
+
     def fetchmany(self, size):
         return self.dataframe.take(size)
+
     def fetchone(self):
         return self.dataframe.head()
+
     def close(self):
         self.dataframe.unpersist()
+
+
 class SparkCursor(object):
     """Class to extend to give SqlAlchemy Cursor like behaviour"""
+
     description = None
+
     def __init__(self, headers) -> None:
         self.description = headers

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -1,9 +1,11 @@
 try:
     from pyspark.sql import DataFrame
     from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
+    from pyspark.sql.utils import AnalysisException
 except ModuleNotFoundError:
     DataFrame = None
     CDataFrame = None
+    AnalysisException = None
 
 from sql import exceptions
 
@@ -13,8 +15,13 @@ def handle_spark_dataframe(dataframe, should_cache=False):
     if not DataFrame and not CDataFrame:
         raise exceptions.MissingPackageError("pysark not installed")
 
-    return SparkResultProxy(dataframe, dataframe.columns, should_cache)
-
+    try:
+        return SparkResultProxy(dataframe, dataframe.columns, should_cache)
+    except AnalysisException as e:
+        print(e)
+    except Exception as e:
+        print(e)
+        raise (e)  
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -9,9 +9,9 @@ from sql import exceptions
 
 
 def handle_spark_dataframe(dataframe, should_cache=False):
-    """Execute a ResultSet sqlaproxy using pysark module."""
+    """Execute a ResultSet sqlaproxy using pyspark module."""
     if not DataFrame and not CDataFrame:
-        raise exceptions.MissingPackageError("pysark not installed")
+        raise exceptions.MissingPackageError("pyspark not installed")
 
     return SparkResultProxy(dataframe, dataframe.columns, should_cache)
 

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -21,7 +21,8 @@ def handle_spark_dataframe(dataframe, should_cache=False):
         print(e)
     except Exception as e:
         print(e)
-        raise (e)  
+        raise (e)
+
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from

--- a/src/sql/run/sparkdataframe.py
+++ b/src/sql/run/sparkdataframe.py
@@ -9,11 +9,12 @@ from sql import exceptions
 
 
 def handle_spark_dataframe(dataframe, should_cache=False):
-    """Execute a ResultSet sqlaproxy using pysark module."""
+    """Execute a ResultSet sqlaproxy using pyspark module."""
     if not DataFrame and not CDataFrame:
-        raise exceptions.MissingPackageError("pysark not installed")
+        raise exceptions.MissingPackageError("pyspark not installed")
 
     return SparkResultProxy(dataframe, dataframe.columns, should_cache)
+
 
 class SparkResultProxy(object):
     """A fake class that pretends to behave like the ResultProxy from

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -559,6 +559,7 @@ def is_non_sqlalchemy_error(error):
         # Pyspark
         "UNRESOLVED_ROUTINE",
         "PARSE_SYNTAX_ERROR",
+        "AnalysisException",
     ]
     return any(msg in str(error) for msg in specific_db_errors)
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -7,6 +7,12 @@ from sqlglot import parse_one, exp
 from sqlglot.errors import ParseError
 from sqlalchemy.exc import SQLAlchemyError
 from ploomber_core.dependencies import requires
+
+try:
+    from pyspark.sql.utils import AnalysisException
+except ModuleNotFoundError:
+    AnalysisException = None
+
 import ast
 from os.path import isfile
 import re
@@ -556,12 +562,14 @@ def is_non_sqlalchemy_error(error):
         "pyodbc.ProgrammingError",
         # Clickhouse errors
         "DB::Exception:",
-        # Pyspark
-        "UNRESOLVED_ROUTINE",
-        "PARSE_SYNTAX_ERROR",
-        "AnalysisException",
     ]
-    return any(msg in str(error) for msg in specific_db_errors)
+    is_pyspark_analysis_exception = (
+        isinstance(error, AnalysisException) if AnalysisException else False
+    )
+    return (
+        any(msg in str(error) for msg in specific_db_errors)
+        or is_pyspark_analysis_exception
+    )
 
 
 def if_substring_exists(string, substrings):


### PR DESCRIPTION
## Describe your changes
1. Updated is_non_sqlalchemy_error to handle pyspark.sql.utils.AnalysisException, thus when `short_errors` is enabled to show only the spark sql error and not the full stack trace

## Issue number

Closes #[1011](https://github.com/ploomber/jupysql/issues/1011)

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--1024.org.readthedocs.build/en/1024/

<!-- readthedocs-preview jupysql end -->