### PR TITLE
The `in` operator in `ResultSetCollection.append` causes problems with numpy arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.0dev
 
 * [API Change] Disabled `%sql` and `%%sql` on Databricks ([#1047](https://github.com/ploomber/jupysql/issues/1047))
+* [Fix] Add support for numpy arrays in result sets
 
 ## 0.10.17 (2025-01-08)
 

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -130,14 +130,23 @@ class ResultSetCollection:
         self._result_sets = []
 
     def append(self, result):
-        for idx in reversed(
-            [
-                i
-                for i, item in enumerate(self._result_sets)
-                if all(starmap(_eq, zip(_results(result), _results(item))))
-            ]
-        ):
-            self._result_sets.pop(idx)
+        try:
+            if result in self._result_sets:
+                self._result_sets.remove(result)
+
+        except ValueError:
+            # If the result does not return a bool when compared
+            # (e.g., numpy arrays, pandas Series, polars Series)
+            # use an alternative comparison technique that tests
+            # that all values in the result are True.
+            for idx in reversed(
+                [
+                    i
+                    for i, item in enumerate(self._result_sets)
+                    if all(starmap(_eq, zip(_results(result), _results(item))))
+                ]
+            ):
+                self._result_sets.pop(idx)
 
         self._result_sets.append(result)
 

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -37,6 +37,7 @@ from sql.parse import (
 from sql.warnings import JupySQLQuotedNamedParametersWarning, JupySQLRollbackPerformed
 from sql import _current
 from sql.connection import error_handling
+from sql.run.resultset import ResultSet
 
 BASE_DOC_URL = "https://jupysql.ploomber.io/en/latest"
 
@@ -118,6 +119,12 @@ def _eq(a, b):
     return a is b or _bool(a == b)
 
 
+def _results(x):
+    if isinstance(x, ResultSet):
+        return x._results
+    return x
+
+
 class ResultSetCollection:
     def __init__(self) -> None:
         self._result_sets = []
@@ -127,7 +134,7 @@ class ResultSetCollection:
             [
                 i
                 for i, item in enumerate(self._result_sets)
-                if all(starmap(_eq, zip(result, item)))
+                if all(starmap(_eq, zip(_results(result), _results(item))))
             ]
         ):
             self._result_sets.pop(idx)

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -112,8 +112,10 @@ class ResultSetCollection:
         self._result_sets = []
 
     def append(self, result):
-        if result in self._result_sets:
-            self._result_sets.remove(result)
+        map(self._result_sets.pop, reversed([
+            i for i, item in enumerate(self._result_sets)
+            if len(result) == len(item) and map(op.eq, zip(result, item))
+        ]))
 
         self._result_sets.append(result)
 

--- a/src/sql/connection/connection.py
+++ b/src/sql/connection/connection.py
@@ -1,6 +1,7 @@
 import warnings
 import difflib
 import abc
+import operator as op
 import os
 from difflib import get_close_matches
 import atexit
@@ -112,10 +113,16 @@ class ResultSetCollection:
         self._result_sets = []
 
     def append(self, result):
-        map(self._result_sets.pop, reversed([
-            i for i, item in enumerate(self._result_sets)
-            if len(result) == len(item) and map(op.eq, zip(result, item))
-        ]))
+        map(
+            self._result_sets.pop,
+            reversed(
+                [
+                    i
+                    for i, item in enumerate(self._result_sets)
+                    if len(result) == len(item) and map(op.eq, zip(result, item))
+                ]
+            ),
+        )
 
         self._result_sets.append(result)
 

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1073,6 +1073,25 @@ def test_result_set_collection_append():
     assert collection._result_sets == [1, 2]
 
 
+def test_result_set_collection_append_numpy():
+    try:
+        import numpy as np
+
+        a1 = np.array([1, 2])
+        a2 = np.array([3, 4])
+
+        collection = ResultSetCollection()
+        collection.append(a1)
+        collection.append(a2)
+
+        assert len(collection._result_sets) == 2
+        assert collection._result_sets[0] is a1
+        assert collection._result_sets[1] is a2
+
+    except ImportError:
+        pass
+
+
 def test_result_set_collection_iterate():
     collection = ResultSetCollection()
     collection.append(1)

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -6,6 +6,7 @@ import pytest
 
 from IPython.core.error import UsageError
 import duckdb
+import numpy as np
 import sqlglot
 import sqlalchemy
 import sqlite3
@@ -1067,6 +1068,14 @@ AS percentiles
 
 def test_result_set_collection_append():
     collection = ResultSetCollection()
+    collection.append(1)
+    collection.append(2)
+
+    assert collection._result_sets == [1, 2]
+
+
+def test_result_set_collection_append_tuple():
+    collection = ResultSetCollection()
     collection.append((1,))
     collection.append((2,))
 
@@ -1074,25 +1083,27 @@ def test_result_set_collection_append():
 
 
 def test_result_set_collection_append_numpy():
-    try:
-        import numpy as np
+    a1 = (np.array([1, 2]),)
+    a2 = (np.array([3, 4]),)
 
-        a1 = (np.array([1, 2]),)
-        a2 = (np.array([3, 4]),)
+    collection = ResultSetCollection()
+    collection.append(a1)
+    collection.append(a2)
 
-        collection = ResultSetCollection()
-        collection.append(a1)
-        collection.append(a2)
-
-        assert len(collection._result_sets) == 2
-        assert collection._result_sets[0] is a1
-        assert collection._result_sets[1] is a2
-
-    except ImportError:
-        pass
+    assert len(collection._result_sets) == 2
+    assert collection._result_sets[0] is a1
+    assert collection._result_sets[1] is a2
 
 
 def test_result_set_collection_iterate():
+    collection = ResultSetCollection()
+    collection.append(1)
+    collection.append(2)
+
+    assert list(collection) == [1, 2]
+
+
+def test_result_set_collection_iterate_tuple():
     collection = ResultSetCollection()
     collection.append((1,))
     collection.append((2,))

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1077,8 +1077,8 @@ def test_result_set_collection_append_numpy():
     try:
         import numpy as np
 
-        a1 = np.array([1, 2])
-        a2 = np.array([3, 4])
+        a1 = (np.array([1, 2]),)
+        a2 = (np.array([3, 4]),)
 
         collection = ResultSetCollection()
         collection.append(a1)
@@ -1102,7 +1102,7 @@ def test_result_set_collection_iterate():
 
 def test_result_set_collection_is_last():
     collection = ResultSetCollection()
-    first, second = object(), object()
+    first, second = (object(),), (object(),)
     collection.append(first)
 
     assert len(collection) == 1

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1067,10 +1067,10 @@ AS percentiles
 
 def test_result_set_collection_append():
     collection = ResultSetCollection()
-    collection.append(1)
-    collection.append(2)
+    collection.append((1,))
+    collection.append((2,))
 
-    assert collection._result_sets == [1, 2]
+    assert collection._result_sets == [(1,), (2,)]
 
 
 def test_result_set_collection_append_numpy():

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1094,10 +1094,10 @@ def test_result_set_collection_append_numpy():
 
 def test_result_set_collection_iterate():
     collection = ResultSetCollection()
-    collection.append(1)
-    collection.append(2)
+    collection.append((1,))
+    collection.append((2,))
 
-    assert list(collection) == [1, 2]
+    assert list(collection) == [(1,), (2,)]
 
 
 def test_result_set_collection_is_last():


### PR DESCRIPTION
## Describe your changes

When using the `in` operator to test for equal results that contain numpy arrays, you will get the following error:
```
The truth value of an array with more than one element is ambiguous
```
This is due to the fact that `np.array == np.array` returns a `np.array` not a bool. The SingleStoreDB database uses numpy arrays for vector values. 

## Issue number

None

## Checklist before requesting a review

- [X] Performed a self-review of my code
- [X] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [X] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [X] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)



<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--1049.org.readthedocs.build/en/1049/

<!-- readthedocs-preview jupysql end -->