### PR TITLE
Fix Spark Connect displaying generic column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.11.2dev
 
+* [Fix] Fix Spark Connect displaying generic column names instead of actual column names ([#1077](https://github.com/ploomber/jupysql/issues/1077))
+
 ## 0.11.1 (2025-03-25)
 
 * [Fix] No longer showing the Slack link in error messages

--- a/doc/api/configuration.md
+++ b/doc/api/configuration.md
@@ -58,7 +58,7 @@ INSERT INTO languages VALUES ('C++', 10.00, 1.98);
 ```
 
 ```{note}
-If you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas `max_rows` option as described in the [pandas documentation](http://pandas.pydata.org/pandas-docs/version/0.18.1/options.html#frequently-used-options).
+If you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas `max_rows` option as described in the [pandas documentation](https://pandas.pydata.org/docs/user_guide/options.html#frequently-used-options).
 ```
 
 +++

--- a/src/sql/run/resultset.py
+++ b/src/sql/run/resultset.py
@@ -429,7 +429,7 @@ class ResultSet(ColumnGuesserMixin):
             # spark doesn't support cursor
             if hasattr(self._sqlaproxy, "dataframe"):
                 self._results = []
-                self._pretty_table.clear()
+                self._pretty_table.clear_rows()
             self._extend_results(returned)
 
             if len(returned) < size:
@@ -455,7 +455,7 @@ class ResultSet(ColumnGuesserMixin):
         if not self._done_fetching():
             if hasattr(self._sqlaproxy, "dataframe"):
                 self._results = []
-                self._pretty_table.clear()
+                self._pretty_table.clear_rows()
             self._extend_results(self.sqlaproxy.fetchall())
             self.mark_fetching_as_done()
 

--- a/src/tests/test_resultset.py
+++ b/src/tests/test_resultset.py
@@ -758,3 +758,85 @@ INSERT INTO Cities VALUES ('US', 'New York City', 2020, 8772);
     }
     expected = getattr(library, "DataFrame")(expected_result)
     assert getattr(result, equal_func)(expected)
+
+
+class TestSparkResultSetFieldNames:
+    """Test that Spark ResultSet preserves column names after fetchmany/fetchall"""
+
+    @staticmethod
+    def _make_spark_proxy(headers, rows):
+        """Create a mock SparkResultProxy-like object with a dataframe attribute"""
+        proxy = Mock()
+        proxy.dataframe = Mock()
+        proxy.keys = Mock(return_value=headers)
+        proxy.returns_rows = True
+        proxy.fetchmany = Mock(return_value=rows)
+        proxy.fetchall = Mock(return_value=rows)
+        # SparkResultProxy does not have 'description' attribute at proxy level
+        del proxy.description
+        return proxy
+
+    @staticmethod
+    def _make_config(displaylimit=5, autolimit=100):
+        config = Mock()
+        config.displaylimit = displaylimit
+        config.autolimit = autolimit
+        config.style = "DEFAULT"
+        return config
+
+    def test_field_names_preserved_after_fetchmany(self, ip_empty):
+        """clear_rows() should preserve field_names, not clear()"""
+        headers = ["name", "age", "city"]
+        rows = [("Alice", 30, "NYC"), ("Bob", 25, "LA")]
+        proxy = self._make_spark_proxy(headers, rows)
+        config = self._make_config()
+
+        rs = ResultSet(proxy, config, statement=None, conn=Mock())
+
+        assert rs.field_names == ["name", "age", "city"]
+        assert "name" in str(rs)
+        assert "age" in str(rs)
+        assert "city" in str(rs)
+
+    def test_field_names_preserved_after_fetchall(self, ip_empty):
+        """fetchall on Spark path should also preserve field_names"""
+        headers = ["col_a", "col_b"]
+        rows = [("x", 1), ("y", 2), ("z", 3)]
+        proxy = self._make_spark_proxy(headers, rows)
+        config = self._make_config(displaylimit=0, autolimit=0)
+
+        rs = ResultSet(proxy, config, statement=None, conn=Mock())
+
+        assert rs.field_names == ["col_a", "col_b"]
+        assert "col_a" in str(rs)
+        assert "col_b" in str(rs)
+
+    def test_field_names_not_generic(self, ip_empty):
+        """Ensure PrettyTable does not generate generic 'Field 1' names"""
+        headers = ["product", "price"]
+        rows = [("Widget", 9.99), ("Gadget", 19.99)]
+        proxy = self._make_spark_proxy(headers, rows)
+        config = self._make_config()
+
+        rs = ResultSet(proxy, config, statement=None, conn=Mock())
+
+        html = rs._repr_html_()
+        assert "Field 1" not in html
+        assert "Field 2" not in html
+        assert "product" in html
+        assert "price" in html
+
+    def test_field_names_preserved_after_repr(self, ip_empty):
+        """fetch_for_repr_if_needed triggers another fetchmany — names must survive"""
+        headers = ["id", "value"]
+        rows = [("1", "a"), ("2", "b"), ("3", "c")]
+        proxy = self._make_spark_proxy(headers, rows)
+        config = self._make_config(displaylimit=2)
+
+        rs = ResultSet(proxy, config, statement=None, conn=Mock())
+
+        # _repr_html_ calls fetch_for_repr_if_needed which may call fetchmany again
+        html = rs._repr_html_()
+        assert "id" in html
+        assert "value" in html
+        assert "Field 1" not in html


### PR DESCRIPTION
## Describe your changes

When using Spark Connect, query results display generic column names like `Field 1`, `Field 2` instead of actual column names. This is caused by `PrettyTable.clear()` removing both rows **and** field_names in the Spark path of `ResultSet.fetchmany()` and `ResultSet.fetchall()`.

**Fix**: Replace `clear()` with `clear_rows()` which only removes rows and preserves field_names.

**Changes**:
- `src/sql/run/resultset.py`: Replace `self._pretty_table.clear()` → `self._pretty_table.clear_rows()` (2 locations)
- `src/tests/test_resultset.py`: Add `TestSparkResultSetFieldNames` class with 4 tests verifying column name preservation

## Issue number

Closes #1077

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)

<!-- readthedocs-preview jupysql start -->
----
📚 Documentation preview 📚: https://jupysql--1078.org.readthedocs.build/en/1078/

<!-- readthedocs-preview jupysql end -->