### PR TITLE
close #1031

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -586,23 +586,23 @@ class SqlMagic(Magics, Configurable):
                 and not isinstance(result, str)
                 and self.column_local_vars
             ):
-                # Instead of returning values, set variables directly in the
-                # users namespace. Variable names given by column names
+                # Set variables directly in the users namespace.
+                # Variable names given by column names
 
                 if self.autopandas or self.autopolars:
                     keys = result.keys()
+                    self.shell.user_ns.update(result)
+                    result = None
                 else:
                     keys = result.keys
-                    result = result.dict()
+                    self.shell.user_ns.update(result.dict())
 
                 if self.feedback:
                     display.message(
                         "Returning data to local variables [{}]".format(", ".join(keys))
                     )
 
-                self.shell.user_ns.update(result)
-
-                return None
+                return result
             else:
                 if command.result_var:
                     self.shell.user_ns.update({command.result_var: result})

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -737,7 +737,7 @@ def test_displaylimit_with_count_statement(ip, load_penguin, config_value):
 def test_column_local_vars(ip):
     ip.run_line_magic("config", "SqlMagic.column_local_vars = True")
     result = runsql(ip, "SELECT * FROM author;")
-    assert result is None
+    assert result is not None
     assert "William" in ip.user_global_ns["first_name"]
     assert "Shakespeare" in ip.user_global_ns["last_name"]
     assert len(ip.user_global_ns["first_name"]) == 2


### PR DESCRIPTION
## Describe your changes

The regular result set is now displayed when the configuration option `column_local_vars` is set.

**NB.** I was unable to install the whole development environment on my machine. Since the changes are small, I hope they doesn't break anything.

## Issue number

Closes #1031

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting). Not needed.
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary). Changed one test.
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog). Not needed, since the current behaviour was not documented.

